### PR TITLE
keep track of scrape items parents

### DIFF
--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -1,3 +1,8 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cyberdrop_dl.scraper.crawler import ScrapeItem
+
 class InvalidContentTypeFailure(Exception):
     """This error will be thrown when the content type isn't as expected"""
 
@@ -17,8 +22,9 @@ class NoExtensionFailure(Exception):
 class PasswordProtected(Exception):
     """This error will be thrown when a file is password protected"""
 
-    def __init__(self, *, message: str = "File/Folder is password protected"):
-        self.message = message
+    def __init__(self,/, scrape_item: 'ScrapeItem'):
+        self.message = "File/Folder is password protected"
+        self.scrape_item = scrape_item
         super().__init__(self.message)
 
 

--- a/cyberdrop_dl/managers/hash_manager.py
+++ b/cyberdrop_dl/managers/hash_manager.py
@@ -16,7 +16,7 @@ class HashManager:
     def _get_hasher(self):
         """Tries to import xxhash, otherwise falls back to hashlib.md5"""
         try:
-            import xxhash
+            import xxhash  # type: ignore
             return xxhash.xxh128
         except ImportError:
             import hashlib

--- a/cyberdrop_dl/managers/log_manager.py
+++ b/cyberdrop_dl/managers/log_manager.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import aiofiles
 
@@ -36,10 +36,10 @@ class LogManager:
         async with aiofiles.open(self.last_post_log, 'a') as f:
             await f.write(f"{url}\n")
 
-    async def write_unsupported_urls_log(self, url: 'URL') -> None:
+    async def write_unsupported_urls_log(self, url: 'URL', parent_url: Optional['URL'] = None ) -> None:
         """Writes to the unsupported urls log"""
         async with aiofiles.open(self.unsupported_urls_log, 'a') as f:
-            await f.write(f"{url}\n")
+            await f.write(f"{url} ; {parent_url}\n")
 
     async def write_download_error_log(self, url: 'URL', error_message: str) -> None:
         """Writes to the download error log"""

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -4,7 +4,7 @@ import asyncio
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import field
-from typing import TYPE_CHECKING, Optional, Union, Any
+from typing import TYPE_CHECKING, Optional, Union, Any, Tuple
 
 from bs4 import BeautifulSoup
 from yarl import URL
@@ -94,7 +94,7 @@ class Crawler(ABC):
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
-    async def check_post_number(self, post_number: int, current_post_number: int) -> (bool, bool):
+    async def check_post_number(self, post_number: int, current_post_number: int) -> Tuple[bool, bool]:
         """Checks if the program should scrape the current post"""
         """Returns (scrape_post, continue_scraping)"""
         scrape_single_forum_post = self.manager.config_manager.settings_data['Download_Options'][
@@ -194,10 +194,12 @@ class Crawler(ABC):
 
     async def create_scrape_item(self, parent_scrape_item: ScrapeItem, url: URL, new_title_part: str,
                                  part_of_album: bool = False, album_id: Union[str, None] = None,
-                                 possible_datetime: Optional[int] = None) -> ScrapeItem:
+                                 possible_datetime: Optional[int] = None, add_parent: Optional[URL] = None) -> ScrapeItem:
         """Creates a scrape item"""
         scrape_item = copy.deepcopy(parent_scrape_item)
         scrape_item.url = url
+        if add_parent:
+            scrape_item.parents.append(add_parent)
         if new_title_part:
             await scrape_item.add_to_parent_title(new_title_part)
         scrape_item.part_of_album = part_of_album if part_of_album else scrape_item.part_of_album

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -84,7 +84,7 @@ class BunkrrCrawler(Crawler):
                 src = src.with_query("download=true")
                 if file_ext.lower() not in FILE_FORMATS['Images']:
                     src = src.with_host(src.host.replace("i-", ""))
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, "", True, album_id, date)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, "", True, album_id, date, add_parent = scrape_item.url)
 
                 if "no-image" in src.name:
                     raise FileNotFoundError("No image found, reverting to parent")

