### PR TITLE
refactor: switch to CSV for every log --- general logging fixes

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -110,7 +110,7 @@ class DownloadClient:
             if resp.status == HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
                 media_item.partial_file.unlink()
 
-            await self.client_manager.check_http_status(resp, download=True)
+            await self.client_manager.check_http_status(resp, download=True, origin = media_item.url)
             content_type = resp.headers.get('Content-Type')
 
             media_item.filesize = int(resp.headers.get('Content-Length', '0'))

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -146,10 +146,10 @@ class DownloadClient:
             await save_content(resp.content)
             return True
 
-    async def _append_content(self, media_item, content: aiohttp.StreamReader, update_progress: partial) -> None:
+    async def _append_content(self, media_item: MediaItem, content: aiohttp.StreamReader, update_progress: partial) -> None:
         """Appends content to a file"""
         if not await self.client_manager.manager.download_manager.check_free_space(media_item.download_folder):
-            raise DownloadFailure(status="No Free Space", message="Not enough free space")
+            raise DownloadFailure(status="Insufficient Free Space", message="Not enough free space")
 
         media_item.partial_file.parent.mkdir(parents=True, exist_ok=True)
         if not media_item.partial_file.is_file():

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 from http import HTTPStatus
+from yarl import URL
+from pathlib import Path
 
 if TYPE_CHECKING:
-    from cyberdrop_dl.scraper.crawler import ScrapeItem
     from yaml.constructor import ConstructorError
-    from yarl import URL
-    from pathlib import Path
+    from cyberdrop_dl.scraper.crawler import ScrapeItem
 
 class CDLBaseException(Exception):
     """Base exception for cyberdrop-dl errors"""
@@ -14,7 +15,7 @@ class CDLBaseException(Exception):
         self.ui_message = ui_message
         self.message = message if message else ui_message
         self.origin = origin 
