### PR TITLE
fix: Bunkr edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.54] - 2024-10-21
+
+This update introduces the following changes:
+1. Fix error on some bunkr videos
+
+#### Details:
+
+- Fix error when downloading videos with no thumbnail (bunkr)
+- Update posible CDNs (bunkr)
+- Better error handling (bunkr)
+
+
+## [5.6.53] - 2024-10-20
+
+This update introduces the following changes:
+1. Update bunkr crawler
+
+#### Details:
+
+- Update bunkr crawler to work on the new site design
+
+
 ## [5.6.52] - 2024-10-10
 
 This update introduces the following changes:

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -11,12 +11,14 @@ from yarl import URL
 from cyberdrop_dl.clients.errors import NoExtensionFailure
 from cyberdrop_dl.scraper.crawler import Crawler
 from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.clients.errors import ScrapeFailure
 from cyberdrop_dl.utils.utilities import FILE_FORMATS, get_filename_and_ext, error_handling_wrapper
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
     from bs4 import BeautifulSoup, Tag
 
+CDN_POSSIBILITIES = re.compile(r"^(?:(?:(?:media-files|cdn|c|pizza|cdn-burger|cdn-nugget|burger|taquito|pizza|fries|meatballs|milkshake|kebab|nachos|ramen|wiener)[0-9]{0,2})|(?:(?:big-taco-|cdn-pizza|cdn-meatballs|cdn-milkshake|i.kebab|i.fries|i-nugget|i-milkshake|i-nachos|i-ramen|i-wiener)[0-9]{0,2}(?:redir)?))\.bunkr?\.[a-z]{2,3}$")
 
 class BunkrrCrawler(Crawler):
     def __init__(self, manager: Manager):
@@ -100,7 +102,6 @@ class BunkrrCrawler(Crawler):
     async def file(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a file"""
         scrape_item.url = self.primary_base_domain.with_path(scrape_item.url.path)
-
         if await self.check_complete_from_referer(scrape_item):
             return
 
@@ -108,18 +109,24 @@ class BunkrrCrawler(Crawler):
             soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
 
         # try video
-        link_container = soup.select_one("video")
+        link_container = soup.select_one('video > source')
         src_selector = "src"
         
         # try image
         if not link_container:
             link_container = soup.select_one("img.max-h-full.w-auto.object-cover.relative")
-            
-        # fallback for evething else
+
+        # fallback for everything else
         if not link_container:
             link_container = soup.select_one("a.btn.ic-download-01")
             src_selector = "href"
-        link = URL(link_container.get(src_selector))
+    
+        link = link_container.get(src_selector) if link_container else None
+
+        if not link:
+            raise ScrapeFailure(404, f"Could not find source for: {scrape_item.url}")
+        
+        link = URL(link)
 
         try:
             filename, ext = await get_filename_and_ext(link.name)
@@ -150,11 +157,14 @@ class BunkrrCrawler(Crawler):
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
+    async def is_cdn(self, url:URL) -> bool:
+        """Checks if a given URL is from a CDN"""
+        return bool(re.match(CDN_POSSIBILITIES, url.host))
+
     async def get_stream_link(self, url: URL) -> URL:
         """Gets the stream link for a given url"""
-        cdn_possibilities = r"^(?:(?:(?:media-files|cdn|c|pizza|cdn-burger|cdn-nugget|burger|taquito|pizza|fries|meatballs|milkshake|kebab)[0-9]{0,2})|(?:(?:big-taco-|cdn-pizza|cdn-meatballs|cdn-milkshake|i.kebab|i.fries|i-nugget|i-milkshake)[0-9]{0,2}(?:redir)?))\.bunkr?\.[a-z]{2,3}$"
-
-        if not re.match(cdn_possibilities, url.host):
+        
+        if not await self.is_cdn(url):
             return url
 
         ext = url.suffix.lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.6.53"
+version = "5.6.54"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
1. Use a more restrictive css selector for videos in case they have no thumbnail
2. Update CDNs definitions
3. Throw `ScrapeFailure` if every filter fails

Fixes #183 