### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ venv
 
 # Compiled package
 /dist/
+
+# MacOS system files
+**.DS_Store


### PR DESCRIPTION
`.DS_Store` files are automatically generated by MacOS.