### PR TITLE
feat: add support for XXXBunker URLs 

### DIFF
--- a/cyberdrop_dl/managers/download_manager.py
+++ b/cyberdrop_dl/managers/download_manager.py
@@ -49,7 +49,7 @@ class DownloadManager:
 
         self.file_lock = FileLock()
 
-        self.download_limits = {'bunkr': 1, 'bunkrr': 1, 'cyberdrop': 1, 'cyberfile': 1, "pixeldrain": 2}
+        self.download_limits = {'bunkr': 1, 'bunkrr': 1, 'cyberdrop': 1, 'cyberfile': 1, "pixeldrain": 2, 'xxxbunker': 2}
 
     async def get_download_limit(self, key: str) -> int:
         """Returns the download limit for a domain"""

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -66,9 +66,11 @@ class Crawler(ABC):
         """Director for scraping"""
         raise NotImplementedError("Must override in child class")
 
-    async def handle_file(self, url: URL, scrape_item: ScrapeItem, filename: str, ext: str) -> None:
+    async def handle_file(self, url: URL, scrape_item: ScrapeItem, filename: str, ext: str, custom_filename: Optional[str]= None) -> None:
         """Finishes handling the file and hands it off to the downloader"""
-        if self.domain in ['cyberdrop', 'bunkrr']:
+        if custom_filename:
+            original_filename, filename = filename , custom_filename
+        elif self.domain in ['cyberdrop', 'bunkrr']:
             original_filename, filename = await remove_id(self.manager, filename, ext)
         else:
             original_filename = filename

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, AsyncGenerator
+
+from aiolimiter import AsyncLimiter
+from yarl import URL
+
+from cyberdrop_dl.clients.errors import ScrapeFailure
+from cyberdrop_dl.scraper.crawler import Crawler
+from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper
+from datetime import datetime, timedelta
+from calendar import timegm
+import re
+from bs4 import BeautifulSoup
+
+if TYPE_CHECKING:
+    from cyberdrop_dl.managers.manager import Manager
+    from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+
+DATE_PATTERN = re.compile(r"(\d+)\s*(weeks?|days?|hours?|minutes?|seconds?)", re.IGNORECASE)
+
+class XXXBunkerCrawler(Crawler):
+    def __init__(self, manager: Manager):
+        super().__init__(manager, "xxxbunker", "XXXBunker")
+        self.primary_base_domain = URL("https://xxxbunker.com")
+        self.api_download = URL('https://xxxbunker.com/ajax/downloadpopup')
+        self.request_limiter = AsyncLimiter(10, 1)
+
+    
+    """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
+
+    async def fetch(self, scrape_item: ScrapeItem) -> None:
+        """Determines where to send the scrape item based on the url"""
+        task_id = await self.scraping_progress.add_task(scrape_item.url)
+
+        # modify URL to always start on page 1
+        new_parts = [part for part in scrape_item.url.parts[1:] if "page-" not in part]
+        scrape_item.url = scrape_item.url.with_path("/".join(new_parts)).with_query(scrape_item.url.query)
+
+        await self.video(scrape_item)
+
+        await self.scraping_progress.remove_task(task_id)
+
+    @error_handling_wrapper
+    async def video(self, scrape_item: ScrapeItem) -> None:
+        """Scrapes a video"""
+        if await self.check_complete_from_referer(scrape_item):
+            return
+        
+        video_id = scrape_item.url.parts[1]
+        async with self.request_limiter:
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            video_iframe: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url.with_path(f"player/{video_id}"))
+
+        title = soup.select_one('title').text.rsplit(" : XXXBunker.com")[0].strip()
+        # WARNING: just for testing, needs to be removed on final implementation
+        PHPSESSID = ''
+        self.client.client_manager.cookies.update_cookies({"PHPSESSID": PHPSESSID},
+                                                            response_url=self.primary_base_domain)
+        try:
+            src = video_iframe.select_one('source')
+            src_url = URL(src.get('src'))
+            relative_date_str = soup.select_one("div.video-details").find('li', string='Date Added').find_next('li').text.strip()
+            date = await self.parse_relative_date(relative_date_str)
+            scrape_item.possible_datetime = date
+            internal_id = src_url.query.get('id')
+
+            if 'internal' in src_url.parts:
+                internal_id = video_id
+
+            data = ({'internalid': internal_id })
+
+            async with self.request_limiter:
+                ajax_dict = await self.client.post_data(self.domain, self.api_download, data=data)
+                ajax_soup = BeautifulSoup(ajax_dict['floater'], 'html.parser')
+            
+            link = URL(ajax_soup.select_one('a#download-download').get('href'))
+ 
+        except AttributeError:
+            if "This is a private" in soup.text:
+                raise ScrapeFailure(403, f"Private video: {scrape_item.url}")
+            raise ScrapeFailure(404, f"Could not find video source for {scrape_item.url}")
+        
+        # NOTE: hardcoding the extension to prevent quering the final server URL
+        # final server URL is always different so it can not be saved to db.
+        filename, ext = f"{video_id}.mp4" , '.mp4'
+        
+        # TODO: add custom filename param to handle_file 
+        #custom_file_name, _ = await get_filename_and_ext(f"{title} [{filename}]{ext}")
+        await self.handle_file(link, scrape_item, filename, ext) #, custom_file_name)
+
+
+    async def web_pager(self, url: URL) -> AsyncGenerator[BeautifulSoup]:
+        "Generator of website pages"
+        page_url = url
+        while True:
+            async with self.request_limiter:
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, page_url)
+            next_page = soup.select_one("div.page-list").find('a', string='next')
+            yield soup
+            if next_page :
+                page_url = next_page.get('href')
+                if page_url:
+                    if page_url.startswith("/"):
+                        page_url = self.primary_base_domain / page_url[1:]
+                    page_url = URL(page_url)
+                    continue
+            break
+
+    async def parse_relative_date(self, relative_date: timedelta|str) -> int:
+        """Parses `datetime.timedelta` or `string` in a timedelta format. Returns `today() - parsed_timedelta` as an unix timestamp"""
+        if isinstance(relative_date,str):
+            time_str = relative_date.casefold()
+            matches: list[str] = re.findall(DATE_PATTERN, time_str)
+
+            # Assume today
+            time_dict = {'days':0}
+
+            for value, unit in matches:
+                value = int(value)
+                unit = unit.lower()
+                time_dict[unit] = value
+
+            relative_date = timedelta (**time_dict)
+
+        date = datetime.today() - relative_date
+        return timegm(date.timetuple())

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -101,10 +101,8 @@ class XXXBunkerCrawler(Crawler):
         # NOTE: hardcoding the extension to prevent quering the final server URL
         # final server URL is always different so it can not be saved to db.
         filename, ext = f"{video_id}.mp4" , '.mp4'
-        
-        # TODO: add custom filename param to handle_file 
-        #custom_file_name, _ = await get_filename_and_ext(f"{title} [{filename}]{ext}")
-        await self.handle_file(link, scrape_item, filename, ext) #, custom_file_name)
+        custom_file_name, _ = await get_filename_and_ext(f"{title} [{video_id}]{ext}")
+        await self.handle_file(link, scrape_item, filename, ext, custom_file_name)
           
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -6,7 +6,7 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 import asyncio
 
-from cyberdrop_dl.clients.errors import ScrapeFailure, DownloadFailure
+from cyberdrop_dl.clients.errors import ScrapeFailure
 from cyberdrop_dl.scraper.crawler import Crawler
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
 from datetime import datetime, timedelta
@@ -97,6 +97,9 @@ class XXXBunkerCrawler(Crawler):
 
  
         except (AttributeError, TypeError):
+            if "You must be registered to download this video" in ajax_soup.text:
+                raise ScrapeFailure(403, f"Invalid PHPSESSID: {scrape_item.url}")
+
             if "TRAFFIC VERIFICATION" in soup.text:
                 await asyncio.sleep(self.wait_time)
                 self.wait_time = min (self.wait_time + 10, MAX_WAIT)
@@ -132,7 +135,7 @@ class XXXBunkerCrawler(Crawler):
         
         # Not a valid URL
         else:
-            raise ScrapeFailure(404, f"Could not find video source for {scrape_item.url}")
+            raise ScrapeFailure(400, f"Unsupported URL format: {scrape_item.url}")
             
         scrape_item.part_of_album = True
 

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -184,7 +184,7 @@ class XXXBunkerCrawler(Crawler):
             break
 
     async def parse_relative_date(self, relative_date: timedelta|str) -> int:
-        """Parses `datetime.timedelta` or `string` in a timedelta format. Returns `today() - parsed_timedelta` as an unix timestamp"""
+        """Parses `datetime.timedelta` or `string` in a timedelta format. Returns `now() - parsed_timedelta` as an unix timestamp"""
         if isinstance(relative_date,str):
             time_str = relative_date.casefold()
             matches: list[str] = re.findall(DATE_PATTERN, time_str)
@@ -199,5 +199,5 @@ class XXXBunkerCrawler(Crawler):
 
             relative_date = timedelta (**time_dict)
 
-        date = datetime.today() - relative_date
+        date = datetime.now() - relative_date
         return timegm(date.timetuple())

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -44,7 +44,7 @@ class ScrapeMapper:
                         "rule34.xxx": self.rule34xxx,
                         "rule34.xyz": self.rule34xyz, "saint": self.saint, "scrolller": self.scrolller,
                         "socialmediagirls": self.socialmediagirls, "toonily": self.toonily,
-                        "xbunker": self.xbunker, "xbunkr": self.xbunkr, "bunkr": self.bunkrr}
+                        "xxxbunker":self.xxxbunker,"xbunker": self.xbunker, "xbunkr": self.xbunkr, "bunkr": self.bunkrr}
         self.existing_crawlers = {}
         self.no_crawler_downloader = Downloader(self.manager, "no_crawler")
         self.jdownloader = JDownloader(self.manager)
@@ -258,6 +258,11 @@ class ScrapeMapper:
         """Creates a XBunkr Crawler instance"""
         from cyberdrop_dl.scraper.crawlers.xbunkr_crawler import XBunkrCrawler
         self.existing_crawlers['xbunkr'] = XBunkrCrawler(self.manager)
+
+    async def xxxbunker(self) -> None:
+        """Creates a XXXBunker Crawler instance"""
+        from cyberdrop_dl.scraper.crawlers.xxxbunker_crawler import XXXBunkerCrawler
+        self.existing_crawlers['xxxbunker'] = XXXBunkerCrawler(self.manager)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/utils/args/config_definitions.py
+++ b/cyberdrop_dl/utils/args/config_definitions.py
@@ -28,6 +28,9 @@ authentication_settings: Dict = {
         "xbunker_username": "",
         "xbunker_password": "",
     },
+    "XXXBunker": {
+        "PHPSESSID": "",
+    },
     "GoFile": {
         "gofile_api_key": "",
     },


### PR DESCRIPTION
1. Add support for playlists, search results and video downloads on XXXBunker.com

Implementation requires the user to supply their `PHPSESSID` cookie value after they log in to the website. I tried to not use cookies and just download the src from the website but got many issues:

1. Videos have multiple sources available. The first one is the default and the website player goes to next one if down,  until an online src is found.
2. This requires the crawler to do the same, trying every source until a successful one is found. This is currently not possible without creating multiple entries in the database for each on the sources link
3. _A bunch_ of sources are down. During testing, I would say at least 70% of the videos got me a `404`. More common in older videos.
4. They have a pretty aggressive rate limiting logic that will require a CAPTCHA verification if triggered. I had to limit concurrent download to 2 and a default rate limit of 10 requests per minute, hardcoded wait time and custom logic to auto-adjusts and not trigger the CAPTCHA. If the CAPTCHA is triggered, user can go to the website and solve it while the crawler continues

Using the src method, the crawler was triggering the CAPTCHA even scraping 1 single video cause it needed to make multiple requests for the sources. So i just switched back to using the cookie and making a single post request.

> [!IMPORTANT]  
> `--retry-failed` won't work for URLs of this crawler cause their downloads require a key that is sent as a query parameter, which the database does not save.

This crawler was placed before xbunker in `scraper.mapping`  to fix #174 
