### PR TITLE
add simpcity cache to reduce load

### DIFF
--- a/cyberdrop_dl/managers/cache_manager.py
+++ b/cyberdrop_dl/managers/cache_manager.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 
 import yaml
+import json
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -16,6 +17,11 @@ def _save_yaml(file: Path, data: Dict) -> None:
     with open(file, 'w') as yaml_file:
         yaml.dump(data, yaml_file)
 
+def _save_json(file: Path, data: Dict) -> None:
+    """Saves a dict to a yaml file"""
+    file.parent.mkdir(parents=True, exist_ok=True)
+    with open(file, 'w') as json_file:
+        json.dump(data, json_file)
 
 def _load_yaml(file: Path) -> Dict:
     """Loads a yaml file and returns it as a dict"""
@@ -23,12 +29,17 @@ def _load_yaml(file: Path) -> Dict:
         return yaml.load(yaml_file.read(), Loader=yaml.FullLoader)
 
 
+def _load_json(file: Path) -> Dict:
+    """Loads a json file and returns it as a dict"""
+    with open(file, 'r') as json_file:
+        return json.loads(json_file.read())
 class CacheManager:
-    def __init__(self, manager: 'Manager'):
+    def __init__(self, manager: 'Manager',backend:str="yaml"):
         self.manager = manager
 
         self.cache_file: Path = field(init=False)
         self._cache = {}
+        self.backend=backend
 
     def startup(self, cache_file: Path) -> None:
         """Ensures that the cache file exists"""
@@ -42,7 +53,11 @@ class CacheManager:
 
     def load(self) -> None:
         """Loads the cache file into memory"""
-        self._cache = _load_yaml(self.cache_file)
+        if self.backend=="yaml":
+            self._cache = _load_yaml(self.cache_file)
+        else:
+            self._cache = _load_json(self.cache_file)
+
 
     def get(self, key: str) -> Any:
         """Returns the value of a key in the cache"""
@@ -51,10 +66,16 @@ class CacheManager:
     def save(self, key: str, value: Any) -> None:
         """Saves a key and value to the cache"""
         self._cache[key] = value
-        _save_yaml(self.cache_file, self._cache)
+        self.update()
 
     def remove(self, key: str) -> None:
         """Removes a key from the cache"""
         if key in self._cache:
             del self._cache[key]
-            _save_yaml(self.cache_file, self._cache)
+            self.update()
+    def update(self) -> None:
+        """Updates cache with new values/changes"""
+        if self.backend=="yaml":
+             _save_yaml(self.cache_file, self._cache)
+        else:
+            _save_json(self.cache_file, self._cache)

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -26,6 +26,7 @@ class Manager:
     def __init__(self):
         self.args_manager: ArgsManager = ArgsManager()
         self.cache_manager: CacheManager = CacheManager(self)
+        self.simpcity_cache_manager: CacheManager = CacheManager(self,backend="json")
         self.path_manager: PathManager = field(init=False)
         self.config_manager: ConfigManager = field(init=False)
         self.hash_manager: HashManager = field(init=False)
@@ -61,6 +62,7 @@ class Manager:
         self.path_manager.pre_startup()
 
         self.cache_manager.startup(self.path_manager.cache_dir / "cache.yaml")
+        self.simpcity_cache_manager.startup(self.path_manager.cache_dir / "simpcity_cache.json")
         self.config_manager = ConfigManager(self)
         self.config_manager.startup()
         self.vi_mode = self.config_manager.global_settings_data['UI_Options'][

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -4,8 +4,9 @@ import re
 from typing import TYPE_CHECKING
 
 from aiolimiter import AsyncLimiter
-from bs4 import Tag
+from bs4 import Tag, BeautifulSoup
 from yarl import URL
+import json
 
 from cyberdrop_dl.scraper.crawler import Crawler
 from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
@@ -99,54 +100,68 @@ class SimpCityCrawler(Crawler):
 
         current_post_number = 0
         while True:
-            async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, thread_url)
+            posts_dict= self.manager.simpcity_cache_manager.get(str(thread_url))
+            if not posts_dict:
+                async with self.request_limiter:
+                    soup = await self.client.get_BS4(self.domain, thread_url)
+                title_block = soup.select_one(self.title_selector)
+                for elem in title_block.find_all(self.title_trash_selector):
+                    elem.decompose()
+                thread_id = thread_url.parts[2].split('.')[-1]
+                title = await self.create_title(title_block.text.replace("\n", ""), None, thread_id)
+                posts = soup.select(self.posts_selector)
+                post_content_array=[]
+                for post in posts:
+                    current_post_number = int(
+                        post.select_one(self.posts_number_selector).get(self.posts_number_attribute).split('/')[-1].split(
+                            'post-')[-1])
+                    scrape_post, continue_scraping = await self.check_post_number(post_number, current_post_number)
 