--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -102,7 +102,7 @@ class CelebForumCrawler(Crawler):
 
                 if scrape_post:
                     date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent= thread_url.joinpath(f"#post-{current_post_number}"))
 
                     for elem in post.find_all(self.quotes_selector):
                         elem.decompose()

--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -102,7 +102,7 @@ class CelebForumCrawler(Crawler):
 
                 if scrape_post:
                     date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent= thread_url.joinpath(f"#post-{current_post_number}"))
+                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent= thread_url.joinpath(f"post-{current_post_number}"))
 
                     for elem in post.find_all(self.quotes_selector):
                         elem.decompose()

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -86,7 +86,7 @@ class CoomerCrawler(Crawler):
         async def handle_file(file_obj):
             link = self.primary_base_domain / ("data" + file_obj['path'])
             link = link.with_query({"f": file_obj['name']})
-            await self.create_new_scrape_item(link, scrape_item, user_str, post_title, post_id, date)
+            await self.create_new_scrape_item(link, scrape_item, user_str, post_title, post_id, date, add_parent = scrape_item.url.joinpath("post", post_id))
 
         if post['file']:
             await handle_file(post['file'])

--- a/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
@@ -52,7 +52,7 @@ class CyberdropCrawler(Crawler):
                 link = self.primary_base_url.with_path(link)
             link = URL(link)
 
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
@@ -72,7 +72,7 @@ class CyberfileCrawler(Crawler):
                     await log(f"Couldn't find folder or file id for {scrape_item.url} element", 30)
                     continue
 
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             page += 1
@@ -112,7 +112,7 @@ class CyberfileCrawler(Crawler):
                     await log(f"Couldn't find folder or file id for {scrape_item.url} element", 30)
                     continue
 
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             page += 1

--- a/cyberdrop_dl/scraper/crawlers/ehentai_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/ehentai_crawler.py
@@ -51,7 +51,7 @@ class EHentaiCrawler(Crawler):
         images = soup.select("div[class=gdtm] div a")
         for image in images:
             link = URL(image.get('href'))
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
         next_page_opts = soup.select('td[onclick="document.location=this.firstChild.href"]')

--- a/cyberdrop_dl/scraper/crawlers/erome_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/erome_crawler.py
@@ -42,7 +42,7 @@ class EromeCrawler(Crawler):
 
         for album in albums:
             link = URL(album['href'])
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
         next_page = soup.select_one('a[rel="next"]')

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -102,7 +102,7 @@ class F95ZoneCrawler(Crawler):
 
                 if scrape_post:
                     date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent= scrape_item.url.joinpath(f"post-{current_post_number}"))
 
                     for elem in post.find_all(self.quotes_selector):
                         elem.decompose()

--- a/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
@@ -50,11 +50,11 @@ class FapelloCrawler(Crawler):
             if "javascript" in post.get('href'):
                 video_tag = post.select_one('iframe')
                 video_link = URL(video_tag.get('src'))
-                new_scrape_item = await self.create_scrape_item(scrape_item, video_link, "", True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, video_link, "", True, add_parent = scrape_item.url)
                 await self.handle_external_links(new_scrape_item)
             else:
                 link = URL(post.get('href'))
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 await self.handle_external_links(new_scrape_item)
 
         next_page = soup.select_one('div[id="next_page"] a')

--- a/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
@@ -61,7 +61,7 @@ class FapelloCrawler(Crawler):
         if next_page:
             next_page = next_page.get('href')
             if next_page:
-                new_scrape_item = ScrapeItem(URL(next_page), scrape_item.parent_title)
+                new_scrape_item = await self.create_scrape_item(scrape_item, URL(next_page), "")
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -70,7 +70,7 @@ class GoFileCrawler(Crawler):
         JSON_Resp = JSON_Resp['data']
 
         if "password" in JSON_Resp:
