### PR TITLE
feat: add support to limit the max number children while scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+This update introduces the following changes:
+1. Adds the option to limit how many items are scraped 
+
+#### Details:
+
+- Users can limit the number of items to scrape by type, using the `--maximum-number-of-children` parameter.
+
+For more details on how to use this feature, visit the wiki: https://script-ware.gitbook.io/cyberdrop-dl/reference/configuration-options/settings#download-options
+
 ## [5.6.50] - 2024-10-07
 
 This update introduces the following changes:

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -27,6 +27,14 @@ class PasswordProtected(Exception):
         self.scrape_item = scrape_item
         super().__init__(self.message)
 
+class ScrapeItemMaxChildrenReached(Exception):
+    """This error will be thrown when an scrape item reaches its max number or children"""
+
+    def __init__(self,/, scrape_item: 'ScrapeItem'):
+        self.message = "Max number of children reached"
+        self.scrape_item = scrape_item
+        super().__init__(self.message)
+
 
 class DDOSGuardFailure(Exception):
     """This error will be thrown when DDoS-Guard is detected"""

--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -7,8 +7,10 @@ from bs4 import Tag
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FORUM, FORUM_POST
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
+
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -75,6 +77,14 @@ class CelebForumCrawler(Crawler):
 
         thread_url = scrape_item.url
         post_number = 0
+        scrape_item.type = FORUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         if len(scrape_item.url.parts) > 3:
             if "post-" in str(scrape_item.url.parts[3]) or "post-" in scrape_item.url.fragment:
                 url_parts = str(scrape_item.url).rsplit("post-", 1)
@@ -109,6 +119,11 @@ class CelebForumCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
+
                 if not continue_scraping:
                     break
 
@@ -122,6 +137,7 @@ class CelebForumCrawler(Crawler):
                     continue
             else:
                 break
+
         post_string = f"post-{current_post_number}"
         if "page-" in scrape_item.url.raw_name or "post-" in scrape_item.url.raw_name:
             last_post_url = scrape_item.url.parent / post_string
@@ -136,16 +152,27 @@ class CelebForumCrawler(Crawler):
             scrape_item = await self.create_scrape_item(scrape_item, scrape_item.url, "")
             await scrape_item.add_to_parent_title("post-" + str(post_number))
 
-        await self.links(scrape_item, post_content)
-        await self.images(scrape_item, post_content)
-        await self.videos(scrape_item, post_content)
-        await self.embeds(scrape_item, post_content)
-        await self.attachments(scrape_item, post_content)
+        scrape_item.type = FORUM_POST
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
+        posts_scrapers = [self.links, self.images, self.videos, self.embeds, self.attachments]
+
+        for scraper in posts_scrapers:
+            scrape_item.children += await scraper(scrape_item, post_content)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
-    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
+        new_children = 0
         for link_obj in links:
             link = link_obj.get(self.links_attribute)
             if not link:
@@ -173,11 +200,17 @@ class CelebForumCrawler(Crawler):
                     continue
             except TypeError:
                 await log(f"Scrape Failed: encountered while handling {link}", 40)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
-    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
+        new_children = 0
         for image in images:
             link = image.get(self.images_attribute)
             if not link:
@@ -204,14 +237,18 @@ class CelebForumCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
-    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
-
+        new_children = 0
         for video in videos:
             link = video.get(self.videos_attribute)
             if not link:
@@ -226,11 +263,17 @@ class CelebForumCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
+        new_children = 0
         for embed in embeds:
             link = embed.get(self.embeds_attribute)
             if not link:
@@ -241,6 +284,11 @@ class CelebForumCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
@@ -248,7 +296,7 @@ class CelebForumCrawler(Crawler):
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:
             return
-
+        new_children = 0
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)
@@ -271,7 +319,11 @@ class CelebForumCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -119,10 +119,10 @@ class CelebForumCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
-                scrape_item.children += 1
-                if scrape_item.children_limit:
-                    if scrape_item.children >= scrape_item.children_limit:
-                        raise ScrapeItemMaxChildrenReached(scrape_item)
+                    scrape_item.children += 1
+                    if scrape_item.children_limit:
+                        if scrape_item.children >= scrape_item.children_limit:
+                            raise ScrapeItemMaxChildrenReached(scrape_item)
 
                 if not continue_scraping:
                     break
@@ -294,9 +294,10 @@ class CelebForumCrawler(Crawler):
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
-        if not attachment_block:
-            return
         new_children = 0
+        if not attachment_block:
+            return new_children
+        
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)

--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -270,7 +270,7 @@ class CelebForumCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
         new_children = 0
@@ -291,7 +291,7 @@ class CelebForumCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -8,8 +8,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_PROFILE, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -50,6 +51,14 @@ class CoomerCrawler(Crawler):
         service, user = await self.get_service_and_user(scrape_item)
         user_str = await self.get_user_str_from_profile(scrape_item)
         api_call = self.api_url / service / "user" / user
+        scrape_item.type = FILE_HOST_PROFILE
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         while True:
             async with self.request_limiter:
                 JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}))
@@ -59,6 +68,10 @@ class CoomerCrawler(Crawler):
 
             for post in JSON_Resp:
                 await self.handle_post_content(scrape_item, post, user, user_str)
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def post(self, scrape_item: ScrapeItem) -> None:
@@ -77,6 +90,14 @@ class CoomerCrawler(Crawler):
             'ignore_coomer_ads']:
             return
 
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         date = post["published"].replace("T", " ")
         post_id = post["id"]
         post_title = post["title"]
@@ -88,11 +109,16 @@ class CoomerCrawler(Crawler):
             link = link.with_query({"f": file_obj['name']})
             await self.create_new_scrape_item(link, scrape_item, user_str, post_title, post_id, date, add_parent = scrape_item.url.joinpath("post", post_id))
 
+        files = []
         if post['file']:
-            await handle_file(post['file'])
+            files.append(post['file'])
 
