### PR TITLE
ci: only run publish to Pypi if pyproject.toml was modified

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -6,6 +6,8 @@ on:
       - master
     tags:
       - '*.*.*'
+    paths:
+      - 'pyproject.toml'
 
 jobs:
   release:

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -8,6 +8,7 @@ on:
       - '*.*.*'
     paths:
       - 'pyproject.toml'
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
1. Only run `publish_to_pypi` if `pyproject.toml` was modified
2. Add manual trigger to `publish_to_pypi` if needed