-            raise PasswordProtected()
+            raise PasswordProtected(scrape_item)
 
         if JSON_Resp["canAccess"] is False:
             raise ScrapeFailure(403, "Album is private")
@@ -83,7 +83,7 @@ class GoFileCrawler(Crawler):
             if content["type"] == "folder":
                 new_scrape_item = await self.create_scrape_item(scrape_item,
                                                                 self.primary_base_domain / "d" / content["code"], title,
-                                                                True)
+                                                                True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
                 continue
             if content["link"] == "overloaded":

--- a/cyberdrop_dl/scraper/crawlers/imageban_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imageban_crawler.py
@@ -59,7 +59,7 @@ class ImageBanCrawler(Crawler):
             else:
                 link = URL(link_path)
 
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
         next_page = soup.select_one('a[class*="page-link next"]')

--- a/cyberdrop_dl/scraper/crawlers/imgbb_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgbb_crawler.py
@@ -64,7 +64,7 @@ class ImgBBCrawler(Crawler):
             links = soup.select("a[class*=image-container]")
             for link in links:
                 link = URL(link.get('href'))
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             link_next = soup.select_one('a[data-pagination=next]')

--- a/cyberdrop_dl/scraper/crawlers/imgkiwi_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgkiwi_crawler.py
@@ -52,7 +52,7 @@ class ImgKiwiCrawler(Crawler):
             links = soup.select("a[href*=image]")
             for link in links:
                 link = URL(link.get('href'))
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             link_next = soup.select_one('a[data-pagination=next]')

--- a/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
@@ -61,7 +61,7 @@ class ImgurCrawler(Crawler):
         for image in JSON_Obj["data"]:
             link = URL(image["link"])
             date = image["datetime"]
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date, add_parent = scrape_item.url)
             await self.handle_direct(new_scrape_item)
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/crawlers/jpgchurch_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/jpgchurch_crawler.py
@@ -56,7 +56,7 @@ class JPGChurchCrawler(Crawler):
             links = soup.select("a[href*=img]")
             for link in links:
                 link = URL(link.get('href'))
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             link_next = soup.select_one('a[data-pagination=next]')
@@ -96,7 +96,7 @@ class JPGChurchCrawler(Crawler):
             links = soup.select("a[href*=img] img")
             for link in links:
                 link = URL(link.get('src'))
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, album_id)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, album_id, add_parent = scrape_item.url)
                 if not await self.check_album_results(link, results):
                     await self.handle_direct_link(new_scrape_item)
 

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -141,7 +141,7 @@ class KemonoCrawler(Crawler):
         for link in yarl_links:
             if "kemono" in link.host:
                 continue
-            scrape_item = await self.create_scrape_item(scrape_item, link, "")
+            scrape_item = await self.create_scrape_item(scrape_item, link, "", add_parent = scrape_item.url.joinpath("post",post_id))
             await self.handle_external_links(scrape_item)
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -69,7 +69,7 @@ class LeakedModelsCrawler(Crawler):
                 await log("LeakedModels login failed. Skipping.", 40)
         else:
             await log(f"Scrape Failed: Unknown URL Path for {scrape_item.url}", 40)
-            await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url)
+            await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url, scrape_item.parents[0] if scrape_item.parents else None)
 
         await self.scraping_progress.remove_task(task_id)
 
@@ -107,7 +107,7 @@ class LeakedModelsCrawler(Crawler):
 
                 if scrape_post:
                     date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent = scrape_item.url.joinpath(f"post-{current_post_number}"))
 
                     for elem in post.find_all(self.quotes_selector):
                         elem.decompose()