-            title_block = soup.select_one(self.title_selector)
-            for elem in title_block.find_all(self.title_trash_selector):
-                elem.decompose()
+                    if scrape_post:
+                        try:
+                            date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
+                        except:
+                            pass
+                        new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
 
-            thread_id = thread_url.parts[2].split('.')[-1]
-            title = await self.create_title(title_block.text.replace("\n", ""), None, thread_id)
+                        # for elem in post.find_all(self.quotes_selector):
+                        #     elem.decompose()
+                        post_content = post.select_one(self.posts_content_selector)
+                        post_content_array.append({"data"   : str(post_content),"current_post_number":current_post_number})
 
-            posts = soup.select(self.posts_selector)
-            for post in posts:
-                current_post_number = int(
-                    post.select_one(self.posts_number_selector).get(self.posts_number_attribute).split('/')[-1].split(
-                        'post-')[-1])
-                scrape_post, continue_scraping = await self.check_post_number(post_number, current_post_number)
-
-                if scrape_post:
-                    try:
-                        date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
-                    except:
-                        pass
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
-
-                    # for elem in post.find_all(self.quotes_selector):
-                    #     elem.decompose()
-                    post_content = post.select_one(self.posts_content_selector)
-                    await self.post(new_scrape_item, post_content, current_post_number)
-
-                if not continue_scraping:
-                    break
-
-            next_page = soup.select_one(self.next_page_selector)
-            if next_page and continue_scraping:
-                thread_url = next_page.get(self.next_page_attribute)
-                if thread_url:
-                    if thread_url.startswith("/"):
-                        thread_url = self.primary_base_domain / thread_url[1:]
-                    thread_url = URL(thread_url)
-                    continue
+                        await self.post(new_scrape_item, post_content, current_post_number)
+                    simp_dict={"posts": post_content_array,"title": title,"date":date}
+                    self.manager.simpcity_cache_manager.save(str(thread_url),json.dumps(simp_dict))
+                    if not continue_scraping:
+                        break
             else:
-                break
-        post_string = f"post-{current_post_number}"
-        if "page-" in scrape_item.url.raw_name or "post-" in scrape_item.url.raw_name:
-            last_post_url = scrape_item.url.parent / post_string
-        else:
-            last_post_url = scrape_item.url / post_string
-        await self.manager.log_manager.write_last_post_log(last_post_url)
+                posts_dict=json.loads(posts_dict)
+                title =posts_dict.get("title")
+                posts= posts_dict.get("posts")
+                date = posts_dict.get("date")
+
+                for post in posts:
+                    current_post_number = post.get("current_post_number")
+                    scrape_post, continue_scraping = await self.check_post_number(post_number, current_post_number)
+
+                    if scrape_post:
+                        new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
+
+                        # for elem in post.find_all(self.quotes_selector):
+                        #     elem.decompose()
+                        post_content =BeautifulSoup(post.get("data"))
+    
+                        await self.post(new_scrape_item, post_content, current_post_number)
+                    if not continue_scraping:
+                        break
+
+
+            post_string = f"post-{current_post_number}"
+            if "page-" in scrape_item.url.raw_name or "post-" in scrape_item.url.raw_name:
+                last_post_url = scrape_item.url.parent / post_string
+            else:
+                last_post_url = scrape_item.url / post_string
+            await self.manager.log_manager.write_last_post_log(last_post_url)
 
     @error_handling_wrapper
     async def post(self, scrape_item: ScrapeItem, post_content: Tag, post_number: int) -> None:


### PR DESCRIPTION
This adds a cache to the simpcity process to reduce load
- data is held in separate simpcity  cache file
- yaml was finky about saving the stringified html objects, so json was used 
- The caching is a little more complicated to save space, saving the entire page response takes about 300kb, however saving only the required information including posts data reduces this to around 15kb per page