### PR TITLE
handle permission errors when using move cd

### DIFF
--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -62,10 +62,11 @@ class Sorter:
         try:
             dest.parent.mkdir(parents=True, exist_ok=True)
             file.rename(dest)
+        except PermissionError:
+            return False
         except FileExistsError:
             if file.stat().st_size == dest.stat().st_size:
                 file.unlink()
-                return
             for i in itertools.count(1):
                 dest_make = dest.parent / f"{dest.stem}{self.incrementer_format.format(i=i)}{dest.suffix}"
                 if not dest_make.is_file():
@@ -181,8 +182,8 @@ class Sorter:
                                     filename=filename, ext=ext, length=length, bitrate=bitrate,
                                     sample_rate=sample_rate, file_date_us=file_date_us, file_date_ca=file_date_ca))
 
-        await self.move_cd(file, new_file)
-        await self.manager.progress_manager.sort_progress.increment_audio()
+        if await self.move_cd(file, new_file) is not False:
+            await self.manager.progress_manager.sort_progress.increment_audio()
 
     async def sort_image(self, file: Path, base_name: str) -> None:
         """Sorts an image file into the sorted image folder"""
@@ -205,8 +206,8 @@ class Sorter:
                                     filename=filename, ext=ext, resolution=resolution, file_date_us=file_date_us,
                                     file_date_ca=file_date_ca))
 
-        await self.move_cd(file, new_file)
-        await self.manager.progress_manager.sort_progress.increment_image()
+        if await self.move_cd(file, new_file) is not False:
+            await self.manager.progress_manager.sort_progress.increment_image()
 
     async def sort_video(self, file: Path, base_name: str) -> None:
         """Sorts a video file into the sorted video folder"""
@@ -236,8 +237,8 @@ class Sorter:
                                     filename=filename, ext=ext, resolution=resolution, fps=frames_per_sec,
                                     codec=codec, file_date_us=file_date_us, file_date_ca=file_date_ca))
 
-        await self.move_cd(file, new_file)
-        await self.manager.progress_manager.sort_progress.increment_video()
+        if await self.move_cd(file, new_file) is not False:
+            await self.manager.progress_manager.sort_progress.increment_video()
 
     async def sort_other(self, file: Path, base_name: str) -> None:
         """Sorts an other file into the sorted other folder"""
@@ -251,5 +252,5 @@ class Sorter:
             self.other_format.format(sort_dir=self.sorted_downloads, base_dir=base_name, parent_dir=parent_name,
                                     filename=filename, ext=ext, file_date_us=file_date_us, file_date_ca=file_date_ca))
 
-        await self.move_cd(file, new_file)
-        await self.manager.progress_manager.sort_progress.increment_other()
+        if await self.move_cd(file, new_file) is not False:
+            await self.manager.progress_manager.sort_progress.increment_other()

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -67,6 +67,7 @@ class Sorter:
         except FileExistsError:
             if file.stat().st_size == dest.stat().st_size:
                 file.unlink()
+                return
             for i in itertools.count(1):
                 dest_make = dest.parent / f"{dest.stem}{self.incrementer_format.format(i=i)}{dest.suffix}"
                 if not dest_make.is_file():


### PR DESCRIPTION
prevents move cd from crashing when permission is denied on when moving a file