### PR TITLE
feat: add option to skip any referer scraped before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+This update introduces the following changes:
+1. Skip file download by referer
+
+#### Details:
+
+- Using the flag `--skip-referer-seen-before` will skip downloading files from any referer that have been scraped before. The file (s) will always be skipped regardless of whether the referer was successfully scraped or not
+
 ## [5.6.43] - 2024-10-03
 
 This update introduces the following changes:

--- a/cyberdrop_dl/managers/db_manager.py
+++ b/cyberdrop_dl/managers/db_manager.py
@@ -7,6 +7,7 @@ import aiosqlite
 from cyberdrop_dl.utils.database.tables.hash_table import HashTable
 from cyberdrop_dl.utils.database.tables.history_table import HistoryTable
 from cyberdrop_dl.utils.database.tables.temp_table import TempTable
+from cyberdrop_dl.utils.database.tables.temp_referer_table import TempRefererTable
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -23,6 +24,7 @@ class DBManager:
         self.history_table: HistoryTable = field(init=False)
         self.hash_table: HashTable = field(init=False)
         self.temp_table: TempTable = field(init=False)
+        self.temp_referer_table: TempRefererTable = field(init=False)
 
     async def startup(self) -> None:
         """Startup process for the DBManager"""
@@ -33,6 +35,7 @@ class DBManager:
         self.history_table = HistoryTable(self._db_conn)
         self.hash_table = HashTable(self._db_conn)
         self.temp_table = TempTable(self._db_conn)
+        self.temp_referer_table = TempRefererTable(self._db_conn)
 
         self.history_table.ignore_history = self.ignore_history
 
@@ -41,9 +44,11 @@ class DBManager:
         await self.history_table.startup()
         await self.hash_table.startup()
         await self.temp_table.startup()
+        await self.temp_referer_table.startup()
 
     async def close(self) -> None:
         """Close the DBManager"""
+        await self.temp_referer_table.sql_drop_temp_referers()
         await self._db_conn.close()
 
     async def _pre_allocate(self) -> None:

--- a/cyberdrop_dl/managers/db_manager.py
+++ b/cyberdrop_dl/managers/db_manager.py
@@ -38,6 +38,7 @@ class DBManager:
         self.temp_referer_table = TempRefererTable(self._db_conn)
 
         self.history_table.ignore_history = self.ignore_history
+        self.temp_referer_table.ignore_history = self.ignore_history
 
         await self._pre_allocate()
 

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -89,7 +89,7 @@ class Crawler(ABC):
         
         check_referer = False
         if self.manager.config_manager.settings_data['Download_Options']['skip_referer_seen_before']:
-            check_referer = await self.manager.db_manager.history_table.check_referer(self.domain, url, scrape_item.url)
+            check_referer = await self.manager.db_manager.history_table.check_referer(scrape_item.url)
 
         if check_referer:
             await log(f"Skipping {url} as referer has been seen before", 10)

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -86,6 +86,15 @@ class Crawler(ABC):
             await log(f"Skipping {url} as it has already been downloaded", 10)
             await self.manager.progress_manager.download_progress.add_previously_completed()
             return
+        
+        check_referer = False
+        if self.manager.config_manager.settings_data['Download_Options']['skip_referer_seen_before']:
+            check_referer = await self.manager.db_manager.history_table.check_referer(self.domain, url, scrape_item.url)
+
+        if check_referer:
+            await log(f"Skipping {url} as referer has been seen before", 10)
+            await self.manager.progress_manager.download_progress.add_skipped()
+            return
 
         if await self.manager.download_manager.get_download_limit(self.domain) == 1:
             await self.downloader.run(media_item)

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -89,7 +89,7 @@ class Crawler(ABC):
         
         check_referer = False
         if self.manager.config_manager.settings_data['Download_Options']['skip_referer_seen_before']:
-            check_referer = await self.manager.db_manager.history_table.check_referer(scrape_item.url)
+            check_referer = await self.manager.db_manager.temp_referer_table.check_referer(scrape_item.url)
 
         if check_referer:
             await log(f"Skipping {url} as referer has been seen before", 10)

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -449,6 +449,16 @@ class ScrapeMapper:
                 await log(f"Skipping {scrape_item.url} as it has already been downloaded", 10)
                 await self.manager.progress_manager.download_progress.add_previously_completed()
                 return
