### PR TITLE
fix: purge_dir_tree

### DIFF
--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -250,7 +250,7 @@ async def purge_dir_tree(dirname: Path) -> None:
     for parent, dirs, _ in os.walk(dirname, topdown=False):
         for child_dir in dirs:
             try:
-                (parent / child_dir).rmdir()
+                (Path(parent) / child_dir).rmdir()
             except OSError:
                 pass #skip if folder is not empty
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.6.39"
+version = "5.6.40"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
Convert directories (`str`) back to `Path` objects before removing them

Related to #137 