### PR TITLE
allow bunkr maint files to still be added to database

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -109,6 +109,7 @@ class DownloadClient:
             if not isinstance(media_item.complete_file, Path):
                 proceed, skip = await self.get_final_file_info(media_item, domain)
                 await self.mark_incomplete(media_item, domain)
+                await self.client_manager.check_bunkr_maint(headers)
                 if skip:
                     await self.manager.progress_manager.download_progress.add_skipped()
                     return False

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -80,8 +80,6 @@ class ClientManager:
         headers = response.headers
 
         if download:
-            if headers.get('Content-Length') == "322509" and headers.get('Content-Type') == "video/mp4":
-                raise DownloadFailure(status="Bunkr Maintenance", message="Bunkr under maintenance")
             if headers.get('ETag') == '"d835884373f4d6c8f24742ceabe74946"':
                 raise DownloadFailure(status=HTTPStatus.NOT_FOUND, message="Imgur image has been removed")
             if headers.get('ETag') == '"65b7753c-528a"':
@@ -119,5 +117,8 @@ class ClientManager:
             raise DownloadFailure(status=CustomHTTPStatus.IM_A_TEAPOT, message="No content-type in response header")
 
         raise DownloadFailure(status=status, message=f"HTTP status code {status}: {phrase}")
+    async def check_bunkr_maint(headers):
+        if headers.get('Content-Length') == "322509" and headers.get('Content-Type') == "video/mp4":
+            raise DownloadFailure(status="Bunkr Maintenance", message="Bunkr under maintenance")
     async def check_bucket(self,size):
         await  self._leaky_bucket.acquire(size)

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -122,7 +122,6 @@ class BunkrrCrawler(Crawler):
                     filename, ext = await get_filename_and_ext(link.name)
                 else:
                     filename, ext = await get_filename_and_ext(scrape_item.url.name)
-
         await self.handle_file(link, scrape_item, filename, ext)
 
     @error_handling_wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.4.51"
+version = "5.4.52"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
Currently when maint file are encountered the add incomplete db step is skipped

change for the files to be added, and then throws an error to prevent downloading right after
 