+
+            check_referer = False
+            if self.manager.config_manager.settings_data['Download_Options']['skip_referer_seen_before']:
+                check_referer = await self.manager.db_manager.history_table.check_referer(self.domain, url, scrape_item.url)
+
+            if check_referer:
+                await log(f"Skipping {url} as referer has been seen before", 10)
+                await self.manager.progress_manager.download_progress.add_skipped()
+                return
+
             await scrape_item.add_to_parent_title("Loose Files")
             scrape_item.part_of_album = True
             download_folder = await get_download_path(self.manager, scrape_item, "no_crawler")

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -428,7 +428,7 @@ class ScrapeMapper:
         scrape_item.created_at = created_at
         return scrape_item
 
-    async def add_item_to_group(self, scrape_item):
+    async def add_item_to_group(self, scrape_item: ScrapeItem):
         if str(scrape_item.url).endswith("/"):
             if scrape_item.url.query_string:
                 query = scrape_item.url.query_string[:-1]
@@ -450,14 +450,16 @@ class ScrapeMapper:
                 await self.manager.progress_manager.download_progress.add_previously_completed()
                 return
 
-            check_referer = False
-            if self.manager.config_manager.settings_data['Download_Options']['skip_referer_seen_before']:
-                check_referer = await self.manager.db_manager.history_table.check_referer(self.domain, url, scrape_item.url)
+            if scrape_item.parents:
+                posible_referer = scrape_item.parents[-1]
+                check_referer = False
+                if self.manager.config_manager.settings_data['Download_Options']['skip_referer_seen_before']:
+                    check_referer = await self.manager.db_manager.history_table.check_referer(posible_referer)
 
-            if check_referer:
-                await log(f"Skipping {url} as referer has been seen before", 10)
-                await self.manager.progress_manager.download_progress.add_skipped()
-                return
+                if check_referer:
+                    await log(f"Skipping {scrape_item.url} as referer has been seen before", 10)
+                    await self.manager.progress_manager.download_progress.add_skipped()
+                    return
 
             await scrape_item.add_to_parent_title("Loose Files")
             scrape_item.part_of_album = True

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -454,7 +454,7 @@ class ScrapeMapper:
                 posible_referer = scrape_item.parents[-1]
                 check_referer = False
                 if self.manager.config_manager.settings_data['Download_Options']['skip_referer_seen_before']:
-                    check_referer = await self.manager.db_manager.history_table.check_referer(posible_referer)
+                    check_referer = await self.manager.db_manager.temp_referer_table.check_referer(posible_referer)
 
                 if check_referer:
                     await log(f"Skipping {scrape_item.url} as referer has been seen before", 10)

--- a/cyberdrop_dl/utils/args/args.py
+++ b/cyberdrop_dl/utils/args/args.py
@@ -75,6 +75,8 @@ def parse_args() -> argparse.Namespace:
                                 help="separate posts into folders")
     download_options.add_argument("--skip-download-mark-completed", action=argparse.BooleanOptionalAction,
                                 help="skip download and mark as completed in history")
+    download_options.add_argument("--skip-referer-seen-before", action="store_true",
+                                  help="skip download if referer has been seen before", default=False)
 
     file_size_limits = parser.add_argument_group("File_Size_Limits")
     file_size_limits.add_argument("--maximum-image-size", type=int,

--- a/cyberdrop_dl/utils/args/args.py
+++ b/cyberdrop_dl/utils/args/args.py
@@ -75,8 +75,8 @@ def parse_args() -> argparse.Namespace:
                                 help="separate posts into folders")
     download_options.add_argument("--skip-download-mark-completed", action=argparse.BooleanOptionalAction,
                                 help="skip download and mark as completed in history")
