### PR TITLE
add rich logger file handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /Test-AppData-Dir/
 /AppData/
 /Downloads/
+**.log
 
 # Python cache
 __pycache__

--- a/cyberdrop_dl/managers/cache_manager.py
+++ b/cyberdrop_dl/managers/cache_manager.py
@@ -4,6 +4,7 @@ from dataclasses import field
 from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 from aiohttp_client_cache import SQLiteBackend
+from datetime import timedelta
 
 import yaml
 
@@ -50,9 +51,9 @@ class CacheManager:
             autoclose=False, 
             allowed_codes=(200, 418), 
             allowed_methods=['GET'], 
-            expire_after=7 * 24 * 60 * 60,
+            expire_after= timedelta(days=7),
             urls_expire_after={
-                '*.simpcity.su': 30 * 24 * 60 * 60,
+                '*.simpcity.su': timedelta(days=30)
             }
         )
 

--- a/cyberdrop_dl/managers/live_manager.py
+++ b/cyberdrop_dl/managers/live_manager.py
@@ -1,4 +1,3 @@
-import traceback
 from contextlib import asynccontextmanager
 
 from rich.live import Live
@@ -26,8 +25,7 @@ class LiveManager:
             if stop:
                 self.live.stop()
         except Exception as e:
-            await log(f"Issue with rich live {e}", level=10)
-            await log(f"Issue with rich live {traceback.format_exc()}", level=10)
+            await log(f"Issue with rich live {e}", level=10, exc_info=True)
 
     @asynccontextmanager
     async def get_remove_file_via_hash_live(self, stop=False):
@@ -41,8 +39,7 @@ class LiveManager:
             if stop:
                 self.live.stop()
         except Exception as e:
-            await log(f"Issue with rich live {e}", level=10)
-            await log(f"Issue with rich live {traceback.format_exc()}", level=10)
+            await log(f"Issue with rich live {e}", level=10, exc_info=True)
 
     @asynccontextmanager
     async def get_hash_live(self, stop=False):
@@ -56,8 +53,7 @@ class LiveManager:
             if stop:
                 self.live.stop()
         except Exception as e:
-            await log(f"Issue with rich live {e}", level=10)
-            await log(f"Issue with rich live {traceback.format_exc()}", level=10)
+            await log(f"Issue with rich live {e}", level=10, exc_info=True)
 
     @asynccontextmanager
     async def get_sort_live(self, stop=False):
@@ -71,5 +67,4 @@ class LiveManager:
             if stop:
                 self.live.stop()
         except Exception as e:
-            await log(f"Issue with rich live {e}", level=10)
-            await log(f"Issue with rich live {traceback.format_exc()}", level=10)
+            await log(f"Issue with rich live {e}", level=10, exc_info=True)

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -19,7 +19,7 @@ from cyberdrop_dl.managers.progress_manager import ProgressManager
 from cyberdrop_dl.utils.args import config_definitions
 from cyberdrop_dl.utils.dataclasses.supported_domains import SupportedDomains
 from cyberdrop_dl.utils.transfer.first_time_setup import TransitionManager
-from cyberdrop_dl.utils.utilities import log
+from cyberdrop_dl.utils.utilities import log, show_cached_request_summary
 
 
 class Manager:
@@ -222,6 +222,7 @@ class Manager:
 
     async def close(self) -> None:
         """Closes the manager"""
+        await show_cached_request_summary() 
         await self.db_manager.close()
         self.console_manager.close()
         await self.cache_manager.close()

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -35,6 +35,7 @@ LOG_OUTPUT_TEXT = "```diff\n"
 
 RAR_MULTIPART_PATTERN = r'^part\d+'
 _7Z_FILE_EXTENSIONS = {"7z","tar","gz","bz2","zip"}
