### PR TITLE
Remove support for scraping SimpCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Brand new and improved! Cyberdrop-DL now has an updated paint job, fantastic new
   - rule34vault
   - saint
   - scrolller
-  - simpcity
   - socialmediagirls
   - toonily
   - xbunker

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -68,6 +68,22 @@ class Manager:
 
         self.path_manager.startup()
         self.log_manager = LogManager(self)
+        
+        # Adjust settings for SimpCity update
+        simp_settings_adjusted = self.cache_manager.get("simp_settings_adjusted")
+        if simp_settings_adjusted == None:
+            for config in self.config_manager.get_configs():
+                if config != self.config_manager.loaded_config:
+                    self.config_manager.change_config(config)
+                self.config_manager.settings_data['Runtime_Options']['update_last_forum_post'] = True
+                self.config_manager.write_updated_settings_config()
+            global_settings = self.config_manager.global_settings_data
+            if global_settings['Rate_Limiting_Options']['download_attempts'] >= 10:
+                global_settings['Rate_Limiting_Options']['download_attempts'] = 5
+            if global_settings['Rate_Limiting_Options']['max_simultaneous_downloads_per_domain'] > 15:
+                global_settings['Rate_Limiting_Options']['max_simultaneous_downloads_per_domain'] = 5
+            self.config_manager.write_updated_global_settings_config()
+        self.cache_manager.save('simp_settings_adjusted', True)
 
     def args_startup(self) -> None:
         """Start the args manager"""

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -68,7 +68,7 @@ class Manager:
 
         self.path_manager.startup()
         self.log_manager = LogManager(self)
-        
+
         # Adjust settings for SimpCity update
         simp_settings_adjusted = self.cache_manager.get("simp_settings_adjusted")
         if simp_settings_adjusted == None:

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -43,7 +43,7 @@ class ScrapeMapper:
                         "redd.it": self.reddit, "redgifs": self.redgifs, "rule34vault": self.rule34vault,
                         "rule34.xxx": self.rule34xxx,
                         "rule34.xyz": self.rule34xyz, "saint": self.saint, "scrolller": self.scrolller,
-                        "simpcity": self.simpcity, "socialmediagirls": self.socialmediagirls, "toonily": self.toonily,
+                        "socialmediagirls": self.socialmediagirls, "toonily": self.toonily,
                         "xbunker": self.xbunker, "xbunkr": self.xbunkr, "bunkr": self.bunkrr}
         self.existing_crawlers = {}
         self.no_crawler_downloader = Downloader(self.manager, "no_crawler")

--- a/cyberdrop_dl/ui/prompts/general_prompts.py
+++ b/cyberdrop_dl/ui/prompts/general_prompts.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 from typing import TYPE_CHECKING
 
-from InquirerPy import inquirer
+from InquirerPy import inquirer, get_style
 from InquirerPy.base.control import Choice
 from InquirerPy.separator import Separator
 from InquirerPy.validator import EmptyInputValidator, PathValidator
@@ -25,24 +25,31 @@ console = Console()
 
 def main_prompt(manager: Manager) -> int:
     """Main prompt for the program"""
+    choices = [
+        Choice(1, "Download"),
+        Choice(2, "Download (All Configs)"),
+        Choice(3, "Retry Failed Downloads"),
+        Choice(4, "Create File Hashes"),
+        Choice(5, "Sort All Configs"),
+        Choice(6, "Edit URLs"),
+        Separator(),
+        Choice(7, f"Select Config (Current: {manager.config_manager.loaded_config})"),
+        Choice(8, "Change URLs.txt file and Download Location"),
+        Choice(9, "Edit Configs"),
+        Separator(),
+        Choice(10, "Import Cyberdrop_V4 Items"),
+        Choice(11, "View Changelog"),
+        Choice(12, "Exit"),
+    ]
+
+    simp_disclaimer_shown = manager.cache_manager.get("simp_disclaimer_shown")
+    if simp_disclaimer_shown == None:
+        choices = [Choice(-1, "!! VIEW DISCLAIMER !!")]
+
     action = inquirer.select(
         message="What would you like to do?",
-        choices=[
-            Choice(1, "Download"),
-            Choice(2, "Download (All Configs)"),
-            Choice(3, "Retry Failed Downloads"),
-            Choice(4, "Create File Hashes"),
-            Choice(5, "Sort All Configs"),
-            Choice(6, "Edit URLs"),
-            Separator(),
-            Choice(7, f"Select Config (Current: {manager.config_manager.loaded_config})"),
-            Choice(8, "Change URLs.txt file and Download Location"),
-            Choice(9, "Edit Configs"),
-            Separator(),
-            Choice(10, "Import Cyberdrop_V4 Items"),
-            Choice(11, "View Changelog"),
-            Choice(12, "Exit"),
-        ], long_instruction="ARROW KEYS: Navigate | ENTER: Select",
+        choices=choices, long_instruction="ARROW KEYS: Navigate | ENTER: Select",
+        style=get_style({"pointer": "#ff0000 bold"}) if simp_disclaimer_shown == None else None,
         vi_mode=manager.vi_mode,
     ).execute()
 