-        for file in post['attachments']:
+        for file in files.extend(post['attachments']):
             await handle_file(file)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def handle_direct_link(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
@@ -8,8 +8,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -41,6 +42,13 @@ class CyberdropCrawler(Crawler):
         """Scrapes an album"""
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         title = await self.create_title(soup.select_one("h1[id=title]").text, scrape_item.url.parts[2], None)
         date = await self.parse_datetime(soup.select("p[class=title]")[-1].text)
@@ -54,6 +62,10 @@ class CyberdropCrawler(Crawler):
 
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/ehentai_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/ehentai_crawler.py
@@ -8,8 +8,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -47,12 +48,23 @@ class EHentaiCrawler(Crawler):
 
         title = await self.create_title(soup.select_one("h1[id=gn]").get_text(), None, None)
         date = await self.parse_datetime(soup.select_one("td[class=gdt2]").get_text())
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         images = soup.select("div[class=gdtm] div a")
         for image in images:
             link = URL(image.get('href'))
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
         next_page_opts = soup.select('td[onclick="document.location=this.firstChild.href"]')
         next_page = None

--- a/cyberdrop_dl/scraper/crawlers/erome_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/erome_crawler.py
@@ -35,14 +35,14 @@ class EromeCrawler(Crawler):
     @error_handling_wrapper
     async def profile(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a profile"""
-        self.type = FILE_HOST_PROFILE
-        scrape_item.children = scrape_item.children_limit = 0
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
 
         title = await self.create_title(scrape_item.url.name, None, None)
         albums = soup.select('a[class=album-link]')
-        scrape_item.type = FILE_HOST_PROFILE
+
+        self.type = FILE_HOST_PROFILE
+        scrape_item.children = scrape_item.children_limit = 0
 
         try:
             scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]

--- a/cyberdrop_dl/scraper/crawlers/erome_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/erome_crawler.py
@@ -41,7 +41,7 @@ class EromeCrawler(Crawler):
         title = await self.create_title(scrape_item.url.name, None, None)
         albums = soup.select('a[class=album-link]')
 
-        self.type = FILE_HOST_PROFILE
+        scrape_item.type = FILE_HOST_PROFILE
         scrape_item.children = scrape_item.children_limit = 0
 
         try:

--- a/cyberdrop_dl/scraper/crawlers/erome_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/erome_crawler.py
@@ -6,8 +6,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
-from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_PROFILE, FILE_HOST_ALBUM
+from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -34,16 +35,28 @@ class EromeCrawler(Crawler):
     @error_handling_wrapper
     async def profile(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a profile"""
+        self.type = FILE_HOST_PROFILE
+        scrape_item.children = scrape_item.children_limit = 0
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
 
         title = await self.create_title(scrape_item.url.name, None, None)
         albums = soup.select('a[class=album-link]')
+        scrape_item.type = FILE_HOST_PROFILE
+
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         for album in albums:
             link = URL(album['href'])
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
         next_page = soup.select_one('a[rel="next"]')
         if next_page:
@@ -57,6 +70,13 @@ class EromeCrawler(Crawler):
         """Scrapes an album"""
         album_id = scrape_item.url.parts[2]
         results = await self.get_album_results(album_id)
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
@@ -68,16 +88,16 @@ class EromeCrawler(Crawler):
         await scrape_item.add_to_parent_title(title)
 
         images = soup.select('img[class="img-front lasyload"]')
-        vidoes = soup.select('div[class=media-group] div[class=video-lg] video source')
+        videos = soup.select('div[class=media-group] div[class=video-lg] video source')
 
-        for image in images:
-            link = URL(image['data-src'])
+        image_links = [URL(image['data-src']) for image in images]
+        video_links = [URL(video['src']) for video in videos]
+
+        for link in image_links + video_links:
             filename, ext = await get_filename_and_ext(link.name)
             if not await self.check_album_results(link, results):
                 await self.handle_file(link, scrape_item, filename, ext)
-
-        for video in vidoes:
-            link = URL(video['src'])
-            filename, ext = await get_filename_and_ext(link.name)
-            if not await self.check_album_results(link, results):
-                await self.handle_file(link, scrape_item, filename, ext)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -167,7 +167,7 @@ class F95ZoneCrawler(Crawler):
                     raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
-    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
         new_children = 0
@@ -209,7 +209,7 @@ class F95ZoneCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
         new_children = 0
@@ -246,7 +246,7 @@ class F95ZoneCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
@@ -272,7 +272,7 @@ class F95ZoneCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
         new_children = 0
@@ -293,7 +293,7 @@ class F95ZoneCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -118,10 +118,10 @@ class F95ZoneCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
-                scrape_item.children += 1
-                if scrape_item.children_limit:
-                    if scrape_item.children >= scrape_item.children_limit:
-                        raise ScrapeItemMaxChildrenReached(scrape_item)
+                    scrape_item.children += 1
+                    if scrape_item.children_limit:
+                        if scrape_item.children >= scrape_item.children_limit:
+                            raise ScrapeItemMaxChildrenReached(scrape_item)
 
                 if not continue_scraping:
                     break
@@ -296,9 +296,10 @@ class F95ZoneCrawler(Crawler):
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
-        if not attachment_block:
-            return
         new_children = 0
+        if not attachment_block:
+            return new_children
+       
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -7,8 +7,9 @@ from bs4 import Tag
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FORUM, FORUM_POST
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -75,6 +76,14 @@ class F95ZoneCrawler(Crawler):
 
         thread_url = scrape_item.url
         post_number = 0
+        scrape_item.type = FORUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         if len(scrape_item.url.parts) > 3:
             if "post-" in str(scrape_item.url.parts[3]) or "post-" in scrape_item.url.fragment:
                 url_parts = str(scrape_item.url).rsplit("post-", 1)
@@ -109,6 +118,11 @@ class F95ZoneCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
+
                 if not continue_scraping:
                     break
 
@@ -136,16 +150,27 @@ class F95ZoneCrawler(Crawler):
             scrape_item = await self.create_scrape_item(scrape_item, scrape_item.url, "")
             await scrape_item.add_to_parent_title("post-" + str(post_number))
 
-        await self.links(scrape_item, post_content)
-        await self.images(scrape_item, post_content)
-        await self.videos(scrape_item, post_content)
-        await self.embeds(scrape_item, post_content)
-        await self.attachments(scrape_item, post_content)
+        scrape_item.type = FORUM_POST
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
+        posts_scrapers = [self.links, self.images, self.videos, self.embeds, self.attachments]
+
+        for scraper in posts_scrapers:
+            scrape_item.children += await scraper(scrape_item, post_content)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
+        new_children = 0
         for link_obj in links:
             link = link_obj.get(self.links_attribute)
             if not link:
@@ -175,14 +200,19 @@ class F95ZoneCrawler(Crawler):
                     await self.handle_internal_links(link, scrape_item)
                 else:
                     await log(f"Unknown link type: {link}", 30)
-                    continue
             except TypeError:
                 await log(f"Scrape Failed: encountered while handling {link}", 40)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
+        new_children = 0
         for image in images:
             link = image.get(self.images_attribute)
             if not link:
@@ -209,14 +239,18 @@ class F95ZoneCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
-
+        new_children = 0
         for video in videos:
             link = video.get(self.videos_attribute)
             if not link:
@@ -231,11 +265,17 @@ class F95ZoneCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
+        new_children = 0
         for embed in embeds:
             link = embed.get(self.embeds_attribute)
             if not link:
@@ -246,6 +286,11 @@ class F95ZoneCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
@@ -253,7 +298,7 @@ class F95ZoneCrawler(Crawler):
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:
             return
-
+        new_children = 0
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)
@@ -276,7 +321,11 @@ class F95ZoneCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
@@ -6,8 +6,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_PROFILE, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -41,6 +42,13 @@ class FapelloCrawler(Crawler):
             soup, response_url = await self.client.get_BS4_and_return_URL(self.domain, scrape_item.url)
             if response_url != scrape_item.url:
                 return
+            
+        scrape_item.type = FILE_HOST_PROFILE
+
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         title = await self.create_title(
             soup.select_one('h2[class="font-semibold lg:text-2xl text-lg mb-2 mt-4"]').get_text(), None, None)
@@ -56,6 +64,9 @@ class FapelloCrawler(Crawler):
                 link = URL(post.get('href'))
                 new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 await self.handle_external_links(new_scrape_item)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
         next_page = soup.select_one('div[id="next_page"] a')
         if next_page:
@@ -73,8 +84,22 @@ class FapelloCrawler(Crawler):
         content = soup.select_one('div[class="flex justify-between items-center"]')
         content_tags = content.select("img")
         content_tags.extend(content.select("source"))
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
+        async with self.request_limiter:
+            soup = await self.client.get_BS4(self.domain, scrape_item.url)
 
         for selection in content_tags:
             link = URL(selection.get('src'))
             filename, ext = await get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)