+TOTAL_REQUESTS = CACHED_RESPONSES = 0
 
 FILE_FORMATS = {
     'Images': {
@@ -134,6 +135,20 @@ async def log_with_color(message: str, style: str, level: int, *kwargs) -> None:
     rich.print(f"[{style}]{message}[/{style}]")
     LOG_OUTPUT_TEXT += f"[{style}]{message}\n"
 
+async def log_request_type(url: URL, from_cache:bool):
+    global TOTAL_REQUESTS, CACHED_RESPONSES 
+    TOTAL_REQUESTS +=1
+    msg = f"{url} fetched from the web"
+    if from_cache:
+        msg = f"{url} fetched from cache"
+        CACHED_RESPONSES +=1
+    if DEBUG_VAR:
+        logger_debug.log(10,msg)
+
+async def show_cached_request_summary():
+    global TOTAL_REQUESTS, CACHED_RESPONSES 
+    if DEBUG_VAR:
+        logger_debug.log(10,f"{TOTAL_REQUESTS = } {CACHED_RESPONSES = }")
 
 async def get_log_output_text() -> str:
     global LOG_OUTPUT_TEXT

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import os
 import re
-import traceback
 from enum import IntEnum
 from functools import wraps
 from pathlib import Path
@@ -18,7 +17,7 @@ from cyberdrop_dl.clients.errors import NoExtensionFailure, FailedLoginFailure, 
 from cyberdrop_dl.managers.console_manager import log as log_console
 
 if TYPE_CHECKING:
-    from typing import Tuple
+    from typing import Tuple, Union
 
     from cyberdrop_dl.managers.manager import Manager
     from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
@@ -100,39 +99,38 @@ def error_handling_wrapper(func):
                     await self.manager.log_manager.write_scrape_error_log(link, f" {e.status}")
                 await self.manager.progress_manager.scrape_stats_progress.add_failure(e.status)
             else:
-                await log(f"Scrape Failed: {link} ({e})", 40)
-                await log(traceback.format_exc(), 40)
+                await log(f"Scrape Failed: {link} ({e})", 40, exc_info=True)
                 await self.manager.log_manager.write_scrape_error_log(link, " See Log for Details")
                 await self.manager.progress_manager.scrape_stats_progress.add_failure("Unknown")
 
     return wrapper
 
 
-async def log(message: [str, Exception], level: int, sleep: int = None) -> None:
+async def log(message: Union[str, Exception], level: int, sleep: int = None, **kwargs) -> None:
     """Simple logging function"""
-    logger.log(level, message)
+    logger.log(level, message, **kwargs)
     if DEBUG_VAR:
-        logger_debug.log(level, message)
+        logger_debug.log(level, message, **kwargs)
     log_console(level, message, sleep=sleep)
 
 
-async def log_debug(message: [str, Exception], level: int, sleep: int = None) -> None:
+async def log_debug(message: Union[str, Exception], level: int, sleep: int = None, *kwargs) -> None:
     """Simple logging function"""
     if DEBUG_VAR:
-        logger_debug.log(level, message.encode('ascii', 'ignore').decode('ascii'))
+        logger_debug.log(level, message.encode('ascii', 'ignore').decode('ascii'), *kwargs)
 
 
-async def log_debug_console(message: [str, Exception], level: int, sleep: int = None):
+async def log_debug_console(message: Union[str, Exception], level: int, sleep: int = None):
     if CONSOLE_DEBUG_VAR:
         log_console(level, message.encode('ascii', 'ignore').decode('ascii'), sleep=sleep)
 
 
-async def log_with_color(message: str, style: str, level: int) -> None:
+async def log_with_color(message: str, style: str, level: int, *kwargs) -> None:
     """Simple logging function with color"""
     global LOG_OUTPUT_TEXT
-    logger.log(level, message)
+    logger.log(level, message, *kwargs)
     if DEBUG_VAR:
-        logger_debug.log(level, message)
+        logger_debug.log(level, message, *kwargs)
     rich.print(f"[{style}]{message}[/{style}]")
     LOG_OUTPUT_TEXT += f"[{style}]{message}\n"
 


### PR DESCRIPTION
1. Replaces built-in log file handler with rich handler for better tracebacks while debugging
2. Adds a basic function to show the total number of requests and the total number of cached responses during the run. Currently only used by the base `ScraperClient` class
3. Fixes return type of  `ScraperClient.get_text() -> str`

**Example log output**

[downloader.log](https://github.com/user-attachments/files/17157717/downloader.log)

[cyberdrop_dl_debug.log](https://github.com/user-attachments/files/17157718/cyberdrop_dl_debug.log)