--- a/cyberdrop_dl/ui/ui.py
+++ b/cyberdrop_dl/ui/ui.py
@@ -80,7 +80,6 @@ def program_ui(manager: Manager):
 
             input("Press Enter to continue...")
             manager.cache_manager.save('simp_disclaimer_shown', True)
-            exit(0)
 
         # Download
         if action == 1:

--- a/cyberdrop_dl/ui/ui.py
+++ b/cyberdrop_dl/ui/ui.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 from pydoc import pager
+from rich import print as rprint
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 from InquirerPy import inquirer
@@ -25,6 +27,11 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
+def bold(text: str) -> str:
+    """Format a string in bold by overstriking."""
+    return ''.join(ch + '\b' + ch for ch in text)
+
+
 def program_ui(manager: Manager):
     """Program UI"""
     while True:
@@ -33,6 +40,47 @@ def program_ui(manager: Manager):
         console.print(f"[bold]Current Config:[/bold] {manager.config_manager.loaded_config}")
 
         action = main_prompt(manager)
+
+        if action == -1:
+            simp_disclaimer = """
+            \t\t[bold red]!!    DISCLAIMER    !![/bold red]
+            
+            
+            Due to the recent DDOS attacks on [italic]SimpCity[/italic], I have made some changes to [italic]Cyberdrop-DL[/italic].
+            
+            First and foremost, we have removed support for scraping [italic]SimpCity[/italic] for the time being. I know that this will upset many of you, but hopefully, you will understand my reasoning.
+            
+            
+            Because of the DDOS attacks that [italic]SimpCity[/italic] has been receiving, they have been forced to implement some protective features such as using a DDOS-Guard browser check, only allowing [link=https://simpcity.su/threads/emails-august-2024.365869/]whitelisted email domains[/link] to access the website, and [link=https://simpcity.su/threads/rate-limit-429-error.397746/]new rate limits[/link].
+            [italic]Cyberdrop-DL[/italic] allows a user to scrape a model's entire thread in seconds, downloading all the files that it finds. This is great but can be problematic for a few reasons:
+            \t- We end up downloading a lot of content that we will never view.
+            \t- Such large-scale scraping with no limits puts a large strain on [italic]SimpCity[/italic]'s servers, especially when they are getting DDOSed.
+            \t- Scraping has no benefit for [italic]SimpCity[/italic] - they gain nothing from us scraping their website.
+            
+            For those reasons, [italic]SimpCity[/italic] has decided that they don't want to allow automated thread scraping anymore, and have removed the [italic]Cyberdrop-DL[/italic] thread from their website.
+            I want to respect [italic]SimpCity[/italic]'s wishes, and as a result, have disabled scraping for [italic]SimpCity[/italic] links.
+            
+            In order to help reduce the impact that [italic]Cyberdrop-DL[/italic] has on other websites, I have decided to enable the [italic bold]update_last_forum_post[/italic bold] setting for all users' configs.
+            You can disable it again after reading through this disclaimer, however, I would recommend against it. [italic bold]update_last_forum_post[/italic bold] actually speeds up scrapes and reduces the load on websites' servers by not re-scraping entire threads and picking up where it left off last time.
+            
+            Furthermore, I have adjusted the default rate-limiting settings in an effort to reduce the impact that [italic]Cyberdrop-DL[/italic] will have on websites.
+            
+            I encourage you to be conscientious about how you use [italic]Cyberdrop-DL[/italic].
+            Some tips on how to reduce the impact your use of [italic]Cyberdrop-DL[/italic] will have on a website:
+            \t- Try to avoid looping runs repeatedly.
+            \t- If you have a large URLs file, try to comb through it occasionally and get rid of items you don't want anymore, and try to run [italic]Cyberdrop-DL[/italic] less often.
+            \t- Avoid downloading content you don't want. It's good to scan through the content quickly to ensure it's not a bunch of stuff you're going to delete after downloading it.
+            
+            If you do want to continue downloading from SimpCity, you can use a tampermonkey script like this one: [link=https://simpcity.su/threads/forum-post-downloader-tampermonkey-script.96714/]SimpCity Tampermonkey Forum Downloader[/link]
+            """
+
+            console.clear()
+            simp_disclaimer = dedent(simp_disclaimer)
+            rprint(simp_disclaimer)
+
+            input("Press Enter to continue...")
+            manager.cache_manager.save('simp_disclaimer_shown', True)
+            exit(0)
 
         # Download
         if action == 1:

--- a/cyberdrop_dl/ui/ui.py
+++ b/cyberdrop_dl/ui/ui.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 from pydoc import pager
-from rich import print as rprint
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
 from InquirerPy import inquirer
 from InquirerPy.validator import PathValidator
