### PR TITLE
Improve new version notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ This update introduces the following changes:
 7. Simplify some UI elements
 8. Improve jdownloader intergration
 9. Implement rich logger
-10. General bug fixes
+10. Add a "Check for Updates" UI option
+11. General bug fixes
 
 
 #### Details:
@@ -31,6 +32,7 @@ This update introduces the following changes:
 - Replace built-in log file handler with rich handler for better error reports
 - UI changes: remove redundant 'X of Y files' from every progress bar, sort scrape and download error by reverse frequency, use equal height for top row UI, fix padding issues, show unsupported URLs stats at the end
 - Add `whitelist` filter, `autostart` and custom `download_dir` options for jdownloader. For more details, visit the wiki: https://script-ware.gitbook.io/cyberdrop-dl/reference/configuration-options/settings#runtime-options
+- Added a "Check for Updates" UI option and improved the update check logic to check for new testing versions.
 - Fix error during program exit when referers table no longer exists
 - Prevents crashes when there are insufficient permissions to move a file
 - Fix an issue where CDL would delete URLs input file

--- a/cyberdrop_dl/ui/prompts/general_prompts.py
+++ b/cyberdrop_dl/ui/prompts/general_prompts.py
@@ -37,9 +37,10 @@ def main_prompt(manager: Manager) -> int:
         Choice(8, "Change URLs.txt file and Download Location"),
         Choice(9, "Edit Configs"),
         Separator(),
-        Choice(10, "Import Cyberdrop_V4 Items"),
-        Choice(11, "View Changelog"),
-        Choice(12, "Exit"),
+        Choice(10, "Check for Updates"),
+        Choice(11, "Import Cyberdrop_V4 Items"),
+        Choice(12, "View Changelog"),
+        Choice(13, "Exit"),
     ]
 
     simp_disclaimer_shown = manager.cache_manager.get("simp_disclaimer_shown")

--- a/cyberdrop_dl/ui/ui.py
+++ b/cyberdrop_dl/ui/ui.py
@@ -197,11 +197,15 @@ def program_ui(manager: Manager):
                 elif action == 7:
                     break
 
-        # Import Cyberdrop_V4 Items
         elif action == 10:
+            asyncio.run(check_latest_pypi(log_to_console=True, call_from_ui=True))
+            exit(0)
+
+        # Import Cyberdrop_V4 Items
+        elif action == 11:
             import_cyberdrop_v4_items_prompt(manager)
 
-        elif action == 11:
+        elif action == 12:
             changelog_path = manager.path_manager.config_dir.parent / "CHANGELOG.md"
             changelog_content = asyncio.run(_get_changelog(changelog_path))
 
@@ -209,7 +213,7 @@ def program_ui(manager: Manager):
                 console.print(Markdown(changelog_content , justify = "left"))
 
         # Exit
-        elif action == 12:
+        elif action == 13:
             exit(0)
 
 
@@ -228,7 +232,7 @@ async def _get_changelog(changelog_path: Path):
                     await f.write(await response.read())
         except Exception:
             return "UNABLE TO GET CHANGELOG INFORMATION"
- 
+
     changelog_lines = latest_changelog.read_text(encoding="utf8").splitlines()
     # remove keep_a_changelog disclaimer
     changelog_content = "\n".join(changelog_lines[:4] + changelog_lines[6:])


### PR DESCRIPTION
Improve new version notifications to let the user know if there is a new testing version available if they are using a testing version.

CDL will also no longer notify you that there is a new version available when you are using a version that has not been uploaded to PyPi yet.