-    download_options.add_argument("--skip-referer-seen-before", action="store_true",
-                                  help="skip download if referer has been seen before", default=False)
+    download_options.add_argument("--skip-referer-seen-before", action=argparse.BooleanOptionalAction,
+                                  help="skip download if referer has been seen before")
 
     file_size_limits = parser.add_argument_group("File_Size_Limits")
     file_size_limits.add_argument("--maximum-image-size", type=int,

--- a/cyberdrop_dl/utils/args/config_definitions.py
+++ b/cyberdrop_dl/utils/args/config_definitions.py
@@ -60,6 +60,7 @@ settings: Dict = {
         "scrape_single_forum_post": False,
         "separate_posts": False,
         "skip_download_mark_completed": False,
+        "skip_referer_seen_before": False,
     },
     "Files": {
         "input_file": str(APP_STORAGE / "Configs" / "{config}" / "URLs.txt"),

--- a/cyberdrop_dl/utils/database/table_definitions.py
+++ b/cyberdrop_dl/utils/database/table_definitions.py
@@ -25,6 +25,8 @@ create_fixed_history = """CREATE TABLE IF NOT EXISTS media_copy (domain TEXT,
 
 create_temp = """CREATE TABLE IF NOT EXISTS temp (downloaded_filename TEXT);"""
 
+create_temp_referer = """CREATE TABLE IF NOT EXISTS temp_referer (referer TEXT);"""
+
 create_hash = """
 CREATE TABLE IF NOT EXISTS hash (
   folder TEXT,

--- a/cyberdrop_dl/utils/database/tables/history_table.py
+++ b/cyberdrop_dl/utils/database/tables/history_table.py
@@ -68,19 +68,6 @@ class HistoryTable:
                 await self.db_conn.commit()
             return True
         return False
-    
-    async def check_referer(self, referer: URL) -> bool:
-        """Checks whether an individual referer url has already been recorded in the database"""
-        if self.ignore_history:
-            return False
-
-        cursor = await self.db_conn.cursor()
-        result = await cursor.execute("""SELECT url_path FROM media WHERE referer = ? """,
-                                      (referer))
-        sql_referer_check = await result.fetchone()
-        if sql_referer_check:
-            return True
-        return False
 
     async def check_album(self, domain: str, album_id: str) -> bool | dict[Any, Any]:
         """Checks whether an album has completed given its domain and album id"""

--- a/cyberdrop_dl/utils/database/tables/history_table.py
+++ b/cyberdrop_dl/utils/database/tables/history_table.py
@@ -68,6 +68,19 @@ class HistoryTable:
                 await self.db_conn.commit()
             return True
         return False
+    
+    async def check_referer(self, referer: URL) -> bool:
+        """Checks whether an individual referer url has already been recorded in the database"""
+        if self.ignore_history:
+            return False
+
+        cursor = await self.db_conn.cursor()
+        result = await cursor.execute("""SELECT url_path FROM media WHERE referer = ? """,
+                                      (referer))
+        sql_referer_check = await result.fetchone()
+        if sql_referer_check:
+            return True
+        return False
 
     async def check_album(self, domain: str, album_id: str) -> bool | dict[Any, Any]:
         """Checks whether an album has completed given its domain and album id"""

--- a/cyberdrop_dl/utils/database/tables/temp_referer_table.py
+++ b/cyberdrop_dl/utils/database/tables/temp_referer_table.py
@@ -1,13 +1,14 @@
 from typing import List
 
 import aiosqlite
-
+from yarl import URL
 from cyberdrop_dl.utils.database.table_definitions import create_temp_referer
 
 
 class TempRefererTable:
     def __init__(self, db_conn: aiosqlite.Connection):
         self.db_conn: aiosqlite.Connection = db_conn
+        self.ignore_history: bool = False
 
     async def startup(self) -> None:
         """Startup process for the TempRefererTable"""
@@ -36,3 +37,36 @@ class TempRefererTable:
         """Delete temp_referers table"""
         await self.db_conn.execute("""DROP TABLE temp_referer;""")
         await self.db_conn.commit()
+
+    async def check_referer(self, referer: URL) -> bool:
+        """Checks whether an individual referer url has already been recorded in the database"""
+        if self.ignore_history:
+            return False
+        
+        referer = str(referer)
+
+        cursor = await self.db_conn.cursor()
+        result = await cursor.execute("""SELECT url_path FROM media WHERE referer = ? """,
+                                      (referer,))
+        sql_referer_check = await result.fetchone()
+        sql_referer_check_current_run = await self._check_temp_referer(referer)
+        if not sql_referer_check:
+            await self.sql_insert_temp_referer(referer)
+            return False
+        elif sql_referer_check_current_run:
+            return False
+        return True
+    
+    async def _check_temp_referer(self, referer: URL) -> bool:
+        """Checks whether an individual referer url has already been recorded in this session"""
+        if self.ignore_history:
+            return False
+
+        referer = str(referer)
+        cursor = await self.db_conn.cursor()
+        result = await cursor.execute("""SELECT referer FROM temp_referer WHERE referer = ? """,
+                                      (referer,))
+        sql_referer_check = await result.fetchone()
+        if sql_referer_check:
+            return True
+        return False

--- a/cyberdrop_dl/utils/database/tables/temp_referer_table.py
+++ b/cyberdrop_dl/utils/database/tables/temp_referer_table.py
@@ -1,0 +1,38 @@
+from typing import List
+
+import aiosqlite
+
+from cyberdrop_dl.utils.database.table_definitions import create_temp_referer
+
+
+class TempRefererTable:
+    def __init__(self, db_conn: aiosqlite.Connection):
+        self.db_conn: aiosqlite.Connection = db_conn
+
+    async def startup(self) -> None:
+        """Startup process for the TempRefererTable"""
+        await self.db_conn.execute(create_temp_referer)
+        await self.db_conn.commit()
+
+    async def get_temp_referers(self) -> List[str]:
+        """Gets the list of temp referers"""
+        cursor = await self.db_conn.cursor()
+        await cursor.execute("SELECT referer FROM temp_referer;")
+        referers = await cursor.fetchall()
+        referers = [list(referer) for referer in referers]
+        return list(sum(referers, ()))
+
+    async def sql_insert_temp_referer(self, referer: str) -> None:
+        """Inserts a temp referer into the temp_referers table"""
+        await self.db_conn.execute("""INSERT OR IGNORE INTO temp_referer VALUES (?)""", (referer,))
+        await self.db_conn.commit()
+
+    async def sql_purge_temp_referers(self) -> None:
+        """Delete all records in temp_referers table"""
+        await self.db_conn.execute("""DELETE FROM temp_referer;""")
+        await self.db_conn.commit()
+
+    async def sql_drop_temp_referers(self) -> None:
+        """Delete temp_referers table"""
+        await self.db_conn.execute("""DROP TABLE temp_referer;""")
+        await self.db_conn.commit()

--- a/docs/reference/cli-arguments.md
+++ b/docs/reference/cli-arguments.md
@@ -46,6 +46,7 @@ For items within Download Options, Ignore Options, Runtime Options, and Sorting 
 --scrape-single-forum-post
 --separate-posts
 --skip-download-mark-completed
+--skip-referer-seen-before
 
 // File Size Limits
 --maximum-image-size <number>

--- a/docs/reference/configuration-options/settings.md
+++ b/docs/reference/configuration-options/settings.md
@@ -85,7 +85,7 @@ Setting this to true (or selecting it) will skip downloading files and mark them
 
 * skip\_referer\_seen\_before
 
-Setting this to true (or selecting it) will skip downloading files from any referer that have been scraped before.
+Setting this to true (or selecting it) will skip downloading files from any referer that have been scraped before. The file (s) will always be skipped regardless of whether the referer was successfully scraped or not
 
 </details>
 

--- a/docs/reference/configuration-options/settings.md
+++ b/docs/reference/configuration-options/settings.md
@@ -81,6 +81,12 @@ Setting this to true (or selecting it) will separate content from forum posts in
 
 Setting this to true (or selecting it) will skip downloading files and mark them as downloaded in the database.
 
+***
+
+* skip\_referer\_seen\_before
+
+Setting this to true (or selecting it) will skip downloading files from any referer that have been scraped before.
+
 </details>
 
 <details>


### PR DESCRIPTION
CDL will not download a file if the referer has already been scraped before.

CLI flag: `--skip-referer-seen-before`

The file (s) will always be skipped regardless of whether the referer was successfully scraped or not.

I was initially trying to implement `--skip-album-seen-before` but almost none of the crawlers were saving the `album_id` to the database. 

> [!NOTE]  
> This PR introduces a change to `cyberdrop.db`, creating a new table to store new referers found since the last run.