### PR TITLE
Pixeldrain text scraping

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -80,7 +80,7 @@ class PixelDrainCrawler(Crawler):
                     link = URL(line)
                     new_scrape_item = await self.create_scrape_item(scrape_item, link, "", False, None, date)
                     await self.handle_external_links(new_scrape_item)
-            elif "image" or "video" in JSON_Resp["mime_type"]:
+            elif "image" in JSON_Resp["mime_type"] or "video" in JSON_Resp["mime_type"]:
                 filename, ext = await get_filename_and_ext(JSON_Resp['name'] + "." + JSON_Resp["mime_type"].split("/")[-1])
             else:
                 raise NoExtensionFailure()

--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -72,12 +72,13 @@ class PixelDrainCrawler(Crawler):
             filename, ext = await get_filename_and_ext(JSON_Resp['name'])
         except NoExtensionFailure:
             if "text/plain" in JSON_Resp["mime_type"]:
+                await scrape_item.add_to_parent_title(f"{JSON_Resp['name']} (Pixeldrain)")
                 async with self.request_limiter:
                     text = await self.client.get_text(self.domain, self.api_address / "file" / scrape_item.url.parts[-1])
                 lines = text.split("\n")
                 for line in lines:
                     link = URL(line)
-                    new_scrape_item = await self.create_scrape_item(scrape_item, link, f"{JSON_Resp['name']} (Pixeldrain)", True, JSON_Resp['id'], date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, link, "", False, None, date)
                     await self.handle_external_links(new_scrape_item)
             elif "image" or "video" in JSON_Resp["mime_type"]:
                 filename, ext = await get_filename_and_ext(JSON_Resp['name'] + "." + JSON_Resp["mime_type"].split("/")[-1])

--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -52,7 +52,7 @@ class PixelDrainCrawler(Crawler):
             try:
                 filename, ext = await get_filename_and_ext(file['name'])
             except NoExtensionFailure:
-                if "image" or "video" in file["mime_type"]:
+                if "image" in file["mime_type"] or "video" in file["mime_type"]:
                     filename, ext = await get_filename_and_ext(file['name'] + "." + file["mime_type"].split("/")[-1])
                 else:
                     raise NoExtensionFailure()

--- a/cyberdrop_dl/utils/changelog.py
+++ b/cyberdrop_dl/utils/changelog.py
@@ -3,6 +3,22 @@
 ------------------------------------------------------------
 
 C\bCH\bHA\bAN\bNG\bGE\bEL\bLO\bOG\bG
+\tVersion 5.6.20
+
+
+D\bDE\bES\bSC\bCR\bRI\bIP\bPT\bTI\bIO\bON\bN
+\tThis update introduces the following changes:
+\t\t1. Ability to scrape URLs from PixelDrain text post
+
+\tDetails:
+\t\t- Cyberdrop-DL will now scrape URLs from PixelDrain text posts and make a folder for all the URLs within the post, reducing clutter.
+
+
+\tFor more details, visit the wiki: https://script-ware.gitbook.io
+
+------------------------------------------------------------
+
+C\bCH\bHA\bAN\bNG\bGE\bEL\bLO\bOG\bG
 \tVersion 5.6.11
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.6.11"
+version = "5.6.20"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
Implement the ability to scrape URLs from a PixelDrain text post and make them their own folder instead of various folders for each URL in the list.