--- a/cyberdrop_dl/scraper/crawlers/mediafire_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/mediafire_crawler.py
@@ -57,7 +57,7 @@ class MediaFireCrawler(Crawler):
             for file in files:
                 date = await self.parse_datetime(file['created'])
                 link = URL(file['links']['normal_download'])
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             if folder_contents["folder_content"]["more_chunks"] == "yes":

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -103,7 +103,7 @@ class NudoStarCrawler(Crawler):
 
                 if scrape_post:
                     date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent = scrape_item.url.joinpath(f"post-{current_post_number}"))
 
                     for elem in post.find_all(self.quotes_selector):
                         elem.decompose()

--- a/cyberdrop_dl/scraper/crawlers/nudostartv_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostartv_crawler.py
@@ -39,7 +39,7 @@ class NudoStarTVCrawler(Crawler):
         content = soup.select('div[id=list_videos_common_videos_list_items] div a')
         for page in content:
             link = URL(page.get('href'))
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             await self.image(new_scrape_item)
         next_page = soup.select_one('li[class=next] a')
         if next_page:

--- a/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
@@ -61,7 +61,7 @@ class OmegaScansCrawler(Crawler):
 
             for chapter in JSON_Obj['data']:
                 chapter_url = scrape_item.url / chapter['chapter_slug']
-                new_scrape_item = await self.create_scrape_item(scrape_item, chapter_url, "", True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, chapter_url, "", True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             if JSON_Obj['meta']['current_page'] == JSON_Obj['meta']['last_page']:

--- a/cyberdrop_dl/scraper/crawlers/pimpandhost_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pimpandhost_crawler.py
@@ -47,7 +47,7 @@ class PimpAndHostCrawler(Crawler):
         files = soup.select('a[class*="image-wrapper center-cropped im-wr"]')
         for file in files:
             link = URL(file.get("href"))
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
         next_page = soup.select_one("li[class=next] a")

--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -56,7 +56,7 @@ class PixelDrainCrawler(Crawler):
                     filename, ext = await get_filename_and_ext(file['name'] + "." + file["mime_type"].split("/")[-1])
                 else:
                     raise NoExtensionFailure()
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date, add_parent = scrape_item.url)
             if not await self.check_album_results(link, results):
                 await self.handle_file(link, new_scrape_item, filename, ext)
 
@@ -79,7 +79,7 @@ class PixelDrainCrawler(Crawler):
                 lines = text.split("\n")
                 for line in lines:
                     link = URL(line)
-                    new_scrape_item = await self.create_scrape_item(scrape_item, link, "", False, None, date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, link, "", False, None, date, add_parent = scrape_item.url)
                     await self.handle_external_links(new_scrape_item)
             elif "image" in JSON_Resp["mime_type"] or "video" in JSON_Resp["mime_type"]:
                 filename, ext = await get_filename_and_ext(JSON_Resp['name'] + "." + JSON_Resp["mime_type"].split("/")[-1])

--- a/cyberdrop_dl/scraper/crawlers/postimg_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/postimg_crawler.py
@@ -50,7 +50,7 @@ class PostImgCrawler(Crawler):
             for image in JSON_Resp['images']:
                 link = URL(image[4])
                 filename, ext = image[2], image[3]
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 await self.handle_file(link, new_scrape_item, filename, ext)
 
             if not JSON_Resp['has_page_next']:

--- a/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
@@ -54,7 +54,7 @@ class RealBooruCrawler(Crawler):
             if link.startswith("/"):
                 link = f"{self.primary_base_url}{link}"
             link = URL(link, encoded=True)
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
         next_page = soup.select_one("a[alt=next]")

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import aiohttp
 import asyncpraw
@@ -107,14 +107,14 @@ class RedditCrawler(Crawler):
             filename, ext = await get_filename_and_ext(media_url.name)
 
         if "redd.it" in media_url.host:
-            new_scrape_item = await self.create_new_scrape_item(media_url, scrape_item, title, date)
+            new_scrape_item = await self.create_new_scrape_item(media_url, scrape_item, title, date, add_parent = scrape_item.url)
             await self.media(new_scrape_item, reddit)
         elif "gallery" in media_url.parts:
-            new_scrape_item = await self.create_new_scrape_item(media_url, scrape_item, title, date)
+            new_scrape_item = await self.create_new_scrape_item(media_url, scrape_item, title, date, add_parent = scrape_item.url)
             await self.gallery(new_scrape_item, submission, reddit)
         else:
             if "reddit.com" not in media_url.host:
-                new_scrape_item = await self.create_new_scrape_item(media_url, scrape_item, title, date)
+                new_scrape_item = await self.create_new_scrape_item(media_url, scrape_item, title, date, add_parent = scrape_item.url)
                 await self.handle_external_links(new_scrape_item)
 
     async def gallery(self, scrape_item: ScrapeItem, submission, reddit: asyncpraw.Reddit) -> None:
@@ -125,7 +125,7 @@ class RedditCrawler(Crawler):
         links = [URL(item["s"]["u"]).with_host("i.redd.it").with_query(None) for item in items]
         for link in links:
             new_scrape_item = await self.create_new_scrape_item(link, scrape_item, scrape_item.parent_title,
-                                                                scrape_item.possible_datetime)
+                                                                scrape_item.possible_datetime, add_parent = scrape_item.url)
             await self.media(new_scrape_item, reddit)
 
     @error_handling_wrapper
@@ -151,10 +151,10 @@ class RedditCrawler(Crawler):
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
-    async def create_new_scrape_item(self, link: URL, old_scrape_item: ScrapeItem, title: str, date: int) -> ScrapeItem:
+    async def create_new_scrape_item(self, link: URL, old_scrape_item: ScrapeItem, title: str, date: int, add_parent: Optional[URL] = None) -> ScrapeItem:
         """Creates a new scrape item with the same parent as the old scrape item"""
 
-        new_scrape_item = await self.create_scrape_item(old_scrape_item, link, "", True, None, date)
+        new_scrape_item = await self.create_scrape_item(old_scrape_item, link, "", True, None, date, add_parent= add_parent)
         if self.manager.config_manager.settings_data['Download_Options']['separate_posts']:
             await new_scrape_item.add_to_parent_title(title)
         return new_scrape_item

--- a/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
@@ -63,7 +63,7 @@ class RedGifsCrawler(Crawler):
                     link = URL(links["sd"])
 
                 filename, ext = await get_filename_and_ext(link.name)
-                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date)
+                new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date,add_parent = scrape_item.url)
                 await self.handle_file(link, new_scrape_item, filename, ext)
             page += 1
 
@@ -84,7 +84,7 @@ class RedGifsCrawler(Crawler):
         link = URL(links["hd"] if "hd" in links else links["sd"])
 
         filename, ext = await get_filename_and_ext(link.name)
-        new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date)
+        new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, dateadd_parent = scrape_item.url, add_parent = scrape_item.url)
         await self.handle_file(link, new_scrape_item, filename, ext)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
@@ -84,7 +84,7 @@ class RedGifsCrawler(Crawler):
         link = URL(links["hd"] if "hd" in links else links["sd"])
 
         filename, ext = await get_filename_and_ext(link.name)
-        new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, dateadd_parent = scrape_item.url, add_parent = scrape_item.url)
+        new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date, add_parent = scrape_item.url, add_parent = scrape_item.url)
         await self.handle_file(link, new_scrape_item, filename, ext)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
@@ -56,7 +56,7 @@ class Rule34VaultCrawler(Crawler):
                 link = f"{self.primary_base_url}{link}"
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(
-                scrape_item, link, title, True)
+                scrape_item, link, title, True,add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
         if not content:
             return
@@ -95,7 +95,7 @@ class Rule34VaultCrawler(Crawler):
                 link = f"{self.primary_base_url}{link}"
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(
-                scrape_item, link, title, True)
+                scrape_item, link, title, True,add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
         if not content:
             return