-        if isinstance(origin, ScrapeItem): 
+        if not isinstance(origin, (URL, Path)): 
             self.origin = origin.parents[0] if origin.parents else None
         super().__init__(self.message)
         if status:

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -57,7 +57,7 @@ class DownloadFailure(CDLBaseException):
 class ScrapeFailure(CDLBaseException):
     def __init__(self, status: int, message: Optional[str] = "Scrape Failure" , origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when a scrape fails"""
-        ui_message = f"{status} {HTTPStatus(status).phrase}"
+        ui_message = f"{status} {HTTPStatus(status).phrase}" if isinstance (status, int) else status
         super().__init__(ui_message, message = message, status = status, origin=origin)
 
 class FailedLoginFailure(CDLBaseException):

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -23,54 +23,65 @@ class CDLBaseException(Exception):
             super().__init__(self.status)
 
 class InvalidContentTypeFailure(CDLBaseException):
-    def __init__(self, *, message: str = "Invalid Content Type", origin: Optional[ScrapeItem | URL] = None):
+    def __init__(self, *, message: Optional [str] = None, origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when the content type isn't as expected"""
         ui_message = "Invalid Content Type"
+        message = message or ui_message
         super().__init__(ui_message, message = message, origin=origin)
 
 class NoExtensionFailure(CDLBaseException):
-    def __init__(self, *, message: str = "No File Extension", origin: Optional[ScrapeItem | URL] = None):
+    def __init__(self, *, message: Optional [str] = None, origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when no extension is given for a file"""
         ui_message = "No File Extension"
+        message = message or ui_message
         super().__init__(ui_message, message = message, origin=origin)
 
 
 class PasswordProtected(CDLBaseException):
-    def __init__(self, *, message: str = "File/Folder is password protected", origin: Optional[ScrapeItem | URL] = None ):
+    def __init__(self, *, message: Optional[str] = None, origin: Optional[ScrapeItem | URL] = None ):
         """This error will be thrown when a file is password protected"""
         ui_message = "Password Protected"
+        message = message or "File/Folder is password protected"
         super().__init__(ui_message, message = message, origin=origin)
 
 
 class DDOSGuardFailure(CDLBaseException):
-    def __init__(self, *, message: str = "DDoS-Guard detected", origin: Optional[ScrapeItem | URL] = None):
+    def __init__(self, *, message: Optional[str] = None, origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when DDoS-Guard is detected"""
         ui_message = "DDoS-Guard"
+        message = message or "DDoS-Guard detected"
         super().__init__(ui_message, message = message, origin=origin)
 
 
 class DownloadFailure(CDLBaseException):
-    def __init__(self, status: int, message: Optional[str] = "Download Failure" , origin: Optional[ScrapeItem | URL] = None):
-        """This error will be thrown when a request fails"""
-        try:
-            ui_message = f"{status} {HTTPStatus(status).phrase}" if isinstance (status, int) else status
-        except ValueError:
-            ui_message = status
+    def __init__(self, status: int, message: Optional[str] = None , origin: Optional[ScrapeItem | URL] = None):
+        """This error will be thrown when a download fails"""
+        ui_message = status
+        if isinstance (status, int):
+            try:
+                ui_message = f"{status} {HTTPStatus(status).phrase}"
+            except ValueError:
+                ui_message = f"{status} HTTP Error"
+        message = message or ui_message
         super().__init__(ui_message, message = message, status = status, origin=origin)
 
 class ScrapeFailure(CDLBaseException):
-    def __init__(self, status: int, message: Optional[str] = "Scrape Failure" , origin: Optional[ScrapeItem | URL] = None):
+    def __init__(self, status: int, message: Optional[str] = None, origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when a scrape fails"""
-        try:
-            ui_message = f"{status} {HTTPStatus(status).phrase}" if isinstance (status, int) else status
-        except ValueError:
-            ui_message = status
+        ui_message = status
+        if isinstance (status, int):
+            try:
+                ui_message = f"{status} {HTTPStatus(status).phrase}"
+            except ValueError:
+                ui_message = f"{status} HTTP Error"
+        message = message or ui_message
         super().__init__(ui_message, message = message, status = status, origin=origin)
 
 class FailedLoginFailure(CDLBaseException):
-    def __init__(self, *, message: str = "Failed Login", origin: Optional[ScrapeItem | URL] = None):
+    def __init__(self, *, message: Optional[str] = None , origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when the login fails for a site"""
         ui_message = "Failed Login"
+        message = message or ui_message
         super().__init__(ui_message, message = message, origin=origin)
 
 

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -1,88 +1,80 @@
-from typing import TYPE_CHECKING
-from pathlib import Path
-from yaml.constructor import ConstructorError
+from typing import TYPE_CHECKING, Optional
+from http import HTTPStatus
 
 if TYPE_CHECKING:
     from cyberdrop_dl.scraper.crawler import ScrapeItem
+    from yaml.constructor import ConstructorError
+    from yarl import URL
+    from pathlib import Path
 
-class InvalidContentTypeFailure(Exception):
-    """This error will be thrown when the content type isn't as expected"""
-
-    def __init__(self, *, message: str = "Invalid content type"):
-        self.message = message
+class CDLBaseException(Exception):
+    """Base exception for cyberdrop-dl errors"""
+   
+    def __init__(self, ui_message: str = "Something went wrong", *, message: Optional[str] = None , status: Optional[int]=None, origin: Optional[ScrapeItem | URL | Path] = None):
+        self.ui_message = ui_message
+        self.message = message if message else ui_message
+        self.origin = origin 
+        if isinstance(origin, ScrapeItem): 
+            self.origin = origin.parents[0] if origin.parents else None
         super().__init__(self.message)
+        if status:
+            self.status = status
+            super().__init__(self.status)
 
-class InvalidYamlConfig(Exception):
-    """This error will be thrown when a yaml config file has invalid values"""
+class InvalidContentTypeFailure(CDLBaseException):
+    def __init__(self, *, message: str = "Invalid Content Type", origin: Optional[ScrapeItem | URL] = None):
+        """This error will be thrown when the content type isn't as expected"""
+        ui_message = "Invalid Content Type"
+        super().__init__(ui_message, message = message, origin=origin)
 
+class NoExtensionFailure(CDLBaseException):
+    def __init__(self, *, message: str = "No File Extension", origin: Optional[ScrapeItem | URL] = None):
+        """This error will be thrown when no extension is given for a file"""
+        ui_message = "No File Extension"
+        super().__init__(ui_message, message = message, origin=origin)
+
+
+class PasswordProtected(CDLBaseException):
+    def __init__(self, *, message: str = "File/Folder is password protected", origin: Optional[ScrapeItem | URL] = None ):
+        """This error will be thrown when a file is password protected"""
+        ui_message = "Password Protected"
+        super().__init__(ui_message, message = message, origin=origin)
+
+
+class DDOSGuardFailure(CDLBaseException):
+    def __init__(self, *, message: str = "DDoS-Guard detected", origin: Optional[ScrapeItem | URL] = None):
+        """This error will be thrown when DDoS-Guard is detected"""
+        ui_message = "DDoS-Guard"
+        super().__init__(ui_message, message = message, origin=origin)
+
+
+class DownloadFailure(CDLBaseException):
+    def __init__(self, status: int, message: Optional[str] = "Download Failure" , origin: Optional[ScrapeItem | URL] = None):
+        """This error will be thrown when a request fails"""
+        ui_message = f"{status} {HTTPStatus(status).phrase}"
+        super().__init__(ui_message, message = message, status = status, origin=origin)
+
+class ScrapeFailure(CDLBaseException):
+    def __init__(self, status: int, message: Optional[str] = "Scrape Failure" , origin: Optional[ScrapeItem | URL] = None):
+        """This error will be thrown when a scrape fails"""
+        ui_message = f"{status} {HTTPStatus(status).phrase}"
+        super().__init__(ui_message, message = message, status = status, origin=origin)
+
+class FailedLoginFailure(CDLBaseException):
+    def __init__(self, *, message: str = "Failed Login", origin: Optional[ScrapeItem | URL] = None):
+        """This error will be thrown when the login fails for a site"""
+        ui_message = "Failed Login"
+        super().__init__(ui_message, message = message, origin=origin)
+
+
+class JDownloaderFailure(CDLBaseException):
+    """This error will be thrown for any Jdownloader error"""
+    pass
+
+class InvalidYamlConfig(CDLBaseException):
     def __init__(self, file: Path, e: ConstructorError):
-        self.file = file
+        """This error will be thrown when a yaml config file has invalid values"""
         mark = e.problem_mark if hasattr(e, 'problem_mark') else e
-        self.message = f"ERROR: File '{file}' has an invalid config. Please verify and edit it manually\n {mark}"
-        self.message_rich = self.message.replace("ERROR:", "[bold red]ERROR:[/bold red]")
-        super().__init__(self.message)
-
-
-class NoExtensionFailure(Exception):
-    """This error will be thrown when no extension is given for a file"""
-
-    def __init__(self, *, message: str = "Extension missing for file"):
-        self.message = message
-        super().__init__(self.message)
-
-
-class PasswordProtected(Exception):
-    """This error will be thrown when a file is password protected"""
-
-    def __init__(self,/, scrape_item: 'ScrapeItem'):
-        self.message = "File/Folder is password protected"
-        self.scrape_item = scrape_item
-        super().__init__(self.message)
-
-
-class DDOSGuardFailure(Exception):
-    """This error will be thrown when DDoS-Guard is detected"""
-
-    def __init__(self, status: int, message: str = "DDoS-Guard detected"):
-        self.status = status
-        self.message = message
-        super().__init__(self.message)
-        super().__init__(self.status)
-
-
-class DownloadFailure(Exception):
-    """This error will be thrown when a request fails"""
-
-    def __init__(self, status: int, message: str = "Something went wrong"):
-        self.status = status
-        self.message = message
-        super().__init__(self.message)
-        super().__init__(self.status)
-
-
-class ScrapeFailure(Exception):
-    """This error will be thrown when a request fails"""
-
-    def __init__(self, status: int, message: str = "Something went wrong"):
-        self.status = status
-        self.message = message
-        super().__init__(self.message)
-        super().__init__(self.status)
-
-
-class FailedLoginFailure(Exception):
-    """This error will be thrown when the login fails for a site"""
-
-    def __init__(self, *, status: int, message: str = "Failed login."):
-        self.status = status
-        self.message = message
-        super().__init__(self.message)
-        super().__init__(self.status)
-
-
-class JDownloaderFailure(Exception):
-    """Basic failure template for JDownloader"""
-
-    def __init__(self, message: str = "Something went wrong"):
-        self.message = message
-        super().__init__(self.message)
+        message = f"ERROR: File '{file}' has an invalid config. Please verify and edit it manually\n {mark}"
+        self.message_rich = message.replace("ERROR:", "[bold red]ERROR:[/bold red]")
+        super().__init__('Invalid YAML', message = message, origin = file)

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -51,7 +51,7 @@ class DDOSGuardFailure(CDLBaseException):
 class DownloadFailure(CDLBaseException):
     def __init__(self, status: int, message: Optional[str] = "Download Failure" , origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when a request fails"""
-        ui_message = f"{status} {HTTPStatus(status).phrase}"
+        ui_message = f"{status} {HTTPStatus(status).phrase}" if isinstance (status, int) else status
         super().__init__(ui_message, message = message, status = status, origin=origin)
 
 class ScrapeFailure(CDLBaseException):

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -15,7 +15,7 @@ class CDLBaseException(Exception):
         self.ui_message = ui_message
         self.message = message if message else ui_message
         self.origin = origin 
-        if not isinstance(origin, (URL, Path)): 
+        if origin and not isinstance(origin, (URL, Path)): 
             self.origin = origin.parents[0] if origin.parents else None
         super().__init__(self.message)
         if status:
@@ -52,13 +52,19 @@ class DDOSGuardFailure(CDLBaseException):
 class DownloadFailure(CDLBaseException):
     def __init__(self, status: int, message: Optional[str] = "Download Failure" , origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when a request fails"""
-        ui_message = f"{status} {HTTPStatus(status).phrase}" if isinstance (status, int) else status
+        try:
+            ui_message = f"{status} {HTTPStatus(status).phrase}" if isinstance (status, int) else status
+        except ValueError:
+            ui_message = status
         super().__init__(ui_message, message = message, status = status, origin=origin)
 
 class ScrapeFailure(CDLBaseException):
     def __init__(self, status: int, message: Optional[str] = "Scrape Failure" , origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when a scrape fails"""
-        ui_message = f"{status} {HTTPStatus(status).phrase}" if isinstance (status, int) else status
+        try:
+            ui_message = f"{status} {HTTPStatus(status).phrase}" if isinstance (status, int) else status
+        except ValueError:
+            ui_message = status
         super().__init__(ui_message, message = message, status = status, origin=origin)
 
 class FailedLoginFailure(CDLBaseException):

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -13,7 +13,7 @@ class CDLBaseException(Exception):
    
     def __init__(self, ui_message: str = "Something went wrong", *, message: Optional[str] = None , status: Optional[int]=None, origin: Optional[ScrapeItem | URL | Path] = None):
         self.ui_message = ui_message
-        self.message = message if message else ui_message
+        self.message = message or ui_message
         self.origin = origin 
         if origin and not isinstance(origin, (URL, Path)): 
             self.origin = origin.parents[0] if origin.parents else None
@@ -26,14 +26,12 @@ class InvalidContentTypeFailure(CDLBaseException):
     def __init__(self, *, message: Optional [str] = None, origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when the content type isn't as expected"""
         ui_message = "Invalid Content Type"
-        message = message or ui_message
         super().__init__(ui_message, message = message, origin=origin)
 
 class NoExtensionFailure(CDLBaseException):
     def __init__(self, *, message: Optional [str] = None, origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when no extension is given for a file"""
         ui_message = "No File Extension"
-        message = message or ui_message
         super().__init__(ui_message, message = message, origin=origin)
 
 
@@ -62,7 +60,6 @@ class DownloadFailure(CDLBaseException):
                 ui_message = f"{status} {HTTPStatus(status).phrase}"
             except ValueError:
                 ui_message = f"{status} HTTP Error"
-        message = message or ui_message
         super().__init__(ui_message, message = message, status = status, origin=origin)
 
 class ScrapeFailure(CDLBaseException):
@@ -74,14 +71,12 @@ class ScrapeFailure(CDLBaseException):
                 ui_message = f"{status} {HTTPStatus(status).phrase}"
             except ValueError:
                 ui_message = f"{status} HTTP Error"
-        message = message or ui_message
         super().__init__(ui_message, message = message, status = status, origin=origin)
 
 class FailedLoginFailure(CDLBaseException):
     def __init__(self, *, message: Optional[str] = None , origin: Optional[ScrapeItem | URL] = None):
         """This error will be thrown when the login fails for a site"""
         ui_message = "Failed Login"
-        message = message or ui_message
         super().__init__(ui_message, message = message, origin=origin)
 
 

--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 from multidict import CIMultiDictProxy
 from yarl import URL
 
-from cyberdrop_dl.clients.errors import InvalidContentTypeFailure, DDOSGuardFailure, ScrapeFailure
+from cyberdrop_dl.clients.errors import InvalidContentTypeFailure, DDOSGuardFailure
 from cyberdrop_dl.utils.utilities import log
 
 if TYPE_CHECKING:

--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -16,13 +16,14 @@ from cyberdrop_dl.utils.utilities import log
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.client_manager import ClientManager
+    from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
 
 
 def limiter(func):
     """Wrapper handles limits for scrape session"""
 
     @wraps(func)
-    async def wrapper(self, *args, **kwargs):
+    async def wrapper(self: ScraperClient, *args, **kwargs):
         domain_limiter = await self.client_manager.get_rate_limiter(args[0])
         async with self.client_manager.session_limit:
             await self._global_limiter.acquire()
@@ -63,10 +64,10 @@ class ScraperClient:
             self.trace_configs.append(trace_config)
 
     @limiter
-    async def flaresolverr(self, domain: str, url: URL, client_session: ClientSession) -> str:
+    async def flaresolverr(self, domain: str, url: URL, client_session: ClientSession, origin: Optional[ ScrapeItem | URL] = None) -> str:
         """Returns the resolved URL from the given URL"""
         if not self.client_manager.flaresolverr:
-            raise DDOSGuardFailure(message="FlareSolverr is not configured")
+            raise DDOSGuardFailure(message="FlareSolverr is not configured", origin=origin)
 
         headers = {**self._headers, **{"Content-Type": "application/json"}}
         data = {"cmd": "request.get", "url": str(url), "maxTimeout": 60000}
@@ -74,66 +75,66 @@ class ScraperClient:
         async with client_session.post(f"http://{self.client_manager.flaresolverr}/v1", headers=headers,
                                     ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy, json=data) as response:
-            json_obj = await response.json()
+            json_obj: dict = await response.json()
             status = json_obj.get("status")
             if status != "ok":
-                raise DDOSGuardFailure(message="Failed to resolve URL with flaresolverr")
+                raise DDOSGuardFailure(message="Failed to resolve URL with flaresolverr", origin=origin)
 
             return json_obj.get("solution").get("response")
 
     @limiter
-    async def get_BS4(self, domain: str, url: URL, client_session: ClientSession) -> BeautifulSoup:
+    async def get_BS4(self, domain: str, url: URL, client_session: ClientSession, origin: Optional[ ScrapeItem | URL] = None) -> BeautifulSoup:
         """Returns a BeautifulSoup object from the given URL"""
         async with client_session.get(url, headers=self._headers, ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy) as response:
             try:
-                await self.client_manager.check_http_status(response)
+                await self.client_manager.check_http_status(response, origin=origin)
             except DDOSGuardFailure:
-                response_text = await self.flaresolverr(domain, url)
+                response_text = await self.flaresolverr(domain, url, origin=origin)
                 return BeautifulSoup(response_text, 'html.parser')
             content_type = response.headers.get('Content-Type')
             assert content_type is not None
             if not any(s in content_type.lower() for s in ("html", "text")):
-                raise InvalidContentTypeFailure(message=f"Received {content_type}, was expecting text")
+                raise InvalidContentTypeFailure(message=f"Received {content_type}, was expecting text", origin=origin )
             text = await response.text()
             return BeautifulSoup(text, 'html.parser')
 
     @limiter
-    async def get_BS4_and_return_URL(self, domain: str, url: URL, client_session: ClientSession) -> tuple[
+    async def get_BS4_and_return_URL(self, domain: str, url: URL, client_session: ClientSession, origin: Optional[ ScrapeItem | URL] = None) -> tuple[
         BeautifulSoup, URL]:
         """Returns a BeautifulSoup object and response URL from the given URL"""
         async with client_session.get(url, headers=self._headers, ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy) as response:
-            await self.client_manager.check_http_status(response)
+            await self.client_manager.check_http_status(response, origin=origin)
             content_type = response.headers.get('Content-Type')
             assert content_type is not None
             if not any(s in content_type.lower() for s in ("html", "text")):
-                raise InvalidContentTypeFailure(message=f"Received {content_type}, was expecting text")
+                raise InvalidContentTypeFailure(message=f"Received {content_type}, was expecting text", origin=origin)
             text = await response.text()
             return BeautifulSoup(text, 'html.parser'), URL(response.url)
 
     @limiter
     async def get_json(self, domain: str, url: URL, params: Optional[Dict] = None, headers_inc: Optional[Dict] = None,
-                    client_session: ClientSession = None) -> Dict:
+                    client_session: ClientSession = None, origin: Optional[ ScrapeItem | URL] = None) -> Dict:
         """Returns a JSON object from the given URL"""
         headers = {**self._headers, **headers_inc} if headers_inc else self._headers
 
         async with client_session.get(url, headers=headers, ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy, params=params) as response:
-            await self.client_manager.check_http_status(response)
+            await self.client_manager.check_http_status(response, origin=origin)
             content_type = response.headers.get('Content-Type')
             assert content_type is not None
             if 'json' not in content_type.lower():
-                raise InvalidContentTypeFailure(message=f"Received {content_type}, was expecting JSON")
+                raise InvalidContentTypeFailure(message=f"Received {content_type}, was expecting JSON", origin=origin)
             return await response.json()
 
     @limiter
-    async def get_text(self, domain: str, url: URL, client_session: ClientSession) -> str:
+    async def get_text(self, domain: str, url: URL, client_session: ClientSession, origin: Optional[ ScrapeItem | URL] = None) -> str:
         """Returns a text object from the given URL"""
         async with client_session.get(url, headers=self._headers, ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy) as response:
             try:
-                await self.client_manager.check_http_status(response)
+                await self.client_manager.check_http_status(response, origin=origin)
             except DDOSGuardFailure:
                 response_text = await self.flaresolverr(domain, url)
                 return response_text
@@ -142,11 +143,11 @@ class ScraperClient:
 
     @limiter
     async def post_data(self, domain: str, url: URL, client_session: ClientSession, data: Dict,
-                        req_resp: bool = True, raw: Optional[bool] = False) -> Dict:
+                        req_resp: bool = True, raw: Optional[bool] = False, origin: Optional[ ScrapeItem | URL] = None) -> Dict:
         """Returns a JSON object from the given URL when posting data. If raw == True, returns raw binary data of response"""
         async with client_session.post(url, headers=self._headers, ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy, data=data) as response:
-            await self.client_manager.check_http_status(response)
+            await self.client_manager.check_http_status(response, origin=origin)
             if req_resp:
                 content = await response.content.read()
                 if raw:

--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -66,7 +66,7 @@ class ScraperClient:
     async def flaresolverr(self, domain: str, url: URL, client_session: ClientSession) -> str:
         """Returns the resolved URL from the given URL"""
         if not self.client_manager.flaresolverr:
-            raise ScrapeFailure(status="DDOS-Guard", message="FlareSolverr is not configured")
+            raise DDOSGuardFailure(message="FlareSolverr is not configured")
 
         headers = {**self._headers, **{"Content-Type": "application/json"}}
         data = {"cmd": "request.get", "url": str(url), "maxTimeout": 60000}
@@ -77,7 +77,7 @@ class ScraperClient:
             json_obj = await response.json()
             status = json_obj.get("status")
             if status != "ok":
-                raise ScrapeFailure(status="DDOS-Guard", message="Failed to resolve URL with flaresolverr")
+                raise DDOSGuardFailure(message="Failed to resolve URL with flaresolverr")
 
             return json_obj.get("solution").get("response")
 

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -193,6 +193,7 @@ class Downloader:
             if not can_download:
                 if reason == 0:
                     await self.manager.progress_manager.download_stats_progress.add_failure("Insufficient Free Space")
+                    await self.manager.log_manager.write_download_error_log(media_item.url,"Insufficient Free Space", media_item.referer)
                     await self.manager.progress_manager.download_progress.add_failed()
                 else:
                     await self.manager.progress_manager.download_progress.add_skipped()

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -79,8 +79,11 @@ def retry(f):
                     e_log_message = "See Log for Details"
                     e_ui_failure = "Unknown"
 
+                await log(f"{self.log_prefix} failed: {media_item.url} with error: {e_log_detail}", 40, exc_info = exc_info)
+
+            if not exc_info:
+                await log(f"{self.log_prefix} failed: {media_item.url} with error: {e_log_detail}", 40)
             await self.attempt_task_removal(media_item)
-            await log(f"{self.log_prefix} failed: {media_item.url} with error: {e_log_detail}", 40, exc_info = exc_info)
             await self.manager.log_manager.write_download_error_log(media_item.url, e_log_message, e_origin)
             await self.manager.progress_manager.download_stats_progress.add_failure(e_ui_failure)
             await self.manager.progress_manager.download_progress.add_failed()
@@ -238,5 +241,5 @@ class Downloader:
             raise DownloadFailure(status=getattr(err, "status", type(err).__name__), message=message)
 
     async def is_failed(self, status: int):
-        return any((await is_4xx_client_error(status) and status != HTTPStatus.TOO_MANY_REQUESTS),
-                    status in (HTTPStatus.SERVICE_UNAVAILABLE, HTTPStatus.BAD_GATEWAY, CustomHTTPStatus.WEB_SERVER_IS_DOWN))
+        return any((await is_4xx_client_error(status) and status != HTTPStatus.TOO_MANY_REQUESTS,
+                    status in (HTTPStatus.SERVICE_UNAVAILABLE, HTTPStatus.BAD_GATEWAY, CustomHTTPStatus.WEB_SERVER_IS_DOWN)))

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -12,7 +12,8 @@ import aiohttp
 import filedate
 
 from cyberdrop_dl.clients.download_client import is_4xx_client_error
-from cyberdrop_dl.clients.errors import DownloadFailure, InvalidContentTypeFailure, DDOSGuardFailure
+from cyberdrop_dl.clients.errors import DownloadFailure, CDLBaseException
+from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
 from cyberdrop_dl.utils.utilities import CustomHTTPStatus, log
 
 if TYPE_CHECKING:
@@ -26,75 +27,64 @@ def retry(f):
 
     @wraps(f)
     async def wrapper(self: Downloader, *args, **kwargs):
+        media_item: MediaItem = args[0]
         while True:
+            e_origin = exc_info = None
             try:
                 return await f(self, *args, **kwargs)
             except DownloadFailure as e:
-                media_item: MediaItem = args[0]
                 await self.attempt_task_removal(media_item)
+
+                max_attempts = self.manager.config_manager.global_settings_data['Rate_Limiting_Options']['download_attempts']
+                if self.manager.config_manager.settings_data['Download_Options']['disable_download_attempt_limit']:
+                    max_attempts = 1
 
                 if e.status != 999:
                     media_item.current_attempt += 1
 
-                if not self.manager.config_manager.settings_data['Download_Options']['disable_download_attempt_limit']:
-                    if media_item.current_attempt >= \
-                            self.manager.config_manager.global_settings_data['Rate_Limiting_Options'][
-                                'download_attempts']:
-                        if hasattr(e, "status"):
-                            await self.manager.progress_manager.download_stats_progress.add_failure(e.status)
-                            if hasattr(e, "message"):
-                                await log(
-                                    f"{self.log_prefix} failed: {media_item.url} with status {e.status} and message {e.message}",
-                                    40)
-                                await self.manager.log_manager.write_download_error_log(media_item.url,
-                                                                                        f" {e.status} - {e.message}")
-                            else:
-                                await log(f"{self.log_prefix} failed: {media_item.url} with status {e.status}", 40)
-                                await self.manager.log_manager.write_download_error_log(media_item.url, f" {e.status}")
-                        else:
-                            await self.manager.progress_manager.download_stats_progress.add_failure("Unknown")
-                            await self.manager.log_manager.write_download_error_log(media_item.url,
-                                                                                    " See Log for Details")
-                            await log(f"{self.log_prefix} failed: {media_item.url} with error {e}", 40)
-                        await self.manager.progress_manager.download_progress.add_failed()
-                        break
-
-                if hasattr(e, "status"):
-                    if hasattr(e, "message"):
-                        await log(f"{self.log_prefix} failed: {media_item.url} with status {e.status} and message {e.message}",
-                                40)
-                    else:
-                        await log(f"{self.log_prefix} failed: {media_item.url} with status {e.status}", 40)
+                if hasattr(e, "status") and hasattr(e, "message"):
+                    e_log_detail = f"with status {e.status} and message {e.message}"
+                elif hasattr(e, "status"):
+                    e_log_detail = f"with status {e.status}"
                 else:
-                    await log(f"{self.log_prefix} failed: {media_item.url} with error {e}", 40)
+                    e_log_detail = f"with error {e}"
+
+                await log(f"{self.log_prefix} failed: {media_item.url} {e_log_detail}",40)
+
+                if media_item.current_attempt >= max_attempts:
+                    await self.manager.progress_manager.download_stats_progress.add_failure(e.ui_message)
+                    await self.manager.log_manager.write_download_error_log(media_item.url, e.message, media_item.referer)
+                    await self.manager.progress_manager.download_progress.add_failed()
+                    break
+
                 await log(f"Retrying {self.log_prefix.lower()}: {media_item.url} , attempt {media_item.current_attempt}", 20)
+                continue
 
-            except DDOSGuardFailure as e:
-                media_item = args[0]
-                await self.attempt_task_removal(media_item)
-                await log(f"{self.log_prefix} failed: {media_item.url} with error {e}", 40, exc_info = True)
-                await self.manager.log_manager.write_download_error_log(media_item.url, " DDOSGuard")
-                await self.manager.progress_manager.download_stats_progress.add_failure("DDOSGuard")
-                await self.manager.progress_manager.download_progress.add_failed()
-                break
 
-            except InvalidContentTypeFailure as e:
-                media_item = args[0]
-                await self.attempt_task_removal(media_item)
-                await log(f"{self.log_prefix} failed: {media_item.url} received Invalid Content. {e.message}", 40)
-                await self.manager.log_manager.write_download_error_log(media_item.url, " Invalid Content Received")
-                await self.manager.progress_manager.download_stats_progress.add_failure("Invalid Content Type")
-                await self.manager.progress_manager.download_progress.add_failed()
-                break
+            except CDLBaseException as err:
+                e_log_detail =  e_log_message = err.message
+                e_ui_failure = err.ui_message
+                e_origin = err.origin
+               
+            except RealDebridError as err:
+                e_log_detail = e_log_message  = f"RealDebridError - {err.error}"
+                e_ui_failure = f"RD - {err.error}"
 
-            except Exception as e:
-                media_item = args[0]
-                await log(f"{self.log_prefix} failed: {media_item.url} with error {e}", 40, exc_info = True)
-                await self.attempt_task_removal(media_item)
-                await self.manager.log_manager.write_download_error_log(media_item.url, " See Log For Details")
-                await self.manager.progress_manager.download_stats_progress.add_failure("Unknown")
-                await self.manager.progress_manager.download_progress.add_failed()
-                break
+            except Exception as err:
+                exc_info = True
+                if hasattr(err, 'status') and hasattr(err, 'message'):
+                    e_log_detail = e_log_message = e_ui_failure = f"{err.status} - {err.message}"
+                else:
+                    e_log_detail = str(err)
+                    e_log_message = "See Log for Details"
+                    e_ui_failure = "Unknown"
+
+            await self.attempt_task_removal(media_item)
+            await log(f"{self.log_prefix} failed: {media_item.url} with error: {e_log_detail}", 40, exc_info = exc_info)
+            await self.manager.log_manager.write_download_error_log(media_item.url, e_log_message, e_origin)
+            await self.manager.progress_manager.download_stats_progress.add_failure(e_ui_failure)
+            await self.manager.progress_manager.download_progress.add_failed()
+            break
 
     return wrapper
 
@@ -215,35 +205,38 @@ class Downloader:
 
         except (aiohttp.ClientPayloadError, aiohttp.ClientOSError, aiohttp.ClientResponseError, ConnectionResetError,
                 DownloadFailure, FileNotFoundError, PermissionError, aiohttp.ServerDisconnectedError,
-                asyncio.TimeoutError, aiohttp.ServerTimeoutError) as e:
-            if hasattr(e, "status"):
-                if ((await is_4xx_client_error(e.status) and e.status != HTTPStatus.TOO_MANY_REQUESTS)
-                        or e.status == HTTPStatus.SERVICE_UNAVAILABLE
-                        or e.status == HTTPStatus.BAD_GATEWAY
-                        or e.status == CustomHTTPStatus.WEB_SERVER_IS_DOWN):
-                    await self.manager.progress_manager.download_progress.add_failed()
-                    await self.manager.progress_manager.download_stats_progress.add_failure(e.status)
-                    await self.attempt_task_removal(media_item)
-                    if hasattr(e, "message"):
-                        if not e.message:
-                            e.message = f"{self.log_prefix} failed"
-                        await log(f"{self.log_prefix} failed: {media_item.url} with status {e.status} and message {e.message}",
-                                40)
-                        await self.manager.log_manager.write_download_error_log(media_item.url,
-                                                                                f" {e.status} - {e.message}")
-                    else:
-                        await log(f"{self.log_prefix} failed: {media_item.url} with status {e.status}", 40)
-                        await self.manager.log_manager.write_download_error_log(media_item.url, f" {e.status}")
-                    return
+                asyncio.TimeoutError, aiohttp.ServerTimeoutError) as err:
+            
+            e_origin = media_item.referer
+            
+            if hasattr(err, "status") and await self.is_failed(err.status):
+                e_ui_failure = err.ui_message if isinstance(err, CDLBaseException) else err.status
+          
+                if hasattr(err, 'message'):
+                    e_log_detail = e_log_message = f"{err.status} - {err.message}"
+                else:
+                    e_log_detail = str(err)
+                    e_log_message = f"{err.status}"
+                    
+                await log(f"{self.log_prefix} failed: {media_item.url} with error: {e_log_detail}", 40)
+                await self.manager.log_manager.write_download_error_log(media_item.url, e_log_message, e_origin)
+                await self.manager.progress_manager.download_stats_progress.add_failure(e_ui_failure)
+                await self.manager.progress_manager.download_progress.add_failed()
+                await self.attempt_task_removal(media_item)
+                return
 
             if isinstance(media_item.partial_file, Path) and media_item.partial_file.is_file():
                 size = media_item.partial_file.stat().st_size
                 if media_item.filename in self._current_attempt_filesize and self._current_attempt_filesize[
                     media_item.filename] >= size:
-                    raise DownloadFailure(status=getattr(e, "status", type(e).__name__), message=f"{self.log_prefix} failed")
+                    raise DownloadFailure(status=getattr(err, "status", type(err).__name__), message=f"{self.log_prefix} failed")
                 self._current_attempt_filesize[media_item.filename] = size
                 media_item.current_attempt = 0
                 raise DownloadFailure(status=999, message="Download timeout reached, retrying")
 
-            message = e.message if hasattr(e, "message") else repr(e)
-            raise DownloadFailure(status=getattr(e, "status", type(e).__name__), message=message)
+            message = err.message if hasattr(err, "message") else repr(err)
+            raise DownloadFailure(status=getattr(err, "status", type(err).__name__), message=message)
+
+    async def is_failed(self, status: int):
+        return any((await is_4xx_client_error(status) and status != HTTPStatus.TOO_MANY_REQUESTS),
+                    status in (HTTPStatus.SERVICE_UNAVAILABLE, HTTPStatus.BAD_GATEWAY, CustomHTTPStatus.WEB_SERVER_IS_DOWN))

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -43,7 +43,7 @@ def retry(f):
                     media_item.current_attempt += 1
 
                 if hasattr(e, "status") and hasattr(e, "message"):
-                    e_log_detail = f"with status {e.status} and message {e.message}"
+                    e_log_detail = f"with status {e.status} and message: {e.message}"
                 elif hasattr(e, "status"):
                     e_log_detail = f"with status {e.status}"
                 else:
@@ -57,7 +57,7 @@ def retry(f):
                     await self.manager.progress_manager.download_progress.add_failed()
                     break
 
-                await log(f"Retrying {self.log_prefix.lower()}: {media_item.url} , attempt {media_item.current_attempt}", 20)
+                await log(f"Retrying {self.log_prefix.lower()}: {media_item.url} ,retry attempt: {media_item.current_attempt+1}", 20)
                 continue
 
 
@@ -238,7 +238,7 @@ class Downloader:
                 media_item.current_attempt = 0
                 raise DownloadFailure(status=999, message="Download timeout reached, retrying")
 
-            message = err.message if hasattr(err, "message") else repr(err)
+            message = err.message if hasattr(err, "message") else str(err)
             raise DownloadFailure(status=getattr(err, "status", type(err).__name__), message=message)
 
     async def is_failed(self, status: int):

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -70,10 +70,6 @@ async def runtime(manager: Manager) -> None:
 async def post_runtime(manager: Manager) -> None:
     """Actions to complete after main runtime, and before ui shutdown"""
 
-     # Skip clearing console if running with no UI
-    if not manager.args_manager.no_ui:
-        Console().clear()
-        
     await log_spacer(20)
     await log_with_color(f"Running Post-Download Processes For Config: {manager.config_manager.loaded_config}...\n", "green", 20)
     #checking and removing dupes
@@ -91,8 +87,6 @@ async def post_runtime(manager: Manager) -> None:
     if manager.config_manager.settings_data['Runtime_Options']['update_last_forum_post']:
         await manager.log_manager.update_last_forum_post()
     
-    await manager.progress_manager.print_stats()
-
 
 async def director(manager: Manager) -> None:
     """Runs the program and handles the UI"""
@@ -175,15 +169,18 @@ async def director(manager: Manager) -> None:
             except Exception:
                 await log("\nAn error occurred, please report this to the developer:", 50, exc_info=True)
                 exit(1)
-
+        
+        await log_spacer(20)
+        await manager.progress_manager.print_stats()
         if not manager.args_manager.all_configs or not list(set(configs) - set(configs_ran)):
             break
 
+    await log_spacer(20)
     await log("Checking for Updates...", 20)
     await check_latest_pypi()
+    await log_spacer(20)
     await log("Closing Program...", 20)
     await manager.close()
-    await log_spacer(20)
     await log_with_color("Finished downloading. Enjoy :)", 'green', 20)
 
 

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -177,34 +177,9 @@ async def director(manager: Manager) -> None:
                 await log("\nAn error occurred, please report this to the developer:", 50, exc_info=True)
                 exit(1)
 
-        # Skip clearing console if running with no UI
-        if not manager.args_manager.no_ui:
-            clear_screen_proc = await asyncio.create_subprocess_shell('cls' if os.name == 'nt' else 'clear')
-            await clear_screen_proc.wait()
-        else:
-            print('\n\n')
-
-        await log_with_color(f"Running Post-Download Processes For Config: {manager.config_manager.loaded_config}...", "green", 20)
-        if isinstance(manager.args_manager.sort_downloads, bool):
-            if manager.args_manager.sort_downloads:
-                sorter = Sorter(manager)
-                await sorter.sort()
-        elif manager.config_manager.settings_data['Sorting']['sort_downloads'] and not manager.args_manager.retry_any:
-            sorter = Sorter(manager)
-            await sorter.sort()
-        await check_partials_and_empty_folders(manager)
-        
-        if manager.config_manager.settings_data['Runtime_Options']['update_last_forum_post']:
-            await log("Updating Last Forum Post...", 20)
-            await manager.log_manager.update_last_forum_post()
-            
-        
         # add the stuff here
-
-        
         await log("Printing Stats...", 20)
         await manager.progress_manager.print_stats()
-
         await log("Checking for Program End...", 20)
         if not manager.args_manager.all_configs or not list(set(configs) - set(configs_ran)):
             break

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import ssl
 from http import HTTPStatus
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import aiohttp
 import certifi
@@ -18,7 +18,14 @@ from cyberdrop_dl.utils.utilities import CustomHTTPStatus
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from cyberdrop_dl.scraper.crawler import ScrapeItem
+    from yarl import URL
 
+
+DOWNLOAD_ERROR_ETAGS = {
+    "d835884373f4d6c8f24742ceabe74946": "Imgur image has been removed",
+    "65b7753c-528a":"SC Scrape Image"
+}
 
 class ClientManager:
     """Creates a 'client' that can be referenced by scraping or download sessions"""
@@ -80,49 +87,37 @@ class ClientManager:
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
-    async def check_http_status(self, response: ClientResponse, download: bool = False) -> None:
+    async def check_http_status(self, response: ClientResponse, download: bool = False, scrape_item: Optional[ScrapeItem | URL]= None) -> None:
         """Checks the HTTP status code and raises an exception if it's not acceptable"""
         status = response.status
         headers = response.headers
 
-        if download:
-            if headers.get('ETag') == '"d835884373f4d6c8f24742ceabe74946"':
-                raise DownloadFailure(status=HTTPStatus.NOT_FOUND, message="Imgur image has been removed")
-            if headers.get('ETag') == '"65b7753c-528a"':
-                raise DownloadFailure(status=HTTPStatus.NOT_FOUND, message="SC Scrape Image")
+        if download and headers.get('ETag') in DOWNLOAD_ERROR_ETAGS:
+            message = DOWNLOAD_ERROR_ETAGS.get(headers.get('ETag'))
+            raise DownloadFailure(HTTPStatus.NOT_FOUND, message=message, origin = scrape_item)
 
         if HTTPStatus.OK <= status < HTTPStatus.BAD_REQUEST:
             return
-
-        if "gofile" in response.url.host.lower():
+        
+        if any({domain in response.url.host.lower() for domain in ("gofile","imgur")}):
             try:
-                JSON_Resp = await response.json()
-                if "notFound" in JSON_Resp["status"]:
-                    raise ScrapeFailure(404, "Does Not Exist")
-            except ContentTypeError:
-                pass
-
-        if "imgur" in response.url.host.lower():
-            try:
-                JSON_Resp = await response.json()
+                JSON_Resp: dict = await response.json()
                 if "status" in JSON_Resp:
-                    raise ScrapeFailure(JSON_Resp['status'], JSON_Resp['data']['error'])
+                    if "notFound" in JSON_Resp["status"]:
+                        raise ScrapeFailure(HTTPStatus.NOT_FOUND, origin = scrape_item)
+                    if JSON_Resp.get('data') and 'error' in JSON_Resp['data']:
+                        raise ScrapeFailure(JSON_Resp['status'], JSON_Resp['data']['error'], origin = scrape_item)
             except ContentTypeError:
                 pass
-
-        try:
-            phrase = HTTPStatus(status).phrase
-        except ValueError:
-            phrase = "Unknown"
 
         response_text = await response.text()
         if "<title>DDoS-Guard</title>" in response_text:
-            raise DDOSGuardFailure(status="DDOS-Guard", message="DDoS-Guard detected")
+            raise DDOSGuardFailure(origin = scrape_item)
 
         if not headers.get('Content-Type'):
-            raise DownloadFailure(status=CustomHTTPStatus.IM_A_TEAPOT, message="No content-type in response header")
+            raise DownloadFailure(status=CustomHTTPStatus.IM_A_TEAPOT, message="No content-type in response header", origin = scrape_item)
 
-        raise DownloadFailure(status=status, message=f"HTTP status code {status}: {phrase}")
+        raise DownloadFailure(status=status, origin = scrape_item )
 
     async def check_bunkr_maint(self, headers):
         if headers.get('Content-Length') == "322509" and headers.get('Content-Type') == "video/mp4":

--- a/cyberdrop_dl/managers/live_manager.py
+++ b/cyberdrop_dl/managers/live_manager.py
@@ -1,70 +1,61 @@
+from __future__ import annotations
 from contextlib import asynccontextmanager
-
+from typing import TYPE_CHECKING
 from rich.live import Live
+from rich.console import Console
 
 from cyberdrop_dl.managers.console_manager import console
 from cyberdrop_dl.utils.utilities import log
 
+if TYPE_CHECKING:
+    from cyberdrop_dl.managers.manager import Manager
+    from rich.layout import Layout
+
 
 class LiveManager:
-    def __init__(self, manager):
+    def __init__(self, manager: Manager):
         self.manager = manager
         self.live = Live(auto_refresh=True,
                         refresh_per_second=self.manager.config_manager.global_settings_data['UI_Options'][
                             'refresh_rate'], console=console)
 
     @asynccontextmanager
-    async def get_main_live(self, stop=False):
+    async def get_live(self, layout: Layout, stop=False):
         try:
             if self.manager.args_manager.no_ui:
                 yield
             else:
                 self.live.start()
-                self.live.update(self.manager.progress_manager.layout, refresh=True)
+                self.live.update(layout, refresh=True)
                 yield self.live
             if stop:
                 self.live.stop()
+                if not self.manager.args_manager.no_ui:
+                    Console().clear()
         except Exception as e:
-            await log(f"Issue with rich live {e}", level=10, exc_info=True)
+            await log(f"Issue with rich live {e}", level=10, exc_info=True)    
+
+    @asynccontextmanager
+    async def get_main_live(self, stop=False):
+        "main UI startup and context manager"
+        layout = self.manager.progress_manager.layout
+        async with self.get_live(layout, stop=stop) as live:
+            yield live   
 
     @asynccontextmanager
     async def get_remove_file_via_hash_live(self, stop=False):
-        try:
-            if self.manager.args_manager.no_ui:
-                yield
-            else:
-                self.live.start()
-                self.live.update(self.manager.progress_manager.hash_remove_layout, refresh=True)
-                yield
-            if stop:
-                self.live.stop()
-        except Exception as e:
-            await log(f"Issue with rich live {e}", level=10, exc_info=True)
+        layout = self.manager.progress_manager.hash_remove_layout
+        async with self.get_live(layout, stop=stop) as live:
+            yield live   
 
     @asynccontextmanager
     async def get_hash_live(self, stop=False):
-        try:
-            if self.manager.args_manager.no_ui:
-                yield
-            else:
-                self.live.start()
-                self.live.update(self.manager.progress_manager.hash_layout, refresh=True)
-                yield
-            if stop:
-                self.live.stop()
-        except Exception as e:
-            await log(f"Issue with rich live {e}", level=10, exc_info=True)
+        layout = self.manager.progress_manager.hash_layout
+        async with self.get_live(layout, stop=stop) as live:
+            yield live   
 
     @asynccontextmanager
     async def get_sort_live(self, stop=False):
-        try:
-            if self.manager.args_manager.no_ui:
-                yield
-            else:
-                self.live.start()
-                self.live.update(self.manager.progress_manager.sort_layout, refresh=True)
-                yield
-            if stop:
-                self.live.stop()
-        except Exception as e:
-            await log(f"Issue with rich live {e}", level=10, exc_info=True)
+        layout = self.manager.progress_manager.sort_layout
+        async with self.get_live(layout, stop=stop) as live:
+            yield live   

--- a/cyberdrop_dl/managers/live_manager.py
+++ b/cyberdrop_dl/managers/live_manager.py
@@ -1,4 +1,3 @@
-import traceback
 from contextlib import asynccontextmanager
 
 from rich.live import Live

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -180,6 +180,7 @@ class Manager:
         print_settings['Files']['input_file'] = str(print_settings['Files']['input_file'])
         print_settings['Files']['download_folder'] = str(print_settings['Files']['download_folder'])
         print_settings["Logs"]["log_folder"] = str(print_settings["Logs"]["log_folder"])
+        print_settings["Logs"]["webhook_url"] = bool(print_settings["Logs"]["webhook_url"])
         print_settings['Sorting']['sort_folder'] = str(print_settings['Sorting']['sort_folder'])
         print_settings['Sorting']['scan_folder'] = str(print_settings['Sorting']['scan_folder']) if str(
             print_settings['Sorting']['scan_folder']) else ""

--- a/cyberdrop_dl/managers/path_manager.py
+++ b/cyberdrop_dl/managers/path_manager.py
@@ -88,9 +88,11 @@ class PathManager:
 
         for log_config_name, log_internal_name in log_options_map.items():
             file_name = Path(getattr(log_args_config, log_config_name, None) or log_settings_config[log_config_name])
+            file_ext = '.log' if log_internal_name == 'main_log' else '.csv'
             if log_settings_config['rotate_logs']:
-                file_name = file_name.with_name(f"{file_name.stem}__{current_time_iso}{file_name.suffix}")
-            setattr(self, log_internal_name, self.log_dir / file_name)
+                file_name = f"{file_name.stem}__{current_time_iso}{file_name.suffix}"
+            log_path = self.log_dir.joinpath(file_name).with_suffix(file_ext)
+            setattr(self, log_internal_name, log_path)
 
         self.log_dir.mkdir(parents=True, exist_ok=True)
         if not self.input_file.is_file():

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -69,9 +69,12 @@ class ProgressManager:
         await log_with_color(f"Downloaded {self.download_progress.completed_files} files", "green", 20)
         await log_with_color(f"Previously Downloaded {self.download_progress.previously_completed_files} files",
                             "yellow", 20)
-
         await log_with_color(f"Skipped By Config {self.download_progress.skipped_files} files", "yellow", 20)
         await log_with_color(f"Failed {self.download_stats_progress.failed_files} files", "red", 20)
+
+        await log_with_color("\nUnsupported URLs Stats:", "cyan", 20)
+        await log_with_color(f"Sent to Jdownloader: {self.scrape_stats_progress.sent_to_jdownloader}", "yellow", 20)
+        await log_with_color(f"Skipped: {self.scrape_stats_progress.unsupported_urls_skipped}", "yellow", 20)
 
         await log_with_color("\nDupe Stats:", "cyan", 20)
         await log_with_color(f"Previously Hashed {self.hash_progress.prev_hashed_files} files", "yellow", 20)
@@ -88,9 +91,6 @@ class ProgressManager:
 
         scrape_failures = await self.scrape_stats_progress.return_totals()
         await log_with_color("\nScrape Failures:", "cyan", 20)
-        await log_with_color(f"Unsupported URLs, Sent to Jdownloader: {self.scrape_stats_progress.sent_to_jdownloader}", "yellow", 20)
-        await log_with_color(f"Unsupported URLs, Skipped: {self.scrape_stats_progress.unsupported_urls_skipped}", "yellow", 20)
-        await log_with_color(f"Unsupported URLs, Total: {self.scrape_stats_progress.unsupported_urls}", "yellow", 20)
         for key, value in scrape_failures.items():
             await log_with_color(f"Scrape Failures ({key}): {value}", "red", 20)
 

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -10,7 +10,7 @@ from cyberdrop_dl.ui.progress.hash_progress import HashProgress
 from cyberdrop_dl.ui.progress.scraping_progress import ScrapingProgress
 from cyberdrop_dl.ui.progress.sort_progress import SortProgress
 from cyberdrop_dl.ui.progress.statistic_progress import DownloadStatsProgress, ScrapeStatsProgress
-from cyberdrop_dl.utils.utilities import log_with_color, get_log_output_text
+from cyberdrop_dl.utils.utilities import log_with_color, get_log_output_text, log, log_spacer
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -65,40 +65,48 @@ class ProgressManager:
 
     async def print_stats(self) -> None:
         """Prints the stats of the program"""
-        await log_with_color("\nDownload Stats:", "cyan", 20)
-        await log_with_color(f"Downloaded {self.download_progress.completed_files} files", "green", 20)
-        await log_with_color(f"Previously Downloaded {self.download_progress.previously_completed_files} files",
+        await log_spacer(20)
+        await log("Printing Stats...\n", 20)
+        await log_with_color("Download Stats:", "cyan", 20)
+        await log_with_color(f"  Downloaded {self.download_progress.completed_files} files", "green", 20)
+        await log_with_color(f"  Previously Downloaded {self.download_progress.previously_completed_files} files",
                             "yellow", 20)
-        await log_with_color(f"Skipped By Config {self.download_progress.skipped_files} files", "yellow", 20)
-        await log_with_color(f"Failed {self.download_stats_progress.failed_files} files", "red", 20)
+        await log_with_color(f"  Skipped By Config {self.download_progress.skipped_files} files", "yellow", 20)
+        await log_with_color(f"  Failed {self.download_stats_progress.failed_files} files", "red", 20)
 
-        await log_with_color("\nUnsupported URLs Stats:", "cyan", 20)
-        await log_with_color(f"Sent to Jdownloader: {self.scrape_stats_progress.sent_to_jdownloader}", "yellow", 20)
-        await log_with_color(f"Skipped: {self.scrape_stats_progress.unsupported_urls_skipped}", "yellow", 20)
+        await log_spacer(20)
+        await log_with_color("Unsupported URLs Stats:", "cyan", 20)
+        await log_with_color(f"  Sent to Jdownloader: {self.scrape_stats_progress.sent_to_jdownloader}", "yellow", 20)
+        await log_with_color(f"  Skipped: {self.scrape_stats_progress.unsupported_urls_skipped}", "yellow", 20)
 
-        await log_with_color("\nDupe Stats:", "cyan", 20)
-        await log_with_color(f"Previously Hashed {self.hash_progress.prev_hashed_files} files", "yellow", 20)
-        await log_with_color(f"Newly Hashed {self.hash_progress.hashed_files} files", "yellow", 20)
-        await log_with_color(f"Removed From Current Downloads {self.hash_progress.removed_files} files", "yellow", 20)
-        await log_with_color(f"Removed From Previous Downloads {self.hash_progress.removed_prev_files} files", "yellow",
+        await log_spacer(20)
+        await log_with_color("Dupe Stats:", "cyan", 20)
+        await log_with_color(f"  Previously Hashed {self.hash_progress.prev_hashed_files} files", "yellow", 20)
+        await log_with_color(f"  Newly Hashed {self.hash_progress.hashed_files} files", "yellow", 20)
+        await log_with_color(f"  Removed From Current Downloads {self.hash_progress.removed_files} files", "yellow", 20)
+        await log_with_color(f"  Removed From Previous Downloads {self.hash_progress.removed_prev_files} files", "yellow",
                             20)
 
-        await log_with_color("\nSort Stats:", "cyan", 20)
-        await log_with_color(f"Organized: {self.sort_progress.audio_count} Audios", "green", 20)
-        await log_with_color(f"Organized: {self.sort_progress.image_count} Images", "green", 20)
-        await log_with_color(f"Organized: {self.sort_progress.video_count} Videos", "green", 20)
-        await log_with_color(f"Organized: {self.sort_progress.other_count} Other Files", "green", 20)
+        await log_spacer(20)
+        await log_with_color("Sort Stats:", "cyan", 20)
+        await log_with_color(f"  Organized: {self.sort_progress.audio_count} Audios", "green", 20)
+        await log_with_color(f"  Organized: {self.sort_progress.image_count} Images", "green", 20)
+        await log_with_color(f"  Organized: {self.sort_progress.video_count} Videos", "green", 20)
+        await log_with_color(f"  Organized: {self.sort_progress.other_count} Other Files", "green", 20)
 
         scrape_failures = await self.scrape_stats_progress.return_totals()
-        await log_with_color("\nScrape Failures:", "cyan", 20)
+        await log_spacer(20)
+        await log_with_color("Scrape Failures:", "cyan", 20)
         for key, value in scrape_failures.items():
-            await log_with_color(f"Scrape Failures ({key}): {value}", "red", 20)
+            await log_with_color(f"  Scrape Failures ({key}): {value}", "red", 20)
 
         download_failures = await self.download_stats_progress.return_totals()
-        await log_with_color("\nDownload Failures:", "cyan", 20)
+        await log_spacer(20)
+        await log_with_color("Download Failures:", "cyan", 20)
         for key, value in download_failures.items():
-            await log_with_color(f"Download Failures ({key}): {value}", "red", 20)
+            await log_with_color(f"  Download Failures ({key}): {value}", "red", 20)
 
+        await log_spacer(20)
         await self.send_webhook_message(self.manager.config_manager.settings_data['Logs']['webhook_url'])
 
     async def send_webhook_message(self, webhook_url: str) -> None:

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -65,7 +65,6 @@ class ProgressManager:
 
     async def print_stats(self) -> None:
         """Prints the stats of the program"""
-        await log_spacer(20)
         await log("Printing Stats...\n", 20)
         await log_with_color("Download Stats:", "cyan", 20)
         await log_with_color(f"  Downloaded {self.download_progress.completed_files} files", "green", 20)
@@ -74,12 +73,12 @@ class ProgressManager:
         await log_with_color(f"  Skipped By Config {self.download_progress.skipped_files} files", "yellow", 20)
         await log_with_color(f"  Failed {self.download_stats_progress.failed_files} files", "red", 20)
 
-        await log_spacer(20)
+        await log_spacer(20,'')
         await log_with_color("Unsupported URLs Stats:", "cyan", 20)
         await log_with_color(f"  Sent to Jdownloader: {self.scrape_stats_progress.sent_to_jdownloader}", "yellow", 20)
         await log_with_color(f"  Skipped: {self.scrape_stats_progress.unsupported_urls_skipped}", "yellow", 20)
 
-        await log_spacer(20)
+        await log_spacer(20,'')
         await log_with_color("Dupe Stats:", "cyan", 20)
         await log_with_color(f"  Previously Hashed {self.hash_progress.prev_hashed_files} files", "yellow", 20)
         await log_with_color(f"  Newly Hashed {self.hash_progress.hashed_files} files", "yellow", 20)
@@ -87,7 +86,7 @@ class ProgressManager:
         await log_with_color(f"  Removed From Previous Downloads {self.hash_progress.removed_prev_files} files", "yellow",
                             20)
 
-        await log_spacer(20)
+        await log_spacer(20,'')
         await log_with_color("Sort Stats:", "cyan", 20)
         await log_with_color(f"  Organized: {self.sort_progress.audio_count} Audios", "green", 20)
         await log_with_color(f"  Organized: {self.sort_progress.image_count} Images", "green", 20)
@@ -95,18 +94,17 @@ class ProgressManager:
         await log_with_color(f"  Organized: {self.sort_progress.other_count} Other Files", "green", 20)
 
         scrape_failures = await self.scrape_stats_progress.return_totals()
-        await log_spacer(20)
+        await log_spacer(20,'')
         await log_with_color("Scrape Failures:", "cyan", 20)
         for key, value in scrape_failures.items():
             await log_with_color(f"  Scrape Failures ({key}): {value}", "red", 20)
 
         download_failures = await self.download_stats_progress.return_totals()
-        await log_spacer(20)
+        await log_spacer(20,'')
         await log_with_color("Download Failures:", "cyan", 20)
         for key, value in download_failures.items():
             await log_with_color(f"  Download Failures ({key}): {value}", "red", 20)
 
-        await log_spacer(20)
         await self.send_webhook_message(self.manager.config_manager.settings_data['Logs']['webhook_url'])
 
     async def send_webhook_message(self, webhook_url: str) -> None:

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -137,14 +137,14 @@ class Crawler(ABC):
                                                             response_url=URL("https://" + login_url.host))
         if (not username or not password) and not session_cookie:
             await log(f"Login wasn't provided for {login_url.host}", 30)
-            raise FailedLoginFailure(status=401, message="Login wasn't provided")
+            raise FailedLoginFailure(message="Login wasn't provided")
         attempt = 0
 
         while True:
             try:
                 attempt += 1
                 if attempt == 5:
-                    raise FailedLoginFailure(status=403, message="Failed to login after 5 attempts")
+                    raise FailedLoginFailure(message="Failed to login after 5 attempts")
 
                 assert login_url.host is not None
 

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -55,7 +55,7 @@ class BunkrrCrawler(Crawler):
         results = await self.get_album_results(album_id)
 
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         title = soup.select_one('title').text.rsplit(" | Bunkr")[0].strip()
 
         title = await self.create_title(title, scrape_item.url.parts[2], None)
@@ -106,7 +106,7 @@ class BunkrrCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         # try video
         link_container = soup.select_one('video > source')
@@ -146,7 +146,7 @@ class BunkrrCrawler(Crawler):
         """Gets the download link for a given reinforced URL"""
         """get.bunkr.su"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, url)
 
         try:
             link_container = soup.select('a[download*=""]')[-1]

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -124,7 +124,7 @@ class BunkrrCrawler(Crawler):
         link = link_container.get(src_selector) if link_container else None
 
         if not link:
-            raise ScrapeFailure(404, f"Could not find source for: {scrape_item.url}")
+            raise ScrapeFailure(404, f"Could not find source for: {scrape_item.url}", origin=scrape_item)
         
         link = URL(link)
 

--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -12,6 +12,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class CelebForumCrawler(Crawler):
@@ -84,7 +85,7 @@ class CelebForumCrawler(Crawler):
         current_post_number = 0
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, thread_url)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, thread_url, origin = scrape_item)
 
             title_block = soup.select_one(self.title_selector)
             for elem in title_block.find_all(self.title_trash_selector):

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class CoomerCrawler(Crawler):
@@ -52,7 +53,7 @@ class CoomerCrawler(Crawler):
         api_call = self.api_url / service / "user" / user
         while True:
             async with self.request_limiter:
-                JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}))
+                JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}), origin = scrape_item)
                 offset += 50
                 if not JSON_Resp:
                     break
@@ -67,7 +68,7 @@ class CoomerCrawler(Crawler):
         user_str = await self.get_user_str_from_post(scrape_item)
         api_call = self.api_url / service / "user" / user / "post" / post_id
         async with self.request_limiter:
-            post = await self.client.get_json(self.domain, api_call)
+            post = await self.client.get_json(self.domain, api_call, origin = scrape_item)
         await self.handle_post_content(scrape_item, post, user, user_str)
 
     @error_handling_wrapper
@@ -116,14 +117,14 @@ class CoomerCrawler(Crawler):
     async def get_user_str_from_post(self, scrape_item: ScrapeItem) -> str:
         """Gets the user string from a scrape item"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         user = soup.select_one("a[class=post__user-name]").text
         return user
 
     async def get_user_str_from_profile(self, scrape_item: ScrapeItem) -> str:
         """Gets the user string from a scrape item"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         user = soup.select_one("span[itemprop=name]").text
         return user
 

--- a/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class CyberdropCrawler(Crawler):
@@ -40,7 +41,7 @@ class CyberdropCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         scrape_item.album_id = scrape_item.url.parts[2]
         scrape_item.part_of_album = True
@@ -66,13 +67,13 @@ class CyberdropCrawler(Crawler):
 
         async with self.request_limiter:
             JSON_Resp = await self.client.get_json(self.domain,
-                                                self.api_url / "file" / "info" / scrape_item.url.path[3:])
+                                                self.api_url / "file" / "info" / scrape_item.url.path[3:], origin = scrape_item)
 
         filename, ext = await get_filename_and_ext(JSON_Resp["name"])
 
         async with self.request_limiter:
             JSON_Resp = await self.client.get_json(self.domain,
-                                                self.api_url / "file" / "auth" / scrape_item.url.path[3:])
+                                                self.api_url / "file" / "auth" / scrape_item.url.path[3:], origin = scrape_item)
 
         link = URL(JSON_Resp['url'])
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
@@ -144,6 +144,7 @@ class CyberfileCrawler(Crawler):
     async def file(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a file"""
         password = scrape_item.url.query.get("password","")
+        scrape_item.url = scrape_item.url.with_query(None)
         async with self.request_limiter:
             soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
             if 'Enter File Password' in soup.text:

--- a/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
@@ -67,7 +67,7 @@ class CyberfileCrawler(Crawler):
                     password_data = {"folderPassword": password, "folderId": nodeId, "submitme": 1}
                     password_response: dict = await self.client.post_data(self.domain, self.api_password_process, data=password_data, origin = scrape_item)
                     if not password_response.get('success'):
-                        raise PasswordProtected(scrape_item)
+                        raise PasswordProtected(origin = scrape_item)
                     ajax_dict: dict = await self.client.post_data(self.domain, self.api_files, data=data, origin = scrape_item)
 
                 ajax_soup = BeautifulSoup(ajax_dict['html'].replace("\\", ""), 'html.parser')
@@ -152,7 +152,7 @@ class CyberfileCrawler(Crawler):
                 soup = BeautifulSoup (await self.client.post_data(
                     self.domain, scrape_item.url, data=password_data, raw=True, origin = scrape_item))
                 if "File password is invalid" in soup.text:
-                    raise PasswordProtected(scrape_item)
+                    raise PasswordProtected(origin =scrape_item)
             
         script_funcs = soup.select('script')
         for script in script_funcs:
@@ -174,7 +174,7 @@ class CyberfileCrawler(Crawler):
             ajax_soup = BeautifulSoup(ajax_dict['html'].replace("\\", ""), 'html.parser')
 
         if "albumPasswordModel" in ajax_dict['html']:
-            raise PasswordProtected(scrape_item)
+            raise PasswordProtected(origin = scrape_item)
 
         file_menu = ajax_soup.select_one('ul[class="dropdown-menu dropdown-info account-dropdown-resize-menu"] li a')
         file_button = ajax_soup.select_one('div[class="btn-group responsiveMobileMargin"] button')

--- a/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
@@ -44,7 +44,7 @@ class CyberfileCrawler(Crawler):
     async def folder(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a folder"""
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         login = soup.select_one('form[id=form_login]')
         if login:
@@ -62,13 +62,13 @@ class CyberfileCrawler(Crawler):
         while True:
             data = {"pageType": "folder", "nodeId": nodeId, "pageStart": page, "perPage": 0, "filterOrderBy": ""}
             async with self.request_limiter:
-                ajax_dict: dict = await self.client.post_data(self.domain, self.api_files, data=data)
+                ajax_dict: dict = await self.client.post_data(self.domain, self.api_files, data=data, origin = scrape_item)
                 if 'Password Required' in ajax_dict['html']:
                     password_data = {"folderPassword": password, "folderId": nodeId, "submitme": 1}
-                    password_response: dict = await self.client.post_data(self.domain, self.api_password_process, data=password_data)
+                    password_response: dict = await self.client.post_data(self.domain, self.api_password_process, data=password_data, origin = scrape_item)
                     if not password_response.get('success'):
                         raise PasswordProtected(scrape_item)
-                    ajax_dict: dict = await self.client.post_data(self.domain, self.api_files, data=data)
+                    ajax_dict: dict = await self.client.post_data(self.domain, self.api_files, data=data, origin = scrape_item)
 
                 ajax_soup = BeautifulSoup(ajax_dict['html'].replace("\\", ""), 'html.parser')
 
@@ -100,7 +100,7 @@ class CyberfileCrawler(Crawler):
     async def shared(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a shared folder"""
         async with self.request_limiter:
-            await self.client.get_BS4(self.domain, scrape_item.url)
+            await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         new_folders = []
         node_id = ''
@@ -110,7 +110,7 @@ class CyberfileCrawler(Crawler):
             data = {"pageType": "nonaccountshared", "nodeId": node_id, "pageStart": page, "perPage": 0,
                     "filterOrderBy": ""}
             async with self.request_limiter:
-                ajax_dict = await self.client.post_data("cyberfile", self.api_files, data=data)
+                ajax_dict = await self.client.post_data("cyberfile", self.api_files, data=data, origin = scrape_item)
                 ajax_soup = BeautifulSoup(ajax_dict['html'].replace("\\", ""), 'html.parser')
             title = await self.create_title(ajax_dict['page_title'], scrape_item.url.parts[2], None)
             num_pages = int(ajax_soup.select_one('input[id=rspTotalPages]').get('value'))
@@ -145,11 +145,11 @@ class CyberfileCrawler(Crawler):
         """Scrapes a file"""
         password = scrape_item.url.query.get("password","")
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
             if 'Enter File Password' in soup.text:
                 password_data = {"filePassword": password, "submitted": 1}
                 soup = BeautifulSoup (await self.client.post_data(
-                    self.domain, scrape_item.url, data=password_data, raw=True))
+                    self.domain, scrape_item.url, data=password_data, raw=True, origin = scrape_item))
                 if "File password is invalid" in soup.text:
                     raise PasswordProtected(scrape_item)
             
@@ -169,7 +169,7 @@ class CyberfileCrawler(Crawler):
         """Scrapes a file using the content id"""
         data = {"u": contentId}
         async with self.request_limiter:
-            ajax_dict = await self.client.post_data(self.domain, self.api_details, data=data)
+            ajax_dict = await self.client.post_data(self.domain, self.api_details, data=data, origin = scrape_item)
             ajax_soup = BeautifulSoup(ajax_dict['html'].replace("\\", ""), 'html.parser')
 
         if "albumPasswordModel" in ajax_dict['html']:

--- a/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
@@ -48,7 +48,7 @@ class CyberfileCrawler(Crawler):
 
         login = soup.select_one('form[id=form_login]')
         if login:
-            raise ScrapeFailure(404, "Folder has been deleted")
+            raise ScrapeFailure(404, "Folder has been deleted", origin = scrape_item)
 
         script_func = soup.select('div[class*="page-container"] script')[-1].text
         script_func = script_func.split('loadImages(')[-1]
@@ -184,7 +184,7 @@ class CyberfileCrawler(Crawler):
                 html_download_text = file_button.get("onclick")
         except AttributeError:
             await log(f"Couldn't find download button for {scrape_item.url}", 30)
-            raise ScrapeFailure(422, "Couldn't find download button")
+            raise ScrapeFailure(422, "Couldn't find download button", origin= scrape_item)
         link = URL(html_download_text.split("'")[1])
 
         file_detail_table = ajax_soup.select('table[class="table table-bordered table-striped"]')[-1]

--- a/cyberdrop_dl/scraper/crawlers/ehentai_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/ehentai_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class EHentaiCrawler(Crawler):
@@ -43,7 +44,7 @@ class EHentaiCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title = await self.create_title(soup.select_one("h1[id=gn]").get_text(), None, None)
         date = await self.parse_datetime(soup.select_one("td[class=gdt2]").get_text())
@@ -73,7 +74,7 @@ class EHentaiCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         image = soup.select_one("img[id=img]")
         link = URL(image.get('src'))
         filename, ext = await get_filename_and_ext(link.name)
@@ -94,4 +95,4 @@ class EHentaiCrawler(Crawler):
         self.warnings_set = True
         async with self.request_limiter:
             scrape_item.url = URL(str(scrape_item.url) + "/").update_query("nw=session")
-            await self.client.get_BS4(self.domain, scrape_item.url)
+            await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)

--- a/cyberdrop_dl/scraper/crawlers/erome_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/erome_crawler.py
@@ -11,6 +11,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class EromeCrawler(Crawler):
@@ -35,7 +36,7 @@ class EromeCrawler(Crawler):
     async def profile(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a profile"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title = await self.create_title(scrape_item.url.name, None, None)
         albums = soup.select('a[class=album-link]')
@@ -61,7 +62,7 @@ class EromeCrawler(Crawler):
         scrape_item.part_of_album = True
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title_portion = soup.select_one('title').text.rsplit(" - Porn")[0].strip()
         if not title_portion:

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -12,6 +12,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class F95ZoneCrawler(Crawler):
@@ -84,7 +85,7 @@ class F95ZoneCrawler(Crawler):
         current_post_number = 0
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, thread_url)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, thread_url, origin = scrape_item)
 
             title_block = soup.select_one(self.title_selector)
             for elem in title_block.find_all(self.title_trash_selector):

--- a/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
@@ -11,6 +11,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class FapelloCrawler(Crawler):
@@ -38,7 +39,7 @@ class FapelloCrawler(Crawler):
     async def profile(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a profile"""
         async with self.request_limiter:
-            soup, response_url = await self.client.get_BS4_and_return_URL(self.domain, scrape_item.url)
+            soup, response_url = await self.client.get_BS4_and_return_URL(self.domain, scrape_item.url, origin = scrape_item)
             if response_url != scrape_item.url:
                 return
 
@@ -68,7 +69,7 @@ class FapelloCrawler(Crawler):
     async def post(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         content = soup.select_one('div[class="flex justify-between items-center"]')
         content_tags = content.select("img")

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -58,7 +58,7 @@ class GoFileCrawler(Crawler):
             async with self.request_limiter:
                 JSON_Resp = await self.client.get_json(self.domain,
                                                     (self.api_address / "contents" / content_id).with_query(
-                                                        {"wt": self.websiteToken, "password": password }), headers_inc=self.headers)
+                                                        {"wt": self.websiteToken, "password": password }), headers_inc=self.headers, origin = scrape_item)
         except DownloadFailure as e:
             if e.status == http.HTTPStatus.UNAUTHORIZED:
                 self.websiteToken = ""
@@ -67,7 +67,7 @@ class GoFileCrawler(Crawler):
                 async with self.request_limiter:
                     JSON_Resp = await self.client.get_json(self.domain,
                                                         (self.api_address / "contents" / content_id).with_query(
-                                                            {"wt": self.websiteToken, "password": password}), headers_inc=self.headers)
+                                                            {"wt": self.websiteToken, "password": password}), headers_inc=self.headers, origin = scrape_item)
             else:
                 raise ScrapeFailure(e.status, e.message, origin= scrape_item)
             

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -51,6 +51,7 @@ class GoFileCrawler(Crawler):
         scrape_item.part_of_album = True
 
         password = scrape_item.url.query.get("password","")
+        scrape_item.url = scrape_item.url.with_query(None)
         if password:
             password = sha256(password.encode()).hexdigest()
 

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -79,7 +79,7 @@ class GoFileCrawler(Crawler):
 
         if "password" in JSON_Resp:
             if JSON_Resp['passwordStatus'] in {'passwordRequired','passwordWrong'} or not password:
-                raise PasswordProtected(scrape_item)
+                raise PasswordProtected(origin = scrape_item)
 
         if JSON_Resp["canAccess"] is False:
             raise ScrapeFailure(403, "Album is private", origin= scrape_item)

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -69,10 +69,10 @@ class GoFileCrawler(Crawler):
                                                         (self.api_address / "contents" / content_id).with_query(
                                                             {"wt": self.websiteToken, "password": password}), headers_inc=self.headers)
             else:
-                raise ScrapeFailure(e.status, e.message)
+                raise ScrapeFailure(e.status, e.message, origin= scrape_item)
             
         if JSON_Resp["status"] == "error-notFound":
-            raise ScrapeFailure(404, "Album not found")
+            raise ScrapeFailure(404, "Album not found", origin= scrape_item)
 
         JSON_Resp = JSON_Resp['data']
 
@@ -81,7 +81,7 @@ class GoFileCrawler(Crawler):
                 raise PasswordProtected(scrape_item)
 
         if JSON_Resp["canAccess"] is False:
-            raise ScrapeFailure(403, "Album is private")
+            raise ScrapeFailure(403, "Album is private", origin= scrape_item)
 
         title = await self.create_title(JSON_Resp["name"], content_id, None)
 

--- a/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
@@ -11,6 +11,7 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class HotPicCrawler(Crawler):
@@ -39,7 +40,7 @@ class HotPicCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         scrape_item.album_id = scrape_item.url.parts[2]
         title = await self.create_title(soup.select_one("title").text.rsplit(" - ")[0], scrape_item.album_id , None)
@@ -59,7 +60,7 @@ class HotPicCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         link = URL(soup.select_one("img[id*=main-image]").get("src"))
         filename, ext = await get_filename_and_ext(link.name)

--- a/cyberdrop_dl/scraper/crawlers/imageban_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imageban_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class ImageBanCrawler(Crawler):
@@ -41,7 +42,7 @@ class ImageBanCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a gallery"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         scrape_item.album_id = scrape_item.url.parts[2]
         scrape_item.part_of_album = True
@@ -79,7 +80,7 @@ class ImageBanCrawler(Crawler):
     async def compilation(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a compilation"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title = await self.create_title(soup.select_one("blockquote").get_text(), scrape_item.url.parts[2], None)
         await scrape_item.add_to_parent_title(title)
@@ -100,7 +101,7 @@ class ImageBanCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         date = await self.parse_datetime(
             f"{(scrape_item.url.parts[2])}-{(scrape_item.url.parts[3])}-{(scrape_item.url.parts[4])}")

--- a/cyberdrop_dl/scraper/crawlers/imgbb_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgbb_crawler.py
@@ -14,6 +14,7 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class ImgBBCrawler(Crawler):
@@ -44,7 +45,7 @@ class ImgBBCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url / "sub")
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url / "sub", origin = scrape_item)
 
         scrape_item.album_id = scrape_item.url.parts[2]
         scrape_item.part_of_album = True
@@ -58,12 +59,12 @@ class ImgBBCrawler(Crawler):
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url / "sub")
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url / "sub", origin = scrape_item)
         link_next = URL(soup.select_one("a[id=list-most-recent-link]").get("href"))
 
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, link_next)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, link_next, origin=scrape_item)
             links = soup.select("a[class*=image-container]")
             for link in links:
                 link = URL(link.get('href'))
@@ -87,7 +88,7 @@ class ImgBBCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         link = URL(soup.select_one("div[id=image-viewer-container] img").get('src'))
         date = soup.select_one("p[class*=description-meta] span").get("title")

--- a/cyberdrop_dl/scraper/crawlers/imgbox_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgbox_crawler.py
@@ -49,7 +49,7 @@ class ImgBoxCrawler(Crawler):
             soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
 
         if "The specified gallery could not be found" in soup.text:
-            raise ScrapeFailure(404, f"Gallery not found: {scrape_item.url}")
+            raise ScrapeFailure(404, f"Gallery not found: {scrape_item.url}", origin= scrape_item)
         
         scrape_item.album_id = scrape_item.url.parts[2]
         scrape_item.part_of_album = True

--- a/cyberdrop_dl/scraper/crawlers/imgbox_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgbox_crawler.py
@@ -46,7 +46,7 @@ class ImgBoxCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         if "The specified gallery could not be found" in soup.text:
             raise ScrapeFailure(404, f"Gallery not found: {scrape_item.url}", origin= scrape_item)
@@ -75,7 +75,7 @@ class ImgBoxCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         image = URL(soup.select_one("img[id=img]").get('src'))
         filename, ext = await get_filename_and_ext(image.name)

--- a/cyberdrop_dl/scraper/crawlers/imgkiwi_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgkiwi_crawler.py
@@ -14,6 +14,7 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class ImgKiwiCrawler(Crawler):
@@ -40,7 +41,7 @@ class ImgKiwiCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         scrape_item.part_of_album = True
         scrape_item.album_id = scrape_item.url.parts[2]
@@ -51,7 +52,7 @@ class ImgKiwiCrawler(Crawler):
 
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, link_next)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, link_next, origin = scrape_item)
             links = soup.select("a[href*=image]")
             for link in links:
                 link = URL(link.get('href'))
@@ -75,7 +76,7 @@ class ImgKiwiCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         link = soup.select_one("div[id=image-viewer-container] img").get('src')
         link = URL(link.replace(".md.", ".").replace(".th.", "."))

--- a/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
@@ -52,13 +52,13 @@ class ImgurCrawler(Crawler):
 
         async with self.request_limiter:
             JSON_Obj = await self.client.get_json(self.domain, self.imgur_api / f"album/{album_id}",
-                                                headers_inc=self.headers)
+                                                headers_inc=self.headers, origin = scrape_item)
         title_part = JSON_Obj["data"].get("title", album_id)
         title = await self.create_title(title_part, scrape_item.url.parts[2], None)
 
         async with self.request_limiter:
             JSON_Obj = await self.client.get_json(self.domain, self.imgur_api / f"album/{album_id}/images",
-                                                headers_inc=self.headers)
+                                                headers_inc=self.headers, origin = scrape_item)
 
         for image in JSON_Obj["data"]:
             link = URL(image["link"])
@@ -77,7 +77,7 @@ class ImgurCrawler(Crawler):
         image_id = scrape_item.url.parts[-1]
         async with self.request_limiter:
             JSON_Obj = await self.client.get_json(self.domain, self.imgur_api / f"image/{image_id}",
-                                                headers_inc=self.headers)
+                                                headers_inc=self.headers, origin = scrape_item)
 
         date = JSON_Obj["data"]["datetime"]
         link = URL(JSON_Obj["data"]["link"])

--- a/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
@@ -43,7 +43,7 @@ class ImgurCrawler(Crawler):
         """Scrapes an album"""
         if self.imgur_client_id == "":
             await log("To scrape imgur content, you need to provide a client id", 30)
-            raise FailedLoginFailure(status=401, message="No Imgur Client ID provided")
+            raise FailedLoginFailure(message="No Imgur Client ID provided")
         await self.check_imgur_credits()
 
         album_id = scrape_item.url.parts[-1]
@@ -71,7 +71,7 @@ class ImgurCrawler(Crawler):
         """Scrapes an image"""
         if self.imgur_client_id == "":
             await log("To scrape imgur content, you need to provide a client id", 30)
-            raise FailedLoginFailure(status=401, message="No Imgur Client ID provided")
+            raise FailedLoginFailure(message="No Imgur Client ID provided")
         await self.check_imgur_credits()
 
         image_id = scrape_item.url.parts[-1]

--- a/cyberdrop_dl/scraper/crawlers/jpgchurch_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/jpgchurch_crawler.py
@@ -14,6 +14,7 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class JPGChurchCrawler(Crawler):
@@ -45,14 +46,14 @@ class JPGChurchCrawler(Crawler):
     async def profile(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a user profile"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title = await self.create_title(soup.select_one('meta[property="og:title"]').get("content"), None, None)
         link_next = URL(soup.select_one("a[id=list-most-recent-link]").get("href"))
 
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, link_next)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, link_next, origin = scrape_item)
             links = soup.select("a[href*=img]")
             for link in links:
                 link = URL(link.get('href'))
@@ -78,7 +79,7 @@ class JPGChurchCrawler(Crawler):
         scrape_item.part_of_album = True
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url / "sub")
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url / "sub", origin = scrape_item)
 
         title = await self.create_title(soup.select_one("a[data-text=album-name]").get_text(), scrape_item.url.parts[2],
                                         None)
@@ -89,12 +90,12 @@ class JPGChurchCrawler(Crawler):
             self.manager.task_group.create_task(self.run(new_scrape_item))
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url / "sub")
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url / "sub", origin = scrape_item)
         link_next = URL(soup.select_one("a[id=list-most-recent-link]").get("href"))
 
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, link_next)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, link_next, origin = scrape_item)
             links = soup.select("a[href*=img] img")
             for link in links:
                 link = URL(link.get('src'))
@@ -119,7 +120,7 @@ class JPGChurchCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         link = URL(soup.select_one("div[id=image-viewer-container] img").get('src'))
         link = link.with_name(link.name.replace('.md.', '.').replace('.th.', '.'))

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -15,6 +15,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class KemonoCrawler(Crawler):
@@ -56,7 +57,7 @@ class KemonoCrawler(Crawler):
         api_call = self.api_url / service / "user" / user
         while True:
             async with self.request_limiter:
-                JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}))
+                JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}), origin = scrape_item)
                 offset += 50
                 if not JSON_Resp:
                     break
@@ -72,7 +73,7 @@ class KemonoCrawler(Crawler):
         api_call = self.api_url / "discord/channel" / channel
         while True:
             async with self.request_limiter:
-                JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}))
+                JSON_Resp = await self.client.get_json(self.domain, api_call.with_query({"o": offset}), origin = scrape_item)
                 offset += 150
                 if not JSON_Resp:
                     break
@@ -87,7 +88,7 @@ class KemonoCrawler(Crawler):
         user_str = await self.get_user_str_from_post(scrape_item)
         api_call = self.api_url / service / "user" / user / "post" / post_id
         async with self.request_limiter:
-            post = await self.client.get_json(self.domain, api_call)
+            post = await self.client.get_json(self.domain, api_call, origin = scrape_item)
         await self.handle_post_content(scrape_item, post, user, user_str)
 
     @error_handling_wrapper
@@ -170,7 +171,7 @@ class KemonoCrawler(Crawler):
     async def get_user_str_from_post(self, scrape_item: ScrapeItem) -> str:
         """Gets the user string from a scrape item"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         user = soup.select_one("a[class=post__user-name]").text
         return user
 
@@ -178,7 +179,7 @@ class KemonoCrawler(Crawler):
     async def get_user_str_from_profile(self, scrape_item: ScrapeItem) -> str:
         """Gets the user string from a scrape item"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         user = soup.select_one("span[itemprop=name]").text
         return user
 

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -12,6 +12,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class LeakedModelsCrawler(Crawler):
@@ -89,7 +90,7 @@ class LeakedModelsCrawler(Crawler):
         current_post_number = 0
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, thread_url)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, thread_url, origin = scrape_item)
 
             title_block = soup.select_one(self.title_selector)
             for elem in title_block.find_all(self.title_trash_selector):

--- a/cyberdrop_dl/scraper/crawlers/mediafire_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/mediafire_crawler.py
@@ -15,6 +15,7 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class MediaFireCrawler(Crawler):
@@ -75,7 +76,7 @@ class MediaFireCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         date = await self.parse_datetime(soup.select('ul[class=details] li span')[-1].get_text())
         scrape_item.possible_datetime = date

--- a/cyberdrop_dl/scraper/crawlers/mediafire_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/mediafire_crawler.py
@@ -54,7 +54,7 @@ class MediaFireCrawler(Crawler):
                 folder_contents = self.api.folder_get_content(folder_key=folder_key, content_type='files', chunk=chunk,
                                                             chunk_size=chunk_size)
             except api.MediaFireConnectionError:
-                raise ScrapeFailure(500, "MediaFire connection closed")
+                raise ScrapeFailure(500, "MediaFire connection closed", origin= scrape_item)
             files = folder_contents['folder_content']['files']
 
             for file in files:

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class NudoStarCrawler(Crawler):
@@ -85,7 +86,7 @@ class NudoStarCrawler(Crawler):
         current_post_number = 0
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, thread_url)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, thread_url, origin = scrape_item)
 
             title_block = soup.select_one(self.title_selector)
             for elem in title_block.find_all(self.title_trash_selector):

--- a/cyberdrop_dl/scraper/crawlers/nudostartv_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostartv_crawler.py
@@ -11,6 +11,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class NudoStarTVCrawler(Crawler):
@@ -33,7 +34,7 @@ class NudoStarTVCrawler(Crawler):
     async def profile(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a profile"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title = await self.create_title(soup.select_one('title').get_text().split("/")[0], None, None)
         content = soup.select('div[id=list_videos_common_videos_list_items] div a')
@@ -51,7 +52,7 @@ class NudoStarTVCrawler(Crawler):
     async def image(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         content = soup.select('div[class=block-video] a img')
         for image in content:
             link = URL(image.get('src'))

--- a/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
@@ -76,7 +76,7 @@ class OmegaScansCrawler(Crawler):
 
         if "This chapter is premium" in soup.get_text():
             await log("Scrape Failed: This chapter is premium", 40)
-            raise ScrapeFailure(401, "This chapter is premium")
+            raise ScrapeFailure(401, "This chapter is premium", origin= scrape_item)
 
         title_parts = soup.select_one("title").get_text().split(" - ")
         series_name = title_parts[0]

--- a/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
@@ -14,6 +14,7 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class OmegaScansCrawler(Crawler):
@@ -42,7 +43,7 @@ class OmegaScansCrawler(Crawler):
     async def series(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         scripts = soup.select("script")
         for script in scripts:
@@ -55,7 +56,7 @@ class OmegaScansCrawler(Crawler):
         while True:
             api_url = URL(self.api_url.format(page_number, number_per_page, series_id))
             async with self.request_limiter:
-                JSON_Obj = await self.client.get_json(self.domain, api_url)
+                JSON_Obj = await self.client.get_json(self.domain, api_url, origin = scrape_item)
             if not JSON_Obj:
                 break
 
@@ -72,7 +73,7 @@ class OmegaScansCrawler(Crawler):
     async def chapter(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         if "This chapter is premium" in soup.get_text():
             await log("Scrape Failed: This chapter is premium", 40)

--- a/cyberdrop_dl/scraper/crawlers/pimpandhost_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pimpandhost_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class PimpAndHostCrawler(Crawler):
@@ -37,7 +38,7 @@ class PimpAndHostCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         scrape_item.album_id = scrape_item.url.parts[2]
         scrape_item.part_of_album = True
@@ -65,7 +66,7 @@ class PimpAndHostCrawler(Crawler):
     async def image(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         link = soup.select_one('.main-image-wrapper')
         link = link.get('data-src')

--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -44,7 +44,7 @@ class PixelDrainCrawler(Crawler):
         results = await self.get_album_results(album_id)
 
         async with self.request_limiter:
-            JSON_Resp = await self.client.get_json(self.domain, self.api_address / "list" / scrape_item.url.parts[-1])
+            JSON_Resp = await self.client.get_json(self.domain, self.api_address / "list" / scrape_item.url.parts[-1], origin = scrape_item)
 
         title = await self.create_title(JSON_Resp['title'], scrape_item.url.parts[2], None)
 
@@ -67,7 +67,7 @@ class PixelDrainCrawler(Crawler):
         """Scrapes a file"""
         async with self.request_limiter:
             JSON_Resp = await self.client.get_json(self.domain,
-                                                self.api_address / "file" / scrape_item.url.parts[-1] / "info")
+                                                self.api_address / "file" / scrape_item.url.parts[-1] / "info", origin = scrape_item)
 
         link = await self.create_download_link(JSON_Resp['id'])
         date = await self.parse_datetime(JSON_Resp['date_upload'].replace("T", " ").split(".")[0])
@@ -77,7 +77,7 @@ class PixelDrainCrawler(Crawler):
             if "text/plain" in JSON_Resp["mime_type"]:
                 await scrape_item.add_to_parent_title(f"{JSON_Resp['name']} (Pixeldrain)")
                 async with self.request_limiter:
-                    text = await self.client.get_text(self.domain, self.api_address / "file" / scrape_item.url.parts[-1])
+                    text = await self.client.get_text(self.domain, self.api_address / "file" / scrape_item.url.parts[-1], origin = scrape_item)
                 lines = text.split("\n")
                 for line in lines:
                     link = URL(line)

--- a/cyberdrop_dl/scraper/crawlers/postimg_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/postimg_crawler.py
@@ -12,6 +12,7 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class PostImgCrawler(Crawler):
@@ -43,7 +44,7 @@ class PostImgCrawler(Crawler):
         for i in itertools.count(1):
             data["page"] = i
             async with self.request_limiter:
-                JSON_Resp = await self.client.post_data(self.domain, self.api_address, data=data)
+                JSON_Resp = await self.client.post_data(self.domain, self.api_address, data=data, origin = scrape_item)
 
             scrape_item.part_of_album = True
             scrape_item.album_id = scrape_item.url.parts[2]
@@ -65,7 +66,7 @@ class PostImgCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         link = URL(soup.select_one("a[id=download]").get('href').replace("?dl=1", ""))
         filename, ext = await get_filename_and_ext(link.name)

--- a/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
@@ -11,6 +11,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class RealBooruCrawler(Crawler):
@@ -43,7 +44,7 @@ class RealBooruCrawler(Crawler):
     async def tag(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title_portion = scrape_item.url.query['tags'].strip()
         title = await self.create_title(title_portion, None, None)
@@ -72,7 +73,7 @@ class RealBooruCrawler(Crawler):
     async def file(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         image = soup.select_one("img[id=image]")
         if image:
             link = URL(image.get('src'))

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -85,9 +85,9 @@ class RedditCrawler(Crawler):
         try:
             submissions = [submission async for submission in submissions]
         except asyncprawcore.exceptions.Forbidden:
-            raise ScrapeFailure(403, "Forbidden")
+            raise ScrapeFailure(403, "Forbidden", origin= scrape_item)
         except asyncprawcore.exceptions.NotFound:
-            raise ScrapeFailure(404, "Not Found")
+            raise ScrapeFailure(404, "Not Found", origin= scrape_item)
 
         for submission in submissions:
             await self.post(scrape_item, submission, reddit)
@@ -140,9 +140,9 @@ class RedditCrawler(Crawler):
             try:
                 post = await reddit.submission(url=head['location'])
             except asyncprawcore.exceptions.Forbidden:
-                raise ScrapeFailure(403, "Forbidden")
+                raise ScrapeFailure(403, "Forbidden", origin= scrape_item)
             except asyncprawcore.exceptions.NotFound:
-                raise ScrapeFailure(404, "Not Found")
+                raise ScrapeFailure(404, "Not Found", origin= scrape_item)
 
             await self.post(scrape_item, post, reddit)
             return

--- a/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
@@ -49,7 +49,7 @@ class RedGifsCrawler(Crawler):
             async with self.request_limiter:
                 JSON_Resp = await self.client.get_json(self.domain,
                                                        (self.redgifs_api / "v2/users" / user_id / "search").with_query(
-                                                           f"order=new&count=40&page={page}"), headers_inc=self.headers)
+                                                           f"order=new&count=40&page={page}"), headers_inc=self.headers, origin = scrape_item)
             total_pages = JSON_Resp["pages"]
             gifs = JSON_Resp["gifs"]
             for gif in gifs:
@@ -74,7 +74,7 @@ class RedGifsCrawler(Crawler):
 
         async with self.request_limiter:
             JSON_Resp = await self.client.get_json(self.domain, self.redgifs_api / "v2/gifs" / post_id,
-                                                headers_inc=self.headers)
+                                                headers_inc=self.headers, origin = scrape_item)
 
         title_part = JSON_Resp["gif"].get("title", "Loose Files")
         title = await self.create_title(title_part, None, None)

--- a/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
@@ -14,6 +14,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class Rule34VaultCrawler(Crawler):
@@ -43,7 +44,7 @@ class Rule34VaultCrawler(Crawler):
     async def tag(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title = await self.create_title(scrape_item.url.parts[1], None, None)
         scrape_item.part_of_album = True
@@ -81,7 +82,7 @@ class Rule34VaultCrawler(Crawler):
     async def playlist(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a playlist"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title_str = soup.select_one("div[class*=title]").text
         scrape_item.part_of_album = True
@@ -115,7 +116,7 @@ class Rule34VaultCrawler(Crawler):
     async def file(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         date = await self.parse_datetime(
             soup.select_one(

--- a/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
@@ -11,6 +11,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class Rule34XXXCrawler(Crawler):
@@ -43,7 +44,7 @@ class Rule34XXXCrawler(Crawler):
     async def tag(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title_portion = scrape_item.url.query['tags'].strip()
         title = await self.create_title(title_portion, None, None)
@@ -73,7 +74,7 @@ class Rule34XXXCrawler(Crawler):
     async def file(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         image = soup.select_one("img[id=image]")
         if image:
             link = URL(image.get('src'))

--- a/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class Rule34XYZCrawler(Crawler):
@@ -38,7 +39,7 @@ class Rule34XYZCrawler(Crawler):
     async def tag(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title = await self.create_title(scrape_item.url.parts[1], None, None)
         scrape_item.part_of_album = True
@@ -67,7 +68,7 @@ class Rule34XYZCrawler(Crawler):
     async def file(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         date = await self.parse_datetime(
             soup.select_one('div[class="posted ng-star-inserted"]').text.split("(")[1].split(")")[0])

--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -73,6 +73,6 @@ class SaintCrawler(Crawler):
         try:
             link = URL(soup.select_one('video[id=main-video] source').get('src'))
         except AttributeError:
-            raise ScrapeFailure(404, f"Could not find video source for {scrape_item.url}")
+            raise ScrapeFailure(404, f"Could not find video source for {scrape_item.url}", origin= scrape_item)
         filename, ext = await get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -45,7 +45,7 @@ class SaintCrawler(Crawler):
         scrape_item.part_of_album = True
 
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title_portion = soup.select_one('title').text.rsplit(" - Saint Video Hosting")[0].strip()
         if not title_portion:
@@ -69,7 +69,7 @@ class SaintCrawler(Crawler):
             return
 
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         try:
             link = URL(soup.select_one('video[id=main-video] source').get('src'))
         except AttributeError:

--- a/cyberdrop_dl/scraper/crawlers/scrolller_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/scrolller_crawler.py
@@ -84,7 +84,7 @@ class ScrolllerCrawler(Crawler):
 
         while True:
             request_body["variables"]["iterator"] = iterator
-            data = await self.client.post_data(self.domain, self.scrolller_api, data=json.dumps(request_body))
+            data = await self.client.post_data(self.domain, self.scrolller_api, data=json.dumps(request_body), origin = scrape_item)
 
             if data:
                 items = data["data"]["getSubreddit"]["children"]["items"]

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class SimpCityCrawler(Crawler):
@@ -88,7 +89,7 @@ class SimpCityCrawler(Crawler):
         current_post_number = 0
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, thread_url)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, thread_url, origin = scrape_item)
 
             title_block = soup.select_one(self.title_selector)
             for elem in title_block.find_all(self.title_trash_selector):

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class SocialMediaGirlsCrawler(Crawler):
@@ -86,7 +87,7 @@ class SocialMediaGirlsCrawler(Crawler):
         current_post_number = 0
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, thread_url)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, thread_url, origin = scrape_item)
 
             title_block = soup.select_one(self.title_selector)
             for elem in title_block.find_all(self.title_trash_selector):
@@ -307,7 +308,7 @@ class SocialMediaGirlsCrawler(Crawler):
     async def handle_link_confirmation(self, link: URL) -> Optional[URL]:
         """Handles link confirmation"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, link)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, link)
         confirm_button = soup.select_one("a[class*=button--cta]")
         if confirm_button:
             return_link = URL(confirm_button.get("href"))

--- a/cyberdrop_dl/scraper/crawlers/tokyomotion_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/tokyomotion_crawler.py
@@ -93,8 +93,8 @@ class TokioMotionCrawler(Crawler):
             link = URL(src)
         except AttributeError:
             if "This is a private" in soup.text:
-                raise ScrapeFailure(403, f"Private video: {scrape_item.url}")
-            raise ScrapeFailure(404, f"Could not find video source for {scrape_item.url}")
+                raise ScrapeFailure(403, f"Private video: {scrape_item.url}", origin= scrape_item)
+            raise ScrapeFailure(404, f"Could not find video source for {scrape_item.url}", origin= scrape_item)
         
         title = soup.select_one('title').text.rsplit(" - TOKYO Motion")[0].strip()
        
@@ -151,7 +151,7 @@ class TokioMotionCrawler(Crawler):
 
         async for soup in self.web_pager(scrape_item.url):
             if "This is a private" in soup.text:
-                raise ScrapeFailure(403, f"Private album: {scrape_item.url}")
+                raise ScrapeFailure(403, f"Private album: {scrape_item.url}", origin= scrape_item)
             images = soup.select(self.image_div_selector)
             for image in images:
                 link = image.select_one(self.image_thumb_selector)
@@ -181,8 +181,8 @@ class TokioMotionCrawler(Crawler):
             link = URL(src)
         except AttributeError:
             if "This is a private" in soup.text:
-                raise ScrapeFailure(403, f"Private Photo: {scrape_item.url}")
-            raise ScrapeFailure(404, f"Could not find image source for {scrape_item.url}")
+                raise ScrapeFailure(403, f"Private Photo: {scrape_item.url}", origin= scrape_item)
+            raise ScrapeFailure(404, f"Could not find image source for {scrape_item.url}", origin= scrape_item)
         
         filename, ext = await get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)
@@ -256,7 +256,7 @@ class TokioMotionCrawler(Crawler):
 
         async for soup in self.web_pager(scrape_item.url):
             if "This is a private" in soup.text:
-                raise ScrapeFailure(403, f"Private playlist: {scrape_item.url}")
+                raise ScrapeFailure(403, f"Private playlist: {scrape_item.url}", origin= scrape_item)
             videos = soup.select(self.video_div_selector)
             for video in videos:
                 link = video.select_one(self.video_selector)

--- a/cyberdrop_dl/scraper/crawlers/tokyomotion_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/tokyomotion_crawler.py
@@ -77,7 +77,7 @@ class TokioMotionCrawler(Crawler):
         
         video_id = scrape_item.url.parts[2]
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         try:
             relative_date_str = soup.select_one("div.pull-right.big-views-xs.visible-xs > span.text-white").text.strip()
@@ -174,7 +174,7 @@ class TokioMotionCrawler(Crawler):
         if await self.check_complete_from_referer(scrape_item):
             return
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
         try:
             img = soup.select_one("img[class='img-responsive-mw']")
             src = img.get('src')

--- a/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class ToonilyCrawler(Crawler):
@@ -40,7 +41,7 @@ class ToonilyCrawler(Crawler):
     async def series(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an album"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         chapters = soup.select("li[class*=wp-manga-chapter] a")
         for chapter in chapters:
@@ -58,7 +59,7 @@ class ToonilyCrawler(Crawler):
     async def chapter(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title_parts = soup.select_one("title").get_text().split(" - ")
         series_name = title_parts[0]

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -13,6 +13,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class XBunkerCrawler(Crawler):
@@ -89,7 +90,7 @@ class XBunkerCrawler(Crawler):
         current_post_number = 0
         while True:
             async with self.request_limiter:
-                soup = await self.client.get_BS4(self.domain, thread_url)
+                soup: BeautifulSoup = await self.client.get_BS4(self.domain, thread_url, origin = scrape_item)
 
             title_block = soup.select_one(self.title_selector)
             for elem in title_block.find_all(self.title_trash_selector):

--- a/cyberdrop_dl/scraper/crawlers/xbunkr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunkr_crawler.py
@@ -12,6 +12,7 @@ from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wr
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
+    from bs4 import BeautifulSoup
 
 
 class XBunkrCrawler(Crawler):
@@ -37,7 +38,7 @@ class XBunkrCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a profile"""
         async with self.request_limiter:
-            soup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         scrape_item.album_id = scrape_item.url.parts[2]
         scrape_item.part_of_album = True

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -60,7 +60,7 @@ class XXXBunkerCrawler(Crawler):
             return
         
         if not self.session_cookie:
-            raise ScrapeFailure(401, "No cookies provided")
+            raise ScrapeFailure(401, "No cookies provided", origin= scrape_item)
         
         async with self.request_limiter:
             soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
@@ -98,15 +98,15 @@ class XXXBunkerCrawler(Crawler):
  
         except (AttributeError, TypeError):
             if "You must be registered to download this video" in ajax_soup.text:
-                raise ScrapeFailure(403, f"Invalid PHPSESSID: {scrape_item.url}")
+                raise ScrapeFailure(403, f"Invalid PHPSESSID: {scrape_item.url}", origin= scrape_item)
 
             if "TRAFFIC VERIFICATION" in soup.text:
                 await asyncio.sleep(self.wait_time)
                 self.wait_time = min (self.wait_time + 10, MAX_WAIT)
                 self.rate_limit = max (self.rate_limit *0.8, MIN_RATE_LIMIT)
                 self.request_limiter = AsyncLimiter(self.rate_limit, 60)
-                raise ScrapeFailure(429, f"Too many request: {scrape_item.url}")
-            raise ScrapeFailure(404, f"Could not find video source for {scrape_item.url}")
+                raise ScrapeFailure(429, f"Too many request: {scrape_item.url}", origin= scrape_item)
+            raise ScrapeFailure(404, f"Could not find video source for {scrape_item.url}", origin= scrape_item)
         
         # NOTE: hardcoding the extension to prevent quering the final server URL
         # final server URL is always different so it can not be saved to db.
@@ -119,7 +119,7 @@ class XXXBunkerCrawler(Crawler):
     async def playlist(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a playlist"""
         if not self.session_cookie:
-            raise ScrapeFailure(401, "No cookies provided")
+            raise ScrapeFailure(401, "No cookies provided", origin= scrape_item)
         
         async with self.request_limiter:
             soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
@@ -135,7 +135,7 @@ class XXXBunkerCrawler(Crawler):
         
         # Not a valid URL
         else:
-            raise ScrapeFailure(400, f"Unsupported URL format: {scrape_item.url}")
+            raise ScrapeFailure(400, f"Unsupported URL format: {scrape_item.url}", origin= scrape_item)
             
         scrape_item.part_of_album = True
 
@@ -178,7 +178,7 @@ class XXXBunkerCrawler(Crawler):
                 await asyncio.sleep(self.wait_time)
 
             if rate_limited:
-                raise ScrapeFailure(429, f"Too many request: {url}")
+                raise ScrapeFailure(429, f"Too many request: {url}", origin= scrape_item)
 
             next_page = soup.select_one("div.page-list")
             next_page = next_page.find('a', string='Next') if next_page else None

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -63,7 +63,7 @@ class XXXBunkerCrawler(Crawler):
             raise ScrapeFailure(401, "No cookies provided", origin= scrape_item)
         
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         title = soup.select_one('title').text.rsplit(" : XXXBunker.com")[0].strip()
         try:
@@ -78,7 +78,7 @@ class XXXBunkerCrawler(Crawler):
             video_iframe_url = URL(video_iframe.get('data-src'))
             video_id = video_iframe_url.parts[-1]
             async with self.request_limiter:
-                video_iframe_soup: BeautifulSoup = await self.client.get_BS4(self.domain, video_iframe_url)
+                video_iframe_soup: BeautifulSoup = await self.client.get_BS4(self.domain, video_iframe_url, origin = scrape_item)
 
             src = video_iframe_soup.select_one('source')
             src_url = URL(src.get('src'))
@@ -90,7 +90,7 @@ class XXXBunkerCrawler(Crawler):
             data = ({'internalid': internal_id })
 
             async with self.request_limiter:
-                ajax_dict = await self.client.post_data(self.domain, self.api_download, data=data)
+                ajax_dict = await self.client.post_data(self.domain, self.api_download, data=data, origin = scrape_item)
             
             ajax_soup = BeautifulSoup(ajax_dict['floater'], 'html.parser')
             link = URL(ajax_soup.select_one('a#download-download').get('href'))
@@ -122,7 +122,7 @@ class XXXBunkerCrawler(Crawler):
             raise ScrapeFailure(401, "No cookies provided", origin= scrape_item)
         
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url)
+            soup: BeautifulSoup = await self.client.get_BS4(self.domain, scrape_item.url, origin= scrape_item)
 
         if 'favoritevideos' in scrape_item.url.parts:
             title = await self.create_title(f"user {scrape_item.url.parts[2]} [favorites]", None,None)
@@ -178,7 +178,7 @@ class XXXBunkerCrawler(Crawler):
                 await asyncio.sleep(self.wait_time)
 
             if rate_limited:
-                raise ScrapeFailure(429, f"Too many request: {url}", origin= scrape_item)
+                raise ScrapeFailure(429, f"Too many request: {url}")
 
             next_page = soup.select_one("div.page-list")
             next_page = next_page.find('a', string='Next') if next_page else None

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -332,7 +332,8 @@ class ScrapeMapper:
         """Loads links from args / input file"""
         input_file = self.manager.path_manager.input_file
           # we need to touch the file just in case, purge_tree deletes it
-        input_file.touch(exist_ok=True)
+        if not input_file.is_file():
+            input_file.touch(exist_ok=True)
 
         links = {'': []}
         if not self.manager.args_manager.other_links:

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -3,6 +3,7 @@ from typing import Dict, Union, NamedTuple
 from rich.console import Group
 from rich.panel import Panel
 from rich.progress import Progress, BarColumn, TaskID
+from http import HTTPStatus
 
 class TaskInfo(NamedTuple):
     id: int
@@ -72,7 +73,7 @@ class DownloadStatsProgress:
         """Adds a failed file to the progress bar"""
         self.failed_files += 1
         if isinstance(failure_type, int):
-            failure_type = str(failure_type) + " HTTP Status"
+            failure_type = f"{failure_type} {HTTPStatus(failure_type).phrase}"
 
         if failure_type in self.failure_types:
             self.progress.advance(self.failure_types[failure_type], 1)

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -73,7 +73,10 @@ class DownloadStatsProgress:
         """Adds a failed file to the progress bar"""
         self.failed_files += 1
         if isinstance(failure_type, int):
-            failure_type = f"{failure_type} {HTTPStatus(failure_type).phrase}"
+            try:
+                failure_type = f"{failure_type} {HTTPStatus(failure_type).phrase}"
+            except ValueError:
+                failure_type = f"{failure_type} HTTP Error"
 
         if failure_type in self.failure_types:
             self.progress.advance(self.failure_types[failure_type], 1)

--- a/cyberdrop_dl/utils/args/config_definitions.py
+++ b/cyberdrop_dl/utils/args/config_definitions.py
@@ -76,8 +76,8 @@ settings: Dict = {
         "log_folder": str(APP_STORAGE / "Configs" / "{config}" / "Logs"),
         "webhook_url": "",
         "main_log_filename": "downloader.log",
-        "last_forum_post_filename": "Last_Scraped_Forum_Posts.txt",
-        "unsupported_urls_filename": "Unsupported_URLs.txt",
+        "last_forum_post_filename": "Last_Scraped_Forum_Posts.csv",
+        "unsupported_urls_filename": "Unsupported_URLs.csv",
         "download_error_urls_filename": "Download_Error_URLs.csv",
         "scrape_error_urls_filename": "Scrape_Error_URLs.csv",
         "rotate_logs": False

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -85,8 +85,10 @@ def error_handling_wrapper(func):
                 e_log_detail = str(err)
                 e_log_message = "See Log for Details"
                 e_ui_failure = "Unknown"
-                 
-        await log(f"Scrape Failed: {link} ({e_log_detail})", 40, exc_info = exc_info)
+            await log(f"Scrape Failed: {link} ({e_log_detail})", 40, exc_info = True)
+
+        if not exc_info:
+            await log(f"Scrape Failed: {link} ({e_log_detail})", 40)    
         await self.manager.log_manager.write_scrape_error_log(link, e_log_message, e_origin )
         await self.manager.progress_manager.scrape_stats_progress.add_failure(e_ui_failure)
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -16,6 +16,8 @@ from cyberdrop_dl.clients.errors import NoExtensionFailure, CDLBaseException
 from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
 from cyberdrop_dl.managers.console_manager import log as log_console
 
+DEFAULT_CONSOLE_WIDTH = 240
+
 if TYPE_CHECKING:
     from typing import Tuple
     from cyberdrop_dl.managers.manager import Manager
@@ -128,6 +130,14 @@ async def get_log_output_text() -> str:
     global LOG_OUTPUT_TEXT
     return LOG_OUTPUT_TEXT + "```"
 
+async def log_spacer(level: int) -> None:
+    global LOG_OUTPUT_TEXT
+    spacer = "-" * min(DEFAULT_CONSOLE_WIDTH / 2, 50)
+    rich.print(f"")
+    LOG_OUTPUT_TEXT += "\n"
+    logger.log(level,spacer)
+    if DEBUG_VAR:
+        logger_debug.log(level,spacer)
 
 """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -130,9 +130,9 @@ async def get_log_output_text() -> str:
     global LOG_OUTPUT_TEXT
     return LOG_OUTPUT_TEXT + "```"
 
-async def log_spacer(level: int) -> None:
+async def log_spacer(level: int, char: str = "-") -> None:
     global LOG_OUTPUT_TEXT
-    spacer = "-" * min(DEFAULT_CONSOLE_WIDTH / 2, 50)
+    spacer = char * min(DEFAULT_CONSOLE_WIDTH / 2, 50)
     rich.print(f"")
     LOG_OUTPUT_TEXT += "\n"
     logger.log(level,spacer)

--- a/docs/reference/configuration-options/settings.md
+++ b/docs/reference/configuration-options/settings.md
@@ -170,10 +170,10 @@ Files that will be rotated:
 | option                       | default_filename              |
 |------------------------------|-------------------------------|
 | download_error_urls_filename |  Download_Error_URLs.csv      |
-| last_forum_post_filename     |  Last_Scraped_Forum_Posts.txt |
+| last_forum_post_filename     |  Last_Scraped_Forum_Posts.csv |
 | main_log_filename            |  downloader.log               |
 | scrape_error_urls_filename   |  Scrape_Error_URLs.csv        |
-| unsupported_urls_filename    |  Unsupported_URLs.txt         |
+| unsupported_urls_filename    |  Unsupported_URLs.csv         |
 
 </details>
 


### PR DESCRIPTION
#### Changes

1. Move `PasswordProtected` errors, from `Unsupported_URLs` to `Scrape_Errors`
2. Use CSV format for every log file (except `downloader.log`)
3. Define a new custom exception, `CDLBaseException`, to simplify error handling. All other custom exceptions are now subclasses of `CDLBaseException`
4. Fix `update_last_forum_post` deleting comments/group lines from input file
5. Fix post-runtime functions running twice
6. Make `Unsupported URLS` their own category inside `print_stats()`
7. HTTP errors will raise with the message `<code> <phrase>` instead of `<code> HTTP Status`, both on the UI and in the logs

#### CSV definitions

| log_file                     | columns |
|------------------------------|---------|
| Scrape_Error_URLs.csv        |`url`, `error`, `origin`         |
| Download_Error_URLs.csv      | `url`, `error`, `origin`          |
| Unsupported_URLs.csv         | `url`, `origin`         |
| Last_Scraped_Forum_Posts.csv | `url`        |

#### TODO

- [x] ~~BUG: The UI does not clear properly before `print_stats()`. Does not happen in current master. Would look into it later today.~~
- [x] ~~Some more testing~~

***

I had to modify all the crawlers (_again..._) to make sure they include the origin before rising an exception.

Resolves #210 