### PR TITLE
feat: add support for password protected GoFile URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+This update introduces the following changes:
+1. Support for password protected GoFile links
+
+#### Details:
+
+1. Users can include the password as a query parameter in the input URL, adding `?password=<URL_PASSWORD>` to it.
+ Example: https://gofile.io/d/xUprGg?password=1234
+
 ## [5.6.43] - 2024-10-03
 
 This update introduces the following changes:

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -75,7 +75,7 @@ class GoFileCrawler(Crawler):
         JSON_Resp = JSON_Resp['data']
 
         if "password" in JSON_Resp:
-            if 'passwordWrong' in JSON_Resp or not password:
+            if 'passwordWrong' == JSON_Resp['password'] or not password:
                 raise PasswordProtected(scrape_item)
 
         if JSON_Resp["canAccess"] is False:

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -4,7 +4,6 @@ import http
 import re
 from copy import deepcopy
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs
 from hashlib import sha256
 
 from aiolimiter import AsyncLimiter
@@ -48,7 +47,7 @@ class GoFileCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         content_id = scrape_item.url.name
-        password = parse_qs(scrape_item.url.raw_query_string, keep_blank_values=True).get("password",[""])[0]
+        password = scrape_item.url.query.get("password","")
         if password:
             password = sha256(password.encode()).hexdigest()
 
@@ -74,7 +73,6 @@ class GoFileCrawler(Crawler):
 
         JSON_Resp = JSON_Resp['data']
 
-        await log (f"{JSON_Resp}",10)
         if "password" in JSON_Resp:
             if JSON_Resp['passwordStatus'] in {'passwordRequired','passwordWrong'} or not password:
                 raise PasswordProtected(scrape_item)

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -74,8 +74,9 @@ class GoFileCrawler(Crawler):
 
         JSON_Resp = JSON_Resp['data']
 
+        await log (f"{JSON_Resp}",10)
         if "password" in JSON_Resp:
-            if 'passwordWrong' == JSON_Resp['password'] or not password:
+            if JSON_Resp['passwordStatus'] in {'passwordRequired','passwordWrong'} or not password:
                 raise PasswordProtected(scrape_item)
 
         if JSON_Resp["canAccess"] is False:


### PR DESCRIPTION
Users can include the password as a query parameter in the input URL, adding `?password=<URL_PASSWORD>` to it.
Example: `https://gofile.io/d/xUprGg?password=1234`

> [!NOTE]  
> `password` if not a valid query parameter for a regular GoFile link (only via the API) but it makes the implementation easy to use.