--- a/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
@@ -6,8 +6,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -44,12 +45,23 @@ class HotPicCrawler(Crawler):
         title = await self.create_title(soup.select_one("title").text.rsplit(" - ")[0], scrape_item.url.parts[2], None)
         await scrape_item.add_to_parent_title(title)
         scrape_item.part_of_album = True
+        self.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         files = soup.select("a[class*=spotlight]")
         for file in files:
             link = URL(file.get("href"))
             filename, ext = await get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def image(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
@@ -45,7 +45,7 @@ class HotPicCrawler(Crawler):
         title = await self.create_title(soup.select_one("title").text.rsplit(" - ")[0], scrape_item.url.parts[2], None)
         await scrape_item.add_to_parent_title(title)
         scrape_item.part_of_album = True
-        self.type = FILE_HOST_ALBUM
+        scrape_item.type = FILE_HOST_ALBUM
         scrape_item.children = scrape_item.children_limit = 0
 
         try:

--- a/cyberdrop_dl/scraper/crawlers/imageban_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imageban_crawler.py
@@ -8,8 +8,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -47,6 +48,14 @@ class ImageBanCrawler(Crawler):
                                         scrape_item.url.parts[2], None)
         content_block = soup.select_one('div[class="row text-center"]')
         images = content_block.select("a")
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
 
         for image in images:
             link_path = image.get("href")
@@ -61,6 +70,10 @@ class ImageBanCrawler(Crawler):
 
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
         next_page = soup.select_one('a[class*="page-link next"]')
         if next_page:
@@ -82,6 +95,13 @@ class ImageBanCrawler(Crawler):
         await scrape_item.add_to_parent_title(title)
         content_block = soup.select("div[class=container-fluid]")[-1]
         images = content_block.select("img")
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         for image in images:
             link = URL(image.get("src"))
@@ -89,6 +109,10 @@ class ImageBanCrawler(Crawler):
             scrape_item.possible_datetime = date
             filename, ext = await get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def image(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/imgbb_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgbb_crawler.py
@@ -9,8 +9,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -46,6 +47,14 @@ class ImgBBCrawler(Crawler):
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url / "sub")
 
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         title = await self.create_title(soup.select_one("a[data-text=album-name]").get_text(), scrape_item.url.parts[2],
                                         None)
         albums = soup.select("a[class='image-container --media']")
@@ -66,6 +75,11 @@ class ImgBBCrawler(Crawler):
                 link = URL(link.get('href'))
                 new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
+
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
             link_next = soup.select_one('a[data-pagination=next]')
             if link_next is not None:

--- a/cyberdrop_dl/scraper/crawlers/imgkiwi_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgkiwi_crawler.py
@@ -9,8 +9,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -41,6 +42,14 @@ class ImgKiwiCrawler(Crawler):
         """Scrapes an album"""
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
+        
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         title = await self.create_title(soup.select_one("a[data-text=album-name]").get_text(), scrape_item.url.parts[2],
                                         None)
@@ -54,6 +63,11 @@ class ImgKiwiCrawler(Crawler):
                 link = URL(link.get('href'))
                 new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 self.manager.task_group.create_task(self.run(new_scrape_item))
+
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
             link_next = soup.select_one('a[data-pagination=next]')
             if link_next is not None:

--- a/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
@@ -7,8 +7,9 @@ from yarl import URL
 
 from cyberdrop_dl.clients.errors import ScrapeFailure, FailedLoginFailure
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, log, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -45,6 +46,13 @@ class ImgurCrawler(Crawler):
             await log("To scrape imgur content, you need to provide a client id", 30)
             raise FailedLoginFailure(status=401, message="No Imgur Client ID provided")
         await self.check_imgur_credits()
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         album_id = scrape_item.url.parts[-1]
 
@@ -63,6 +71,10 @@ class ImgurCrawler(Crawler):
             date = image["datetime"]
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, date, add_parent = scrape_item.url)
             await self.handle_direct(new_scrape_item)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def image(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/jpgchurch_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/jpgchurch_crawler.py
@@ -9,8 +9,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -78,6 +79,14 @@ class JPGChurchCrawler(Crawler):
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url / "sub")
 
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         title = await self.create_title(soup.select_one("a[data-text=album-name]").get_text(), scrape_item.url.parts[2],
                                         None)
         albums = soup.select("a[class='image-container --media']")
@@ -99,6 +108,11 @@ class JPGChurchCrawler(Crawler):
                 new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, album_id, add_parent = scrape_item.url)
                 if not await self.check_album_results(link, results):
                     await self.handle_direct_link(new_scrape_item)
+
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
             link_next = soup.select_one('a[data-pagination=next]')
             if link_next is not None:

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -10,8 +10,9 @@ from yarl import URL
 
 from cyberdrop_dl.clients.errors import NoExtensionFailure
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_PROFILE, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -54,6 +55,13 @@ class KemonoCrawler(Crawler):
         service, user = await self.get_service_and_user(scrape_item)
         user_str = await self.get_user_str_from_profile(scrape_item)
         api_call = self.api_url / service / "user" / user
+        scrape_item.type = FILE_HOST_PROFILE
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
         while True:
             async with self.request_limiter:
                 JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}))
@@ -63,6 +71,10 @@ class KemonoCrawler(Crawler):
 
             for post in JSON_Resp:
                 await self.handle_post_content(scrape_item, post, user, user_str)
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def discord(self, scrape_item: ScrapeItem) -> None:
@@ -70,6 +82,13 @@ class KemonoCrawler(Crawler):
         offset = 0
         channel = scrape_item.url.raw_fragment
         api_call = self.api_url / "discord/channel" / channel
+        scrape_item.type = FILE_HOST_PROFILE
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
         while True:
             async with self.request_limiter:
                 JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}))
@@ -79,6 +98,10 @@ class KemonoCrawler(Crawler):
 
             for post in JSON_Resp:
                 await self.handle_post_content(scrape_item, post, channel, channel)
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def post(self, scrape_item: ScrapeItem) -> None:
@@ -93,28 +116,44 @@ class KemonoCrawler(Crawler):
     @error_handling_wrapper
     async def handle_post_content(self, scrape_item: ScrapeItem, post: Dict, user: str, user_str: str) -> None:
         """Handles the content of a post"""
+
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         date = post["published"].replace("T", " ")
         post_id = post["id"]
         post_title = post.get("title", "")
 
-        await self.get_content_links(scrape_item, post, user_str)
+        scrape_item.children += await self.get_content_links(scrape_item, post, user_str)
 
         async def handle_file(file_obj):
             link = self.primary_base_domain / ("data" + file_obj['path'])
             link = link.with_query({"f": file_obj['name']})
             await self.create_new_scrape_item(link, scrape_item, user_str, post_title, post_id, date)
 
-        if post.get('file'):
-            await handle_file(post['file'])
+        files = []
+        if post['file']:
+            files.append(post['file'])
 
-        for file in post['attachments']:
+        for file in files.extend(post['attachments']):
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
             await handle_file(file)
+            scrape_item.children += 1
 
     async def get_content_links(self, scrape_item: ScrapeItem, post: Dict, user: str) -> None:
         """Gets links out of content in post"""
         content = post.get("content", "")
         if not content:
             return