--- a/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
@@ -54,7 +54,7 @@ class Rule34XXXCrawler(Crawler):
             if link.startswith("/"):
                 link = f"{self.primary_base_url}{link}"
             link = URL(link, encoded=True)
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True,add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
         next_page = soup.select_one("a[alt=next]")

--- a/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
@@ -49,7 +49,7 @@ class Rule34XYZCrawler(Crawler):
             if link.startswith("/"):
                 link = f"{self.primary_base_url}{link}"
             link = URL(link)
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True,add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
         if not content:
             return

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -109,7 +109,7 @@ class SimpCityCrawler(Crawler):
                         date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
                     except:
                         pass
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent = scrape_item.url.joinpath(f"post-{current_post_number}"))
 
                     # for elem in post.find_all(self.quotes_selector):
                     #     elem.decompose()

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -104,7 +104,7 @@ class SocialMediaGirlsCrawler(Crawler):
 
                 if scrape_post:
                     date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent = scrape_item.url.joinpath(f"post-{current_post_number}"))
 
                     for elem in post.find_all(self.quotes_selector):
                         elem.decompose()

--- a/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
@@ -51,7 +51,7 @@ class ToonilyCrawler(Crawler):
                 chapter_path = self.primary_base_domain / chapter_path[1:]
             else:
                 chapter_path = URL(chapter_path)
-            new_scrape_item = await self.create_scrape_item(scrape_item, chapter_path, "", True)
+            new_scrape_item = await self.create_scrape_item(scrape_item, chapter_path, "", True , add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -107,7 +107,7 @@ class XBunkerCrawler(Crawler):
 
                 if scrape_post:
                     date = int(post.select_one(self.post_date_selector).get(self.post_date_attribute))
-                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date)
+                    new_scrape_item = await self.create_scrape_item(scrape_item, thread_url, title, False, None, date, add_parent = scrape_item.url.joinpath(f"post-{current_post_number}"))
 
                     for elem in post.find_all(self.quotes_selector):
                         elem.decompose()

--- a/cyberdrop_dl/scraper/crawlers/xbunkr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunkr_crawler.py
@@ -49,5 +49,5 @@ class XBunkrCrawler(Crawler):
             except NoExtensionFailure:
                 await log(f"Couldn't get extension for {str(link)}", 30)
                 continue
-            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True)
+            new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             await self.handle_file(link, new_scrape_item, filename, ext)

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -463,13 +463,13 @@ class ScrapeMapper:
             except JDownloaderFailure as e:
                 await log(f"Failed to send {scrape_item.url} to JDownloader", 40)
                 await log(e.message, 40)
-                await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url)
+                await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url, scrape_item.parents[0] if scrape_item.parents else None)
 
         else:
             await log(f"Unsupported URL: {scrape_item.url}", 30)
-            await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url)
+            await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url, scrape_item.parents[0] if scrape_item.parents else None)
 
-    async def filter_items(self, scrape_item) -> None:
+    async def filter_items(self, scrape_item: ScrapeItem) -> None:
         """Maps URLs to their respective handlers"""
         if not scrape_item.url:
             return
@@ -536,8 +536,8 @@ class ScrapeMapper:
             except JDownloaderFailure as e:
                 await log(f"Failed to send {scrape_item.url} to JDownloader", 40)
                 await log(e.message, 40)
-                await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url)
+                await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url, scrape_item.parents[0] if scrape_item.parents else None)
 
         else:
             await log(f"Unsupported URL: {scrape_item.url}", 30)
-            await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url)
+            await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url, scrape_item.parents[0] if scrape_item.parents else None)

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Union
 
 from rich.console import Group
 from rich.panel import Panel
@@ -27,7 +27,7 @@ class DownloadStatsProgress:
         for key in self.failure_types:
             self.progress.update(self.failure_types[key], total=total)
 
