### PR TITLE
feat: add support for password protected GoFile URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+This update introduces the following changes:
+1. Support for password protected GoFile links
+
+#### Details:
+
+1. Users can include the password as a query parameter in the input URL, adding `?password=<URL_PASSWORD>` to it.
+ Example: https://gofile.io/d/xUprGg?password=1234
+
 ## [5.6.43] - 2024-10-03
 
 This update introduces the following changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [5.6.50] - 2024-10-07
 
 This update introduces the following changes:
 1. Support for password protected GoFile links

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -4,6 +4,7 @@ import http
 import re
 from copy import deepcopy
 from typing import TYPE_CHECKING
+from hashlib import sha256
 
 from aiolimiter import AsyncLimiter
 from yarl import URL
@@ -46,12 +47,15 @@ class GoFileCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         content_id = scrape_item.url.name
+        password = scrape_item.url.query.get("password","")
+        if password:
+            password = sha256(password.encode()).hexdigest()
 
         try:
             async with self.request_limiter:
                 JSON_Resp = await self.client.get_json(self.domain,
                                                        (self.api_address / "contents" / content_id).with_query(
-                                                           {"wt": self.websiteToken}), headers_inc=self.headers)
+                                                           {"wt": self.websiteToken, "password": password }), headers_inc=self.headers)
         except DownloadFailure as e:
             if e.status == http.HTTPStatus.UNAUTHORIZED:
                 self.websiteToken = ""
@@ -60,17 +64,18 @@ class GoFileCrawler(Crawler):
                 async with self.request_limiter:
                     JSON_Resp = await self.client.get_json(self.domain,
                                                            (self.api_address / "contents" / content_id).with_query(
-                                                               {"wt": self.websiteToken}), headers_inc=self.headers)
+                                                               {"wt": self.websiteToken, "password": password}), headers_inc=self.headers)
             else:
                 raise ScrapeFailure(e.status, e.message)
-
+            
         if JSON_Resp["status"] == "error-notFound":
             raise ScrapeFailure(404, "Album not found")
 
         JSON_Resp = JSON_Resp['data']
 
         if "password" in JSON_Resp:
-            raise PasswordProtected(scrape_item)
+            if JSON_Resp['passwordStatus'] in {'passwordRequired','passwordWrong'} or not password:
+                raise PasswordProtected(scrape_item)
 
         if JSON_Resp["canAccess"] is False:
             raise ScrapeFailure(403, "Album is private")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.6.43"
+version = "5.6.50"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
Users can include the password as a query parameter in the input URL, adding `?password=<URL_PASSWORD>` to it.
Example: `https://gofile.io/d/xUprGg?password=1234`

> [!NOTE]  
> `password` if not a valid query parameter for a regular GoFile link (only via the API) but it makes the implementation easy to use.