+        
+        new_children = 0
 
         date = post["published"].replace("T", " ")
         post_id = post["id"]
@@ -143,6 +182,11 @@ class KemonoCrawler(Crawler):
                 continue
             scrape_item = await self.create_scrape_item(scrape_item, link, "", add_parent = scrape_item.url.joinpath("post",post_id))
             await self.handle_external_links(scrape_item)
+            new_children += 1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def handle_direct_link(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -122,10 +122,10 @@ class LeakedModelsCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
-                scrape_item.children += 1
-                if scrape_item.children_limit:
-                    if scrape_item.children >= scrape_item.children_limit:
-                        raise ScrapeItemMaxChildrenReached(scrape_item)
+                    scrape_item.children += 1
+                    if scrape_item.children_limit:
+                        if scrape_item.children >= scrape_item.children_limit:
+                            raise ScrapeItemMaxChildrenReached(scrape_item)
 
                 if not continue_scraping:
                     break
@@ -295,9 +295,9 @@ class LeakedModelsCrawler(Crawler):
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
-        if not attachment_block:
-            return
         new_children = 0
+        if not attachment_block:
+            return new_children
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -7,8 +7,9 @@ from bs4 import Tag
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FORUM, FORUM_POST
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -80,6 +81,13 @@ class LeakedModelsCrawler(Crawler):
 
         thread_url = scrape_item.url
         post_number = 0
+        scrape_item.type = FORUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
         if len(scrape_item.url.parts) > 4:
             if "post-" in str(scrape_item.url.parts[4]) or "post-" in scrape_item.url.fragment:
                 url_parts = str(scrape_item.url).rsplit("post-", 1)
@@ -114,6 +122,11 @@ class LeakedModelsCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
+
                 if not continue_scraping:
                     break
 
@@ -141,16 +154,27 @@ class LeakedModelsCrawler(Crawler):
             scrape_item = await self.create_scrape_item(scrape_item, scrape_item.url, "")
             await scrape_item.add_to_parent_title("post-" + str(post_number))
 
-        await self.links(scrape_item, post_content)
-        await self.images(scrape_item, post_content)
-        await self.videos(scrape_item, post_content)
-        await self.embeds(scrape_item, post_content)
-        await self.attachments(scrape_item, post_content)
+        scrape_item.type = FORUM_POST
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
+        posts_scrapers = [self.links, self.images, self.videos, self.embeds, self.attachments]
+
+        for scraper in posts_scrapers:
+            scrape_item.children += await scraper(scrape_item, post_content)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
+        new_children = 0
         for link_obj in links:
             test_for_img = link_obj.select_one("img")
             if test_for_img is not None:
@@ -179,14 +203,19 @@ class LeakedModelsCrawler(Crawler):
                     await self.handle_internal_links(link, scrape_item)
                 else:
                     await log(f"Unknown link type: {link}", 30)
-                    continue
             except TypeError:
                 await log(f"Scrape Failed: encountered while handling {link}", 40)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
+        new_children = 0
         for image in images:
             link = image.get(self.images_attribute)
             if not link:
@@ -209,14 +238,18 @@ class LeakedModelsCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
-
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
+    
     @error_handling_wrapper
     async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
-
+        new_children = 0
         for video in videos:
             link = video.get(self.videos_attribute)
             if not link:
@@ -231,11 +264,17 @@ class LeakedModelsCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
+        new_children = 0
         for embed in embeds:
             link = embed.get(self.embeds_attribute)
             if not link:
@@ -246,6 +285,11 @@ class LeakedModelsCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
@@ -253,7 +297,7 @@ class LeakedModelsCrawler(Crawler):
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:
             return
-
+        new_children = 0
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)
@@ -276,8 +320,11 @@ class LeakedModelsCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
-
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -171,7 +171,7 @@ class LeakedModelsCrawler(Crawler):
                     raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
-    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
         new_children = 0
@@ -212,7 +212,7 @@ class LeakedModelsCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
         new_children = 0
@@ -245,7 +245,7 @@ class LeakedModelsCrawler(Crawler):
         return new_children
     
     @error_handling_wrapper
-    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
@@ -271,7 +271,7 @@ class LeakedModelsCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
         new_children = 0
@@ -292,7 +292,7 @@ class LeakedModelsCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -118,10 +118,10 @@ class NudoStarCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
-                scrape_item.children += 1
-                if scrape_item.children_limit:
-                    if scrape_item.children >= scrape_item.children_limit:
-                        raise ScrapeItemMaxChildrenReached(scrape_item)
+                    scrape_item.children += 1
+                    if scrape_item.children_limit:
+                        if scrape_item.children >= scrape_item.children_limit:
+                            raise ScrapeItemMaxChildrenReached(scrape_item)
 
                 if not continue_scraping:
                     break
@@ -301,9 +301,9 @@ class NudoStarCrawler(Crawler):
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
-        if not attachment_block:
-            return
         new_children = 0
+        if not attachment_block:
+            return new_children
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -168,7 +168,7 @@ class NudoStarCrawler(Crawler):
 
 
     @error_handling_wrapper
-    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
         new_children = 0
@@ -206,7 +206,7 @@ class NudoStarCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
         new_children = 0
@@ -241,7 +241,7 @@ class NudoStarCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
@@ -265,7 +265,7 @@ class NudoStarCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
         new_children = 0
@@ -298,7 +298,7 @@ class NudoStarCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -8,8 +8,9 @@ from bs4 import Tag
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FORUM, FORUM_POST
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -76,6 +77,13 @@ class NudoStarCrawler(Crawler):
 
         thread_url = scrape_item.url
         post_number = 0
+        scrape_item.type = FORUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
         if len(scrape_item.url.parts) > 4:
             if "post-" in str(scrape_item.url.parts[4]) or "post-" in scrape_item.url.fragment:
                 url_parts = str(scrape_item.url).rsplit("post-", 1)
@@ -110,6 +118,11 @@ class NudoStarCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
+
                 if not continue_scraping:
                     break
 
@@ -137,16 +150,28 @@ class NudoStarCrawler(Crawler):
             scrape_item = await self.create_scrape_item(scrape_item, scrape_item.url, "")
             await scrape_item.add_to_parent_title("post-" + str(post_number))
 
-        await self.links(scrape_item, post_content)
-        await self.images(scrape_item, post_content)
-        await self.videos(scrape_item, post_content)
-        await self.embeds(scrape_item, post_content)
-        await self.attachments(scrape_item, post_content)
+        scrape_item.type = FORUM_POST
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
+        posts_scrapers = [self.links, self.images, self.videos, self.embeds, self.attachments]
+
+        for scraper in posts_scrapers:
+            scrape_item.children += await scraper(scrape_item, post_content)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
+
 
     @error_handling_wrapper
     async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
+        new_children = 0
         for link_obj in links:
             link = link_obj.get(self.links_attribute)
             if not link:
@@ -172,14 +197,19 @@ class NudoStarCrawler(Crawler):
                     await self.handle_internal_links(link, scrape_item)
                 else:
                     await log(f"Unknown link type: {link}", 30)
-                    continue
             except TypeError:
                 await log(f"Scrape Failed: encountered while handling {link}", 40)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
+        new_children = 0
         for image in images:
             link = image.get(self.images_attribute)
             if not link:
@@ -204,13 +234,18 @@ class NudoStarCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
+        new_children = 0
 
         for video in videos:
             link = video.get(self.videos_attribute)