-    async def add_failure(self, failure_type: [str, int]) -> None:
+    async def add_failure(self, failure_type: Union[str, int]) -> None:
         """Adds a failed file to the progress bar"""
         self.failed_files += 1
         if isinstance(failure_type, int):
@@ -70,7 +70,7 @@ class ScrapeStatsProgress:
         for key in self.failure_types:
             self.progress.update(self.failure_types[key], total=total)
 
-    async def add_failure(self, failure_type: [str, int]) -> None:
+    async def add_failure(self, failure_type: Union[str, int]) -> None:
         """Adds a failed site to the progress bar"""
         self.failed_files += 1
         if isinstance(failure_type, int):

--- a/cyberdrop_dl/utils/dataclasses/url_objects.py
+++ b/cyberdrop_dl/utils/dataclasses/url_objects.py
@@ -37,6 +37,8 @@ class ScrapeItem:
                  retry: bool = False, retry_path: Path = None):
         self.url: URL = url
         self.parent_title: str = parent_title
+        # WARNING: unsafe but deepcopy is used when a new child item is created
+        self.parents : list[URL] = []
         self.part_of_album: bool = part_of_album
         self.album_id: Union[str, None] = album_id
         self.possible_datetime: int = possible_datetime

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -8,7 +8,7 @@ import traceback
 from enum import IntEnum
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import rich
 from yarl import URL
@@ -74,9 +74,10 @@ def error_handling_wrapper(func):
             await log(f"Scrape Failed: {link} (No File Extension)", 40)
             await self.manager.log_manager.write_scrape_error_log(link, " No File Extension")
             await self.manager.progress_manager.scrape_stats_progress.add_failure("No File Extension")
-        except PasswordProtected:
+        except PasswordProtected as e:
             await log(f"Scrape Failed: {link} (Password Protected)", 40)
-            await self.manager.log_manager.write_unsupported_urls_log(link)
+            parent_url = e.scrape_item.parents[0] if e.scrape_item.parents[0] else None
+            await self.manager.log_manager.write_unsupported_urls_log(link,parent_url)
             await self.manager.progress_manager.scrape_stats_progress.add_failure("Password Protected")
         except FailedLoginFailure:
             await log(f"Scrape Failed: {link} (Failed Login)", 40)
@@ -108,7 +109,7 @@ def error_handling_wrapper(func):
     return wrapper
 
 
-async def log(message: [str, Exception], level: int, sleep: int = None) -> None:
+async def log(message: Union [str, Exception], level: int, sleep: int = None) -> None:
     """Simple logging function"""
     logger.log(level, message)
     if DEBUG_VAR:
@@ -116,13 +117,13 @@ async def log(message: [str, Exception], level: int, sleep: int = None) -> None:
     log_console(level, message, sleep=sleep)
 
 
-async def log_debug(message: [str, Exception], level: int, sleep: int = None) -> None:
+async def log_debug(message: Union [str, Exception], level: int, sleep: int = None) -> None:
     """Simple logging function"""
     if DEBUG_VAR:
         logger_debug.log(level, message.encode('ascii', 'ignore').decode('ascii'))
 
 
-async def log_debug_console(message: [str, Exception], level: int, sleep: int = None):
+async def log_debug_console(message: Union [str, Exception], level: int, sleep: int = None):
     if CONSOLE_DEBUG_VAR:
         log_console(level, message.encode('ascii', 'ignore').decode('ascii'), sleep=sleep)
 


### PR DESCRIPTION
Each new scrape item will keep a list of its ancestors. 

**Example:**

`Forum post` -> `File-host album` -> `video/photo/etc`

Only use right now is in the generated `Unsupported_URLs.txt` file. URLs will be written alonside their oldest parent. For forums, the first parent is the post URL. 

If the URL is a password protected GoFile link, it will allow the user to retrieve the password from the post.

Links in a Pixeldrain text file will become its children. 

