### PR TITLE
feat: add support for password protected Cyberfile URLs

### DIFF
--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -142,13 +142,16 @@ class ScraperClient:
 
     @limiter
     async def post_data(self, domain: str, url: URL, client_session: ClientSession, data: Dict,
-                        req_resp: bool = True) -> Dict:
-        """Returns a JSON object from the given URL when posting data"""
+                        req_resp: bool = True, raw: Optional[bool] = False) -> Dict:
+        """Returns a JSON object from the given URL when posting data. If raw == True, returns raw binary data of response"""
         async with client_session.post(url, headers=self._headers, ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy, data=data) as response:
             await self.client_manager.check_http_status(response)
             if req_resp:
-                return json.loads(await response.content.read())
+                content = await response.content.read()
+                if raw:
+                    return content
+                return json.loads(content)
             else:
                 return {}
 


### PR DESCRIPTION
1. Add support for both file and folder protected URLs. Users can include the password as a query parameter in the input URL, adding `?password=<URL_PASSWORD>` to it. Example: `https://cyberfile.me/folder/xUGg?password=1234`

3. Minor typos and formatting fixes on the changelog

> [!NOTE]  
> `password` is not a valid query parameter for a regular Cyberfile link (only via the API) but it makes the implementation easy to use.