### PR TITLE
feat: always start forum scrape from input URL

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -83,6 +83,7 @@ class CelebForumCrawler(Crawler):
 
         current_post_number = 0
         while True:
+            thread_url = scrape_item.url if current_post_number == 0 else thread_url
             async with self.request_limiter:
                 soup = await self.client.get_BS4(self.domain, thread_url)
 

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -83,6 +83,7 @@ class F95ZoneCrawler(Crawler):
 
         current_post_number = 0
         while True:
+            thread_url = scrape_item.url if current_post_number == 0 else thread_url
             async with self.request_limiter:
                 soup = await self.client.get_BS4(self.domain, thread_url)
 

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -88,6 +88,7 @@ class LeakedModelsCrawler(Crawler):
 
         current_post_number = 0
         while True:
+            thread_url = scrape_item.url if current_post_number == 0 else thread_url
             async with self.request_limiter:
                 soup = await self.client.get_BS4(self.domain, thread_url)
 

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -84,6 +84,7 @@ class NudoStarCrawler(Crawler):
 
         current_post_number = 0
         while True:
+            thread_url = scrape_item.url if current_post_number == 0 else thread_url
             async with self.request_limiter:
                 soup = await self.client.get_BS4(self.domain, thread_url)
 

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -115,6 +115,7 @@ class SimpCityCrawler(Crawler):
 
         current_post_number = 0
         while True:
+            thread_url = scrape_item.url if current_post_number == 0 else thread_url
             async with self.request_limiter:
                 soup = await self.client.get_BS4(self.domain, thread_url, filter_fn=self.check_last_page)
 

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -99,6 +99,7 @@ class SocialMediaGirlsCrawler(Crawler):
 
         current_post_number = 0
         while True:
+            thread_url = scrape_item.url if current_post_number == 0 else thread_url
             async with self.request_limiter:
                 soup = await self.client.get_BS4(self.domain, thread_url, filter_fn=self.check_last_page)
 

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -88,6 +88,7 @@ class XBunkerCrawler(Crawler):
 
         current_post_number = 0
         while True:
+            thread_url = scrape_item.url if current_post_number == 0 else thread_url
             async with self.request_limiter:
                 soup = await self.client.get_BS4(self.domain, thread_url)
 


### PR DESCRIPTION
Currently, all forum crawlers start from the first page of the thread, even if the `input URL` is from an specific post.

CDL just ignores any post that is lower that the post from the `input URL` (if any).

This PR forces the use of the input URL as the first scrape to reduce unnecessary requests.

Tested on SC and SMG. If the post was deleted or did no exists, both returned the first page of the thread so it should be safe.

There may be other edge cases were it fails and gets stuck in the while loop _(could not think of any)_ and so it needs testing.