### PR TITLE
Fix Bunkr Maintenance Video Detection

### DIFF
--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -80,7 +80,7 @@ class ClientManager:
         headers = response.headers
 
         if download:
-            if headers.get('ETag') in ['"eb669b6362e031fa2b0f1215480c4e30"', '"a9e4cee098dc6f1e09ec124299f26b30"']:
+            if headers.get('Content-Length') == "322509" and headers.get('Content-Type') == "video/mp4":
                 raise DownloadFailure(status="Bunkr Maintenance", message="Bunkr under maintenance")
             if headers.get('ETag') == '"d835884373f4d6c8f24742ceabe74946"':
                 raise DownloadFailure(status=HTTPStatus.NOT_FOUND, message="Imgur image has been removed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.4.50"
+version = "5.4.51"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
Switch from using the ETag header (Bunkr does not include it anymore) to checking for the content length, which could have issues with other videos being of the same length, but it it extremely unlikely that any other video will have the exact same length.