+from rich import print as rprint
 from rich.console import Console
 
 import cyberdrop_dl.utils.changelog as Changelog

--- a/cyberdrop_dl/utils/args/config_definitions.py
+++ b/cyberdrop_dl/utils/args/config_definitions.py
@@ -99,7 +99,7 @@ settings: Dict = {
         "skip_check_for_empty_folders": False,
         "delete_partial_files": False,
         "send_unsupported_to_jdownloader": False,
-        "update_last_forum_post": False,
+        "update_last_forum_post": True,
     },
     "Sorting": {
         "sort_downloads": False,
@@ -126,12 +126,12 @@ global_settings: Dict = {
     },
     "Rate_Limiting_Options": {
         "connection_timeout": 15,
-        "download_attempts": 10,
+        "download_attempts": 5,
         "read_timeout": 300,
         "rate_limit": 50,
         "download_delay": 0.5,
         "max_simultaneous_downloads": 15,
-        "max_simultaneous_downloads_per_domain": 5,
+        "max_simultaneous_downloads_per_domain": 3,
         "download_speed_limit": 0
     },
     "Dupe_Cleanup_Options":

--- a/cyberdrop_dl/utils/changelog.py
+++ b/cyberdrop_dl/utils/changelog.py
@@ -3,6 +3,16 @@
 ------------------------------------------------------------
 
 C\bCH\bHA\bAN\bNG\bGE\bEL\bLO\bOG\bG
+\tVersion 5.6.30
+
+
+S\bSI\bIM\bMP\bPC\bCI\bIT\bTY\bY H\bHA\bAS\bS B\bBE\bEE\bEN\bN R\bRE\bEM\bMO\bOV\bVE\bED\bD F\bFR\bRO\bOM\bM T\bTH\bHE\bE S\bSU\bUP\bPP\bPO\bOR\bRT\bTE\bED\bD W\bWE\bEB\bBS\bSI\bIT\bTE\bES\bS L\bLI\bIS\bST\bT.\b.
+
+T\bTO\bO S\bSE\bEE\bE W\bWH\bHY\bY,\b, V\bVI\bIS\bSI\bIT\bT T\bTH\bHE\bE W\bWI\bIK\bKI\bI:\b: https://script-ware.gitbook.io/cyberdrop-dl/simpcity-support-dropped
+
+------------------------------------------------------------
+
+C\bCH\bHA\bAN\bNG\bGE\bEL\bLO\bOG\bG
 \tVersion 5.6.20
 
 

--- a/cyberdrop_dl/utils/dataclasses/supported_domains.py
+++ b/cyberdrop_dl/utils/dataclasses/supported_domains.py
@@ -21,7 +21,7 @@ class SupportedDomains:
     supported_forums: ClassVar[Tuple[str, ...]] = ("celebforum.to", "f95zone.to", "leakedmodels.com", "nudostar.com",
                                                    "forums.socialmediagirls.com", "xbunker.nu")
     supported_forums_map = {"celebforum.to": "celebforum", "f95zone.to": "f95zone", "leakedmodels.com": "leakedmodels",
-                            "nudostar.com": "nudostar", 
+                            "nudostar.com": "nudostar",
                             "forums.socialmediagirls.com": "socialmediagirls", "xbunker.nu": "xbunker"}
 
     sites: List[str]

--- a/cyberdrop_dl/utils/dataclasses/supported_domains.py
+++ b/cyberdrop_dl/utils/dataclasses/supported_domains.py
@@ -15,13 +15,13 @@ class SupportedDomains:
                                                   "omegascans", "pimpandhost", "pixeldrain", "postimg", "realbooru",
                                                   "reddit", "redd.it", "redgifs", "rule34.xxx", "rule34.xyz",
                                                   "rule34vault", "saint",
-                                                  "scrolller", "simpcity", "socialmediagirls", "toonily", "xbunker",
+                                                  "scrolller", "socialmediagirls", "toonily", "xbunker",
                                                   "xbunkr")
 
     supported_forums: ClassVar[Tuple[str, ...]] = ("celebforum.to", "f95zone.to", "leakedmodels.com", "nudostar.com",
-                                                   "simpcity.su", "forums.socialmediagirls.com", "xbunker.nu")
+                                                   "forums.socialmediagirls.com", "xbunker.nu")
     supported_forums_map = {"celebforum.to": "celebforum", "f95zone.to": "f95zone", "leakedmodels.com": "leakedmodels",
-                            "nudostar.com": "nudostar", "simpcity.su": "simpcity",
+                            "nudostar.com": "nudostar", 
                             "forums.socialmediagirls.com": "socialmediagirls", "xbunker.nu": "xbunker"}
 
     sites: List[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.6.21"
+version = "5.6.3"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
Removed the ability to scrape simpcity.su and added a disclaimer explaining the reasoning behind this decision as well as a docs page for it.

https://script-ware.gitbook.io/cyberdrop-dl/simpcity-support-dropped