### PR TITLE
Expand cache filter definition

### DIFF
--- a/cyberdrop_dl/managers/cache_manager.py
+++ b/cyberdrop_dl/managers/cache_manager.py
@@ -4,6 +4,7 @@ from dataclasses import field
 from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING
 from aiohttp_client_cache import SQLiteBackend
+from http import HTTPStatus
 from datetime import timedelta
 from cyberdrop_dl.utils.dataclasses.supported_domains import SupportedDomains
 
@@ -58,7 +59,7 @@ class CacheManager:
         self.request_cache = SQLiteBackend(
             cache_name=self.manager.path_manager.cache_db, 
             autoclose=False, 
-            allowed_codes=(200, 404), 
+            allowed_codes=(HTTPStatus.OK, HTTPStatus.NOT_FOUND),
             allowed_methods=['GET'], 
             expire_after=timedelta(days=7),
             urls_expire_after=urls_expire_after

--- a/cyberdrop_dl/managers/cache_manager.py
+++ b/cyberdrop_dl/managers/cache_manager.py
@@ -59,7 +59,11 @@ class CacheManager:
         self.request_cache = SQLiteBackend(
             cache_name=self.manager.path_manager.cache_db, 
             autoclose=False, 
-            allowed_codes=(HTTPStatus.OK, HTTPStatus.NOT_FOUND),
+            allowed_codes=(
+                HTTPStatus.OK, 
+                HTTPStatus.NOT_FOUND, 
+                HTTPStatus.GONE, 
+                HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS),
             allowed_methods=['GET'], 
             expire_after=timedelta(days=7),
             urls_expire_after=urls_expire_after


### PR DESCRIPTION
1. Add `410 (Gone)` and `451 (Unavailable For Legal Reasons`) to cached responses
2. Add cache to `download_client` requests, excluding successful ones to not save file payloads in the database