@@ -223,11 +258,17 @@ class NudoStarCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
+        new_children = 0
         for embed in embeds:
             data = embed.get(self.embeds_attribute)
             if not data:
@@ -250,6 +291,11 @@ class NudoStarCrawler(Crawler):
                 link = URL(link)
                 new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
                 await self.handle_external_links(new_scrape_item)
+                new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
@@ -257,7 +303,7 @@ class NudoStarCrawler(Crawler):
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:
             return
-
+        new_children = 0
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)
@@ -277,7 +323,11 @@ class NudoStarCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -9,8 +9,9 @@ from yarl import URL
 
 from cyberdrop_dl.clients.errors import NoExtensionFailure
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -40,6 +41,13 @@ class PixelDrainCrawler(Crawler):
         """Scrapes a folder"""
         album_id = scrape_item.url.parts[2]
         results = await self.get_album_results(album_id)
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         async with self.request_limiter:
             JSON_Resp = await self.client.get_json(self.domain, self.api_address / "list" / scrape_item.url.parts[-1])
@@ -59,6 +67,10 @@ class PixelDrainCrawler(Crawler):
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, None, date, add_parent = scrape_item.url)
             if not await self.check_album_results(link, results):
                 await self.handle_file(link, new_scrape_item, filename, ext)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/postimg_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/postimg_crawler.py
@@ -7,8 +7,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -40,6 +41,13 @@ class PostImgCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         data = {"action": "list", "album": scrape_item.url.raw_name, "page": 0}
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
         for i in itertools.count(1):
             data["page"] = i
             async with self.request_limiter:
@@ -52,6 +60,10 @@ class PostImgCrawler(Crawler):
                 filename, ext = image[2], image[3]
                 new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
                 await self.handle_file(link, new_scrape_item, filename, ext)
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
 
             if not JSON_Resp['has_page_next']:
                 break

--- a/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
@@ -6,8 +6,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -47,6 +48,13 @@ class RealBooruCrawler(Crawler):
 
         title_portion = scrape_item.url.query['tags'].strip()
         title = await self.create_title(title_portion, None, None)
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         content = soup.select("div[class=items] div a")
         for file_page in content:
@@ -56,6 +64,10 @@ class RealBooruCrawler(Crawler):
             link = URL(link, encoded=True)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
         next_page = soup.select_one("a[alt=next]")
         if next_page is not None:

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -90,7 +90,7 @@ class RedditCrawler(Crawler):
         except asyncprawcore.exceptions.NotFound:
             raise ScrapeFailure(404, "Not Found")
         
-        self.type = FILE_HOST_PROFILE
+        scrape_item.type = FILE_HOST_PROFILE
         scrape_item.children = scrape_item.children_limit = 0
 
         try:

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -10,8 +10,9 @@ from yarl import URL
 
 from cyberdrop_dl.clients.errors import ScrapeFailure, NoExtensionFailure
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM, FILE_HOST_PROFILE
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, log, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -88,9 +89,20 @@ class RedditCrawler(Crawler):
             raise ScrapeFailure(403, "Forbidden")
         except asyncprawcore.exceptions.NotFound:
             raise ScrapeFailure(404, "Not Found")
+        
+        self.type = FILE_HOST_PROFILE
+        scrape_item.children = scrape_item.children_limit = 0
+
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         for submission in submissions:
             await self.post(scrape_item, submission, reddit)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def post(self, scrape_item: ScrapeItem, submission, reddit: asyncpraw.Reddit) -> None:
@@ -123,10 +135,21 @@ class RedditCrawler(Crawler):
             return
         items = [item for item in submission.media_metadata.values() if item["status"] == "valid"]
         links = [URL(item["s"]["u"]).with_host("i.redd.it").with_query(None) for item in items]
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
         for link in links:
             new_scrape_item = await self.create_new_scrape_item(link, scrape_item, scrape_item.parent_title,
                                                                 scrape_item.possible_datetime, add_parent = scrape_item.url)
             await self.media(new_scrape_item, reddit)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def media(self, scrape_item: ScrapeItem, reddit: asyncpraw.Reddit) -> None:

--- a/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
@@ -47,7 +47,7 @@ class RedGifsCrawler(Crawler):
         page = 1
         total_pages = 1
 
-        self.type = FILE_HOST_PROFILE
+        scrape_item.type = FILE_HOST_PROFILE
         scrape_item.children = scrape_item.children_limit = 0
 
         try:

--- a/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
@@ -8,9 +8,10 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper
 from cyberdrop_dl.utils.utilities import get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -46,6 +47,13 @@ class Rule34VaultCrawler(Crawler):
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
 
         title = await self.create_title(scrape_item.url.parts[1], None, None)
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         content_block = soup.select_one(
             'div[class="box-grid ng-star-inserted"]')
