### PR TITLE
Fix crash when unsupported URLs have no parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.41] - 2024-10-01
+
+This update introduces the following changes:
+1. Fixes crash when unsupported URLs have no parents
+2. Display new changelog if an update is available
+3. Updated supported sites in Wiki
+
+#### Details:
+
+- Fixes crash if an unsupported url have no parents
+- Always display an updated changelog if a new version has been released on Pypi
+- Remove Simpcity from supported websites on Wiki
+
+## [5.6.40] - 2024-10-01
+
+This update introduces the following changes:
+1. Fixes empty folder cleanup 
+
+#### Details:
+- Fixes incorrent path objects on post-runtime folder cleanup
+
 ## [5.6.39] - 2024-09-30
 
 This update introduces the following changes:

--- a/cyberdrop_dl/ui/ui.py
+++ b/cyberdrop_dl/ui/ui.py
@@ -23,7 +23,6 @@ from cyberdrop_dl.ui.prompts.settings_global_prompts import edit_global_settings
 from cyberdrop_dl.ui.prompts.settings_hash_prompts import path_prompt
 from cyberdrop_dl.ui.prompts.settings_user_prompts import create_new_config_prompt, edit_config_values_prompt
 from cyberdrop_dl.ui.prompts.url_file_prompts import edit_urls_prompt
-from cyberdrop_dl.utils.utilities import check_latest_pypi
 
 console = Console()
 

--- a/cyberdrop_dl/ui/ui.py
+++ b/cyberdrop_dl/ui/ui.py
@@ -23,6 +23,7 @@ from cyberdrop_dl.ui.prompts.settings_global_prompts import edit_global_settings
 from cyberdrop_dl.ui.prompts.settings_hash_prompts import path_prompt
 from cyberdrop_dl.ui.prompts.settings_user_prompts import create_new_config_prompt, edit_config_values_prompt
 from cyberdrop_dl.ui.prompts.url_file_prompts import edit_urls_prompt
+from cyberdrop_dl.utils.utilities import check_latest_pypi
 
 console = Console()
 
@@ -214,7 +215,8 @@ def program_ui(manager: Manager):
 
 async def _get_changelog(changelog_path: Path):
     url = "https://raw.githubusercontent.com/jbsparrow/CyberDropDownloader/refs/heads/master/CHANGELOG.md"
-    if not changelog_path.is_file():
+    current_version, lastest_version = await check_latest_pypi(log_to_console = False)
+    if not changelog_path.is_file() or current_version != lastest_version :
         try:
             async with request("GET", url) as response:
                 response.raise_for_status()

--- a/cyberdrop_dl/ui/ui.py
+++ b/cyberdrop_dl/ui/ui.py
@@ -23,6 +23,7 @@ from cyberdrop_dl.ui.prompts.settings_global_prompts import edit_global_settings
 from cyberdrop_dl.ui.prompts.settings_hash_prompts import path_prompt
 from cyberdrop_dl.ui.prompts.settings_user_prompts import create_new_config_prompt, edit_config_values_prompt
 from cyberdrop_dl.ui.prompts.url_file_prompts import edit_urls_prompt
+from cyberdrop_dl.utils.utilities import check_latest_pypi
 
 console = Console()
 
@@ -201,7 +202,7 @@ def program_ui(manager: Manager):
             import_cyberdrop_v4_items_prompt(manager)
 
         elif action == 11:
-            changelog_path = manager.path_manager.config_dir.parent / f"CHANGELOG_{__version__}.md"
+            changelog_path = manager.path_manager.config_dir.parent / "CHANGELOG.md"
             changelog_content = asyncio.run(_get_changelog(changelog_path))
 
             with console.pager(links = True):
@@ -214,16 +215,21 @@ def program_ui(manager: Manager):
 
 async def _get_changelog(changelog_path: Path):
     url = "https://raw.githubusercontent.com/jbsparrow/CyberDropDownloader/refs/heads/master/CHANGELOG.md"
-    if not changelog_path.is_file():
+    _ , lastest_version = await check_latest_pypi(log_to_console = False)
+    latest_changelog = changelog_path.with_name(f"{changelog_path.stem}_{lastest_version}{changelog_path.suffix}")
+    if not latest_changelog.is_file():
+        changelog_pattern = f"{changelog_path.stem}*{changelog_path.suffix}"
+        for old_changelog in changelog_path.parent.glob(changelog_pattern):
+            old_changelog.unlink() 
         try:
             async with request("GET", url) as response:
                 response.raise_for_status()
