### PR TITLE
Fix empty folders cleanup

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
@@ -84,7 +84,7 @@ class RedGifsCrawler(Crawler):
         link = URL(links["hd"] if "hd" in links else links["sd"])
 
         filename, ext = await get_filename_and_ext(link.name)
-        new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date, add_parent = scrape_item.url, add_parent = scrape_item.url)
+        new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date, add_parent = scrape_item.url)
         await self.handle_file(link, new_scrape_item, filename, ext)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/utils/changelog.py
+++ b/cyberdrop_dl/utils/changelog.py
@@ -3,6 +3,21 @@
 ------------------------------------------------------------
 
 C\bCH\bHA\bAN\bNG\bGE\bEL\bLO\bOG\bG
+\tVersion 5.6.37
+
+
+D\bDE\bES\bSC\bCR\bRI\bIP\bPT\bTI\bIO\bON\bN
+\tThis update introduces the following changes:
+\t\t1. Fixes empty folder cleanup on python 3.11
+
+\tDetails:
+\t\t- Fixes logic by walking the directory tree using os.walk to remain compatibility with python 3.11
+
+\tFor more details, visit the wiki: https://script-ware.gitbook.io
+
+------------------------------------------------------------
+
+C\bCH\bHA\bAN\bNG\bGE\bEL\bLO\bOG\bG
 \tVersion 5.6.36
 
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -247,7 +247,7 @@ async def purge_dir_tree(dirname: Path) -> None:
         if file.is_file() and file.stat().st_size == 0:
             file.unlink()
 
-    for parent, dirs, _ in dirname.walk(top_down=False):
+    for parent, dirs, _ in os.walk(dirname, topdown=False):
         for child_dir in dirs:
             try:
                 (parent / child_dir).rmdir()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.6.36"
+version = "5.6.37"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
1. Replaces `Path.walk` with `os.walk` to remain compatible with python 3.11
2. Fixes minor bug where duplicate parents were added to new redgifs items.