@@ -58,6 +66,9 @@ class Rule34VaultCrawler(Crawler):
             new_scrape_item = await self.create_scrape_item(
                 scrape_item, link, title, True,add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
         if not content:
             return
 
@@ -82,6 +93,14 @@ class Rule34VaultCrawler(Crawler):
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
 
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         title_str = soup.select_one("div[class*=title]").text
         title = await self.create_title(title_str, scrape_item.url.parts[-1],
                                         None)
@@ -97,6 +116,9 @@ class Rule34VaultCrawler(Crawler):
             new_scrape_item = await self.create_scrape_item(
                 scrape_item, link, title, True,add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
         if not content:
             return
 

--- a/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
@@ -8,8 +8,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -40,6 +41,14 @@ class Rule34XYZCrawler(Crawler):
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
 
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         title = await self.create_title(scrape_item.url.parts[1], None, None)
 
         content_block = soup.select_one('div[class="box-grid ng-star-inserted"]')
@@ -51,6 +60,9 @@ class Rule34XYZCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True,add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
         if not content:
             return
 

--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
+# TODO: add saint.su album support
+
 class SaintCrawler(Crawler):
     def __init__(self, manager: Manager):
         super().__init__(manager, "saint", "Saint")
@@ -33,7 +35,7 @@ class SaintCrawler(Crawler):
 
     @error_handling_wrapper
     async def video(self, scrape_item: ScrapeItem) -> None:
-        """Scrapes an album"""
+        """Get file info before sending to downloader"""
         if await self.check_complete_from_referer(scrape_item):
             return
 

--- a/cyberdrop_dl/scraper/crawlers/scrolller_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/scrolller_crawler.py
@@ -7,8 +7,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, log, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -42,6 +43,13 @@ class ScrolllerCrawler(Crawler):
         title = await self.create_title(subreddit, None, None)
         await scrape_item.add_to_parent_title(title)
         scrape_item.part_of_album = True
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         request_body = {
             "query": """
@@ -95,6 +103,9 @@ class ScrolllerCrawler(Crawler):
                         highest_res_image_url = URL(media_sources[-1]['url'])
                         filename, ext = await get_filename_and_ext(highest_res_image_url.name)
                         await self.handle_file(highest_res_image_url, scrape_item, filename, ext)
+                        if scrape_item.children_limit:
+                            if scrape_item.children >= scrape_item.children_limit:
+                                raise ScrapeItemMaxChildrenReached(scrape_item)
 
                 prev_iterator = iterator
                 iterator = data["data"]["getSubreddit"]["children"]["iterator"]

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -173,7 +173,7 @@ class SimpCityCrawler(Crawler):
                     raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
-    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
         new_children = 0
@@ -214,7 +214,7 @@ class SimpCityCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
         new_children = 0
@@ -251,7 +251,7 @@ class SimpCityCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
@@ -277,7 +277,7 @@ class SimpCityCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
         new_children = 0
@@ -310,7 +310,7 @@ class SimpCityCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -124,10 +124,10 @@ class SimpCityCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
-                scrape_item.children += 1
-                if scrape_item.children_limit:
-                    if scrape_item.children >= scrape_item.children_limit:
-                        raise ScrapeItemMaxChildrenReached(scrape_item)
+                    scrape_item.children += 1
+                    if scrape_item.children_limit:
+                        if scrape_item.children >= scrape_item.children_limit:
+                            raise ScrapeItemMaxChildrenReached(scrape_item)
 
                 if not continue_scraping:
                     break
@@ -313,9 +313,9 @@ class SimpCityCrawler(Crawler):
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
-        if not attachment_block:
-            return
         new_children = 0
+        if not attachment_block:
+            return new_children
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -8,8 +8,9 @@ from bs4 import Tag
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FORUM, FORUM_POST
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -79,6 +80,13 @@ class SimpCityCrawler(Crawler):
 
         thread_url = scrape_item.url
         post_number = 0
+        scrape_item.type = FORUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
         if len(scrape_item.url.parts) > 3:
             if "post-" in str(scrape_item.url.parts[3]) or "post-" in scrape_item.url.fragment:
                 url_parts = str(scrape_item.url).rsplit("post-", 1)
@@ -116,6 +124,11 @@ class SimpCityCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
+
                 if not continue_scraping:
                     break
 
@@ -143,16 +156,27 @@ class SimpCityCrawler(Crawler):
             scrape_item = await self.create_scrape_item(scrape_item, scrape_item.url, "")
             await scrape_item.add_to_parent_title("post-" + str(post_number))
 
-        await self.links(scrape_item, post_content)
-        await self.images(scrape_item, post_content)
-        await self.videos(scrape_item, post_content)
-        await self.embeds(scrape_item, post_content)
-        await self.attachments(scrape_item, post_content)
+        scrape_item.type = FORUM_POST
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
+        posts_scrapers = [self.links, self.images, self.videos, self.embeds, self.attachments]
+
+        for scraper in posts_scrapers:
+            scrape_item.children += await scraper(scrape_item, post_content)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
+        new_children = 0
         for link_obj in links:
             test_for_img = link_obj.select_one("img")
             if test_for_img is not None and self.attachment_url_part not in link_obj.get(self.links_attribute):
@@ -181,14 +205,19 @@ class SimpCityCrawler(Crawler):
                     await self.handle_internal_links(link, scrape_item)
                 else:
                     await log(f"Unknown link type: {link}", 30)
-                    continue
             except TypeError:
                 await log(f"Scrape Failed: encountered while handling {link}", 40)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
+        new_children = 0
         for image in images:
             link = image.get(self.images_attribute)
             if not link:
@@ -215,14 +244,18 @@ class SimpCityCrawler(Crawler):
                 continue
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
-
+        new_children = 0
         for video in videos:
             link = video.get(self.videos_attribute)
             if not link:
@@ -237,11 +270,17 @@ class SimpCityCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
+        new_children = 0
         for embed in embeds:
             data = embed.get(self.embeds_attribute)
             if not data:
@@ -264,6 +303,11 @@ class SimpCityCrawler(Crawler):
                 link = URL(link)
                 new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
                 await self.handle_external_links(new_scrape_item)
+                new_children +=1
+                if scrape_item.children_limit:
+                    if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                        break
+        return new_children
 
     @error_handling_wrapper
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
@@ -271,7 +315,7 @@ class SimpCityCrawler(Crawler):
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:
             return
-
+        new_children = 0
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)
@@ -294,7 +338,11 @@ class SimpCityCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -193,7 +193,7 @@ class SocialMediaGirlsCrawler(Crawler):
             if "link-confirmation" in link.path:
                 link = await self.handle_link_confirmation(link)
             if link is None:
-                return
+                return new_children
             try:
                 if self.domain not in link.host:
                     new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
@@ -312,9 +312,9 @@ class SocialMediaGirlsCrawler(Crawler):
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
-        if not attachment_block:
-            return
         new_children = 0
+        if not attachment_block:
+            return new_children
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -145,7 +145,7 @@ class SocialMediaGirlsCrawler(Crawler):
         await self.attachments(scrape_item, post_content)
 
     @error_handling_wrapper
-    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
         for link_obj in links:
@@ -184,7 +184,7 @@ class SocialMediaGirlsCrawler(Crawler):
                 await log(f"Scrape Failed: encountered while handling {link}", 40)
 
     @error_handling_wrapper
-    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
         for image in images:
@@ -216,7 +216,7 @@ class SocialMediaGirlsCrawler(Crawler):
                 continue
 
     @error_handling_wrapper
-    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
@@ -237,7 +237,7 @@ class SocialMediaGirlsCrawler(Crawler):
             await self.handle_external_links(new_scrape_item)
 
     @error_handling_wrapper
-    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
         for embed in embeds:
@@ -264,7 +264,7 @@ class SocialMediaGirlsCrawler(Crawler):
                 await self.handle_external_links(new_scrape_item)
 
     @error_handling_wrapper
-    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:

--- a/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
@@ -8,8 +8,9 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM, FILE_HOST_PROFILE
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -38,9 +39,17 @@ class ToonilyCrawler(Crawler):
 
     @error_handling_wrapper
     async def series(self, scrape_item: ScrapeItem) -> None:
-        """Scrapes an album"""
+        """Scrapes a series"""
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
+
+        self.type = FILE_HOST_PROFILE
+        scrape_item.children = scrape_item.children_limit = 0
+
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         chapters = soup.select("li[class*=wp-manga-chapter] a")
         for chapter in chapters:
@@ -53,12 +62,23 @@ class ToonilyCrawler(Crawler):
                 chapter_path = URL(chapter_path)
             new_scrape_item = await self.create_scrape_item(scrape_item, chapter_path, "", True , add_parent = scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def chapter(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image"""
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
+
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
 
         title_parts = soup.select_one("title").get_text().split(" - ")
         series_name = title_parts[0]
@@ -87,6 +107,9 @@ class ToonilyCrawler(Crawler):
 
             filename, ext = await get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def handle_direct_link(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
@@ -43,7 +43,7 @@ class ToonilyCrawler(Crawler):
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
 
-        self.type = FILE_HOST_PROFILE
+        scrape_item.type = FILE_HOST_PROFILE
         scrape_item.children = scrape_item.children_limit = 0
 
         try:

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -8,8 +8,9 @@ from bs4 import Tag
 from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FORUM, FORUM_POST
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -80,6 +81,13 @@ class XBunkerCrawler(Crawler):
 
         thread_url = scrape_item.url
         post_number = 0
+        scrape_item.type = FORUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
         if len(scrape_item.url.parts) > 3:
             if "post-" in str(scrape_item.url.parts[3]) or "post-" in scrape_item.url.fragment:
                 url_parts = str(scrape_item.url).rsplit("post-", 1)
@@ -114,6 +122,11 @@ class XBunkerCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
+                scrape_item.children += 1
+                if scrape_item.children_limit:
+                    if scrape_item.children >= scrape_item.children_limit:
+                        raise ScrapeItemMaxChildrenReached(scrape_item)
+
                 if not continue_scraping:
                     break
 
@@ -141,16 +154,27 @@ class XBunkerCrawler(Crawler):
             scrape_item = await self.create_scrape_item(scrape_item, scrape_item.url, "")
             await scrape_item.add_to_parent_title("post-" + str(post_number))
 
-        await self.links(scrape_item, post_content)
-        await self.images(scrape_item, post_content)
-        await self.videos(scrape_item, post_content)
-        await self.embeds(scrape_item, post_content)
-        await self.attachments(scrape_item, post_content)
+        scrape_item.type = FORUM_POST
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
+        posts_scrapers = [self.links, self.images, self.videos, self.embeds, self.attachments]
+
+        for scraper in posts_scrapers:
+            scrape_item.children += await scraper(scrape_item, post_content)
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
     async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
+        new_children = 0
         for link_obj in links:
             test_for_img = link_obj.select_one("img")
             if test_for_img is not None:
@@ -181,12 +205,18 @@ class XBunkerCrawler(Crawler):
                     continue
             except TypeError:
                 await log(f"Scrape Failed: encountered while handling {link}", 40)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
         images.extend(post_content.select(self.extra_image_selector))
+        new_children = 0
         for image in images:
             link = image.get(self.images_attribute)
             if not link:
@@ -211,13 +241,18 @@ class XBunkerCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
+        new_children = 0
 
         for video in videos:
             link = video.get(self.videos_attribute)
@@ -233,11 +268,17 @@ class XBunkerCrawler(Crawler):
             link = URL(link)
             new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
             await self.handle_external_links(new_scrape_item)
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     @error_handling_wrapper
     async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
+        new_children = 0
         for embed in embeds:
             data = embed.get(self.embeds_attribute)
             if not data:
@@ -260,6 +301,11 @@ class XBunkerCrawler(Crawler):
                 link = URL(link)
                 new_scrape_item = await self.create_scrape_item(scrape_item, link, "")
                 await self.handle_external_links(new_scrape_item)
+                new_children +=1
+                if scrape_item.children_limit:
+                    if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                        break
+        return new_children
 
     @error_handling_wrapper
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
@@ -267,7 +313,7 @@ class XBunkerCrawler(Crawler):
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:
             return
-
+        new_children = 0
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)
@@ -290,7 +336,11 @@ class XBunkerCrawler(Crawler):
                 await self.handle_internal_links(link, scrape_item)
             else:
                 await log(f"Unknown image type: {link}", 30)
-                continue
+            new_children +=1
+            if scrape_item.children_limit:
+                if (new_children + scrape_item.children) >= scrape_item.children_limit:
+                    break
+        return new_children
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -122,10 +122,10 @@ class XBunkerCrawler(Crawler):
                     post_content = post.select_one(self.posts_content_selector)
                     await self.post(new_scrape_item, post_content, current_post_number)
 
-                scrape_item.children += 1
-                if scrape_item.children_limit:
-                    if scrape_item.children >= scrape_item.children_limit:
-                        raise ScrapeItemMaxChildrenReached(scrape_item)
+                    scrape_item.children += 1
+                    if scrape_item.children_limit:
+                        if scrape_item.children >= scrape_item.children_limit:
+                            raise ScrapeItemMaxChildrenReached(scrape_item)
 
                 if not continue_scraping:
                     break
@@ -311,9 +311,9 @@ class XBunkerCrawler(Crawler):
     async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
-        if not attachment_block:
-            return
         new_children = 0
+        if not attachment_block:
+            return new_children
         attachments = attachment_block.select(self.attachments_selector)
         for attachment in attachments:
             link = attachment.get(self.attachments_attribute)

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -171,7 +171,7 @@ class XBunkerCrawler(Crawler):
                     raise ScrapeItemMaxChildrenReached(scrape_item)
 
     @error_handling_wrapper
-    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def links(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes links from a post"""
         links = post_content.select(self.links_selector)
         new_children = 0
@@ -212,7 +212,7 @@ class XBunkerCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def images(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes images from a post"""
         images = post_content.select(self.images_selector)
         images.extend(post_content.select(self.extra_image_selector))
@@ -248,7 +248,7 @@ class XBunkerCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def videos(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes videos from a post"""
         videos = post_content.select(self.videos_selector)
         videos.extend(post_content.select(self.iframe_selector))
@@ -275,7 +275,7 @@ class XBunkerCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def embeds(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes embeds from a post"""
         embeds = post_content.select(self.embeds_selector)
         new_children = 0
@@ -308,7 +308,7 @@ class XBunkerCrawler(Crawler):
         return new_children
 
     @error_handling_wrapper
-    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> None:
+    async def attachments(self, scrape_item: ScrapeItem, post_content: Tag) -> int:
         """Scrapes attachments from a post"""
         attachment_block = post_content.select_one(self.attachments_block_selector)
         if not attachment_block:

--- a/cyberdrop_dl/scraper/crawlers/xbunkr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunkr_crawler.py
@@ -7,8 +7,9 @@ from yarl import URL
 
 from cyberdrop_dl.clients.errors import NoExtensionFailure
 from cyberdrop_dl.scraper.crawler import Crawler
-from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem, FILE_HOST_ALBUM
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.clients.errors import ScrapeItemMaxChildrenReached
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -39,6 +40,14 @@ class XBunkrCrawler(Crawler):
         async with self.request_limiter:
             soup = await self.client.get_BS4(self.domain, scrape_item.url)
 
+        scrape_item.type = FILE_HOST_ALBUM
+        scrape_item.children = scrape_item.children_limit = 0
+        
+        try:
+            scrape_item.children_limit = self.manager.config_manager.settings_data['Download_Options']['maximum_number_of_children'][scrape_item.type]
+        except (IndexError, TypeError):
+            pass
+
         title = await self.create_title(soup.select_one("h1[id=title]").text, scrape_item.url.parts[2], None)
 
         links = soup.select("a[class=image]")
@@ -51,3 +60,7 @@ class XBunkrCrawler(Crawler):
                 continue
             new_scrape_item = await self.create_scrape_item(scrape_item, link, title, True, add_parent = scrape_item.url)
             await self.handle_file(link, new_scrape_item, filename, ext)
+            scrape_item.children += 1
+            if scrape_item.children_limit:
+                if scrape_item.children >= scrape_item.children_limit:
+                    raise ScrapeItemMaxChildrenReached(scrape_item)

--- a/cyberdrop_dl/utils/args/args.py
+++ b/cyberdrop_dl/utils/args/args.py
@@ -75,6 +75,8 @@ def parse_args() -> argparse.Namespace:
                                 help="separate posts into folders")
     download_options.add_argument("--skip-download-mark-completed", action=argparse.BooleanOptionalAction,
                                 help="skip download and mark as completed in history")
+    download_options.add_argument("--maximum-number-of-children",nargs="*", type=int,
+                                  help="max number of children a root scrape item can have. Use multi ttime to specify max children of descendants", default=[])
 
     file_size_limits = parser.add_argument_group("File_Size_Limits")
     file_size_limits.add_argument("--maximum-image-size", type=int,

--- a/cyberdrop_dl/utils/args/args.py
+++ b/cyberdrop_dl/utils/args/args.py
@@ -75,8 +75,8 @@ def parse_args() -> argparse.Namespace:
                                 help="separate posts into folders")
     download_options.add_argument("--skip-download-mark-completed", action=argparse.BooleanOptionalAction,
                                 help="skip download and mark as completed in history")
-    download_options.add_argument("--maximum-number-of-children",nargs="*", type=int,
-                                  help="max number of children a root scrape item can have. Use multi ttime to specify max children of descendants", default=[])
+    download_options.add_argument("--maximum-number-of-children", nargs="*", type=int,
+                                  help="max number of children an scrape item can have", default=[])
 
     file_size_limits = parser.add_argument_group("File_Size_Limits")
     file_size_limits.add_argument("--maximum-image-size", type=int,

--- a/cyberdrop_dl/utils/args/config_definitions.py
+++ b/cyberdrop_dl/utils/args/config_definitions.py
@@ -60,6 +60,7 @@ settings: Dict = {
         "scrape_single_forum_post": False,
         "separate_posts": False,
         "skip_download_mark_completed": False,
+        "maximum_number_of_children": []
     },
     "Files": {
         "input_file": str(APP_STORAGE / "Configs" / "{config}" / "URLs.txt"),

--- a/cyberdrop_dl/utils/dataclasses/url_objects.py
+++ b/cyberdrop_dl/utils/dataclasses/url_objects.py
@@ -48,7 +48,7 @@ class ScrapeItem:
         self.parents : list[URL] = []
         self.children : int = 0
         self.children_limit: int = 0
-        self.type: Union[str, None] = None
+        self.type: Union[int, None] = None
         self.part_of_album: bool = part_of_album
         self.album_id: Union[str, None] = album_id
         self.possible_datetime: int = possible_datetime

--- a/cyberdrop_dl/utils/dataclasses/url_objects.py
+++ b/cyberdrop_dl/utils/dataclasses/url_objects.py
@@ -39,6 +39,8 @@ class ScrapeItem:
         self.parent_title: str = parent_title
         # WARNING: unsafe but deepcopy is used when a new child item is created
         self.parents : list[URL] = []
+        self.children : int = 0
+        self.type: Union[str, None] = None
         self.part_of_album: bool = part_of_album
         self.album_id: Union[str, None] = album_id
         self.possible_datetime: int = possible_datetime

--- a/cyberdrop_dl/utils/dataclasses/url_objects.py
+++ b/cyberdrop_dl/utils/dataclasses/url_objects.py
@@ -9,6 +9,13 @@ if TYPE_CHECKING:
     from yarl import URL
 
 
+FORUM = 0
+FORUM_POST = 1
+FILE_HOST_PROFILE = 2
+FILE_HOST_ALBUM = 3
+
+SCRAPE_ITEM_TYPES = [FORUM, FORUM_POST, FILE_HOST_PROFILE, FILE_HOST_ALBUM]
+
 class MediaItem:
     def __init__(self, url: "URL", referer: "URL", album_id: Union[str, None], download_folder: Path, filename: str,
                  ext: str, original_filename: str):
@@ -40,6 +47,7 @@ class ScrapeItem:
         # WARNING: unsafe but deepcopy is used when a new child item is created
         self.parents : list[URL] = []
         self.children : int = 0
+        self.children_limit: int = 0
         self.type: Union[str, None] = None
         self.part_of_album: bool = part_of_album
         self.album_id: Union[str, None] = album_id

--- a/docs/reference/cli-arguments.md
+++ b/docs/reference/cli-arguments.md
@@ -46,6 +46,7 @@ For items within Download Options, Ignore Options, Runtime Options, and Sorting 
 --scrape-single-forum-post
 --separate-posts
 --skip-download-mark-completed
+--maximum-number-of-children
 
 // File Size Limits
 --maximum-image-size <number>

--- a/docs/reference/configuration-options/settings.md
+++ b/docs/reference/configuration-options/settings.md
@@ -104,12 +104,12 @@ Limit FORUM scrape to 15 posts max, grab all links and media within those posts,
     --maximum-number-of-children 15 0 10
 
 
-Only grap the first link from each post in a forum, but that link will have no children_limit:
+Only grab the first link from each post in a forum, but that link will have no children_limit:
 
     --maximum-number-of-children 0 1
 
 
-Only grap the first POST/ALBUM from a FILE_HOST_PROFILE
+Only grab the first POST/ALBUM from a FILE_HOST_PROFILE
 
     --maximum-number-of-children 0 0 1
 

--- a/docs/reference/configuration-options/settings.md
+++ b/docs/reference/configuration-options/settings.md
@@ -81,6 +81,44 @@ Setting this to true (or selecting it) will separate content from forum posts in
 
 Setting this to true (or selecting it) will skip downloading files and mark them as downloaded in the database.
 
+***
+
+* maximum\_number\_of\_children
+
+Limit the number of items to scrape using a tuple of up to 4 positions. Each position defines the maximum number of sub-items (`children_limit`) an specific type of `scrape_item` will have:
+
+    1. Max number of children from a FORUM URL
+    2. Max number of children from a FORUM POST
+    3. Max number of children from a FILE HOST PROFILE
+    4. Max number of children from a FILE HOST ALBUM
+
+Using `0` on any position means no `children_limit` for that type of `scrape_item`. Any tailing value not supplied is assumed as `0`
+
+
+
+Examples:
+
+```
+Limit FORUM scrape to 15 posts max, grab all links and media within those posts, but only scrape a maximun of 10 items from each link in a post:
+
+    --maximum-number-of-children 15 0 10
+
+
+Only grap the first link from each post in a forum, but that link will have no children_limit:
+
+    --maximum-number-of-children 0 1
+
+
+Only grap the first POST/ALBUM from a FILE_HOST_PROFILE
+
+    --maximum-number-of-children 0 0 1
+
+
+No FORUM limit, no FORUM_POST limit, no FILE_HOST_PROFILE limit, maximum of 20 items from any FILE_HOST_ALBUM:
+
+    --maximum-number-of-children 0 0 0 20
+``` 
+
 </details>
 
 <details>


### PR DESCRIPTION
This PR adds a new option: `--maximum-number-of-children`

This limits the number of items to scrape using a tuple of up to 4 positions. Each position defines the maximum number of sub-items (`children_limit`) an specific type of `scrape_item` will have:

    1. Max number of children from a FORUM URL
    2. Max number of children from a FORUM POST
    3. Max number of children from a FILE HOST PROFILE
    4. Max number of children from a FILE HOST ALBUM

Using `0` on any position means no `children_limit` for that type of `scrape_item`. Any tailing value not supplied is assumed as `0`

**Examples:**


1. Limit FORUM scrape to 15 posts max, grab all links and media within those posts, but only scrape a maximun of 10 items from each link in a post:

    `--maximum-number-of-children 15 0 10`


2. Only grab the first link from each post in a forum, but that link will have no `children_limit`:

    `--maximum-number-of-children 0 1`


3. Only grab the first POST/ALBUM from a FILE_HOST_PROFILE

    `--maximum-number-of-children 0 0 1`


4. No FORUM limit, no FORUM_POST limit, no FILE_HOST_PROFILE limit, maximum of 20 items from any FILE_HOST_ALBUM:

    `--maximum-number-of-children 0 0 0 20`

The modification is small but its on every crawler. I may have overlooked or mistyped something. If approved, i suggest to publish as pre-release if possible, just in case (there are a _lot_ of crawlers)