-                async with aiofiles.open(changelog_path, 'wb') as f:   
+                async with aiofiles.open(latest_changelog, 'wb') as f:   
                     await f.write(await response.read())
         except Exception:
             return "UNABLE TO GET CHANGELOG INFORMATION"
  
-    changelog_lines = changelog_path.read_text(encoding="utf8").splitlines()
+    changelog_lines = latest_changelog.read_text(encoding="utf8").splitlines()
     # remove keep_a_changelog disclaimer
     changelog_content = "\n".join(changelog_lines[:4] + changelog_lines[6:])
     

--- a/cyberdrop_dl/ui/ui.py
+++ b/cyberdrop_dl/ui/ui.py
@@ -202,7 +202,7 @@ def program_ui(manager: Manager):
             import_cyberdrop_v4_items_prompt(manager)
 
         elif action == 11:
-            changelog_path = manager.path_manager.config_dir.parent / "CHANGELOG.md"
+            changelog_path = manager.path_manager.config_dir.parent / f"CHANGELOG_{__version__}.md"
             changelog_content = asyncio.run(_get_changelog(changelog_path))
 
             with console.pager(links = True):
@@ -215,8 +215,7 @@ def program_ui(manager: Manager):
 
 async def _get_changelog(changelog_path: Path):
     url = "https://raw.githubusercontent.com/jbsparrow/CyberDropDownloader/refs/heads/master/CHANGELOG.md"
-    current_version, lastest_version = await check_latest_pypi(log_to_console = False)
-    if not changelog_path.is_file() or current_version != lastest_version :
+    if not changelog_path.is_file():
         try:
             async with request("GET", url) as response:
                 response.raise_for_status()

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -290,8 +290,7 @@ async def check_latest_pypi(log_to_console: bool = True) -> Tuple[str]:
     data = json.loads(contents)
     latest_version = data['info']['version']
 
-    if log_to_console:
-        if current_version != latest_version:
-            await log_with_color(f"New version of cyberdrop-dl available: {latest_version}", "bold_red", 30)
+    if log_to_console and current_version != latest_version:
+        await log_with_color(f"New version of cyberdrop-dl available: {latest_version}", "bold_red", 30)
 
     return current_version, latest_version

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -279,7 +279,7 @@ async def check_partials_and_empty_folders(manager: Manager):
             await purge_dir_tree(manager.path_manager.sorted_dir)
 
 
-async def check_latest_pypi():
+async def check_latest_pypi(log_to_console: bool = True) -> Tuple[str]:
     """Checks if the current version is the latest version"""
     from cyberdrop_dl import __version__ as current_version
     import json
@@ -290,8 +290,8 @@ async def check_latest_pypi():
     data = json.loads(contents)
     latest_version = data['info']['version']
 
-    if current_version.split(".")[0] > latest_version.split(".")[0]:
-        return
+    if log_to_console:
+        if current_version != latest_version:
+            await log_with_color(f"New version of cyberdrop-dl available: {latest_version}", "bold_red", 30)
 
-    if current_version != latest_version:
-        await log_with_color(f"New version of cyberdrop-dl available: {latest_version}", "bold_red", 30)
+    return current_version, latest_version

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -76,7 +76,7 @@ def error_handling_wrapper(func):
             await self.manager.progress_manager.scrape_stats_progress.add_failure("No File Extension")
         except PasswordProtected as e:
             await log(f"Scrape Failed: {link} (Password Protected)", 40)
-            parent_url = e.scrape_item.parents[0] if e.scrape_item.parents[0] else None
+            parent_url = e.scrape_item.parents[0] if e.scrape_item.parents else None
             await self.manager.log_manager.write_unsupported_urls_log(link,parent_url)
             await self.manager.progress_manager.scrape_stats_progress.add_failure("Password Protected")
         except FailedLoginFailure:

--- a/docs/reference/supported-websites.md
+++ b/docs/reference/supported-websites.md
@@ -49,6 +49,5 @@ description: These are the websites supported by Cyberdrop-DL
 | LeakedModels                | Threads: `/forum/threads/...`                                     |
 | Nudostar                    | Threads: `/forum/threads/...`                                     |
 | Reddit                      | User: `/user/...` User: `/u/...` Subreddit: `/r/...` Direct Links |
-| SimpCity                    | Threads: `/threads/...`                                           |
 | Forums.SocialMediaGirls.com | Threads: `/threads/...`                                           |
 | XBunker                     | Threads: `/threads/...`                                           |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.6.40"
+version = "5.6.41"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
1. Fixes crash if an unsupported URL have no parents
2. Always fetch an updated `CHANGELOG` from GH if a new version has been released on `Pypi`
3. Remove Simpcity from supported websites on the Wiki
