### PR TITLE
ci: add ruff as linter and formatter + pre-commit hooks

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,19 @@
+name: Ruff
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+
+      - name: ruff lint
+        uses: astral-sh/ruff-action@v1
+        with:
+          changed-files: "true"
+
+      - name: ruff format check
+        uses: astral-sh/ruff-action@v1
+        with:
+          args: "format --check"
+          changed-files: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0  
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-toml
+      - id: check-yaml
+      - id: detect-private-key
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.2
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing
+
+## Found an Issue?
+
+If you find a bug in the source code or a mistake in the documentation, you can
+[open an Issue](#submitting-an-issue) to the GitHub Repository or you can
+[submit a Pull Request](#submitting-a-pull-request-pr) with a fix if you know how to code.
+
+## Want a Feature?
+
+You can *request* a new feature by [opening an issue](#submitting-an-issue). If you would like to *implement* a new feature,
+please open an issue or a discussion with a proposal first. If your feature is *small* and easy to implement,
+you can craft it and directly [submit it as a Pull Request](#submitting-a-pull-request-pr).
+
+## Submission Guidelines
+
+### Submitting an Issue
+
+Before openning an issue, search through existing issues to ensure you are not opening a duplicate.
+You must also [read the wiki](https://script-ware.gitbook.io/cyberdrop-dl/frequently-asked-questions) to learn how to solve most common problems.
+
+If your issue appears to be a bug, and hasn't been reported, open a new issue. Please do not report duplicate issues.
+Providing the following information will allow your issue to be dealt with quickly:
+
+- **Overview of the Issue** - always attach you logs to any new issue.
+- **Version** - what version of Cyberdrop-DL are you running. You should always update to the latest release before opening an issue since 
+the issue may have been fixed already
+- **Motivation for or Use Case** - explain what are you trying to do and why the current behavior is a bug for you
+- **Operating System** - what OS and version are you using
+- **Reproduce the Error** - provide a live example or a unambiguous set of steps
+- **Related Issues** - has a similar issue been reported before?
+- **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
+  causing the problem (line of code or commit)
+
+You can open a new issue by providing the above information at https://github.com/jbsparrow/CyberDropDownloader/issues/new/choose.
+
+### Submitting a Pull Request (PR)
+
+Before you submit your Pull Request (PR) consider the following guidelines:
+
+- Search the [repository](https://github.com/jbsparrow/CyberDropDownloader/pulls) for an open or closed PR
+  that relates to your submission. You don't want to duplicate effort.
+- Clone the repo and make your changes on a new branch in your fork
+- Follow [code style conventions](#code-style)
+- Commit your changes using a descriptive commit message
+- Push your fork to GitHub
+- In GitHub, create a pull request to the `master` branch of the repository. 
+- Add a description to your PR. If the PR is small (such as a typo fix), you can go brief. 
+If it contains a lot of changes, it's better to write more details.
+If your changes are user-facing (e.g. a new feature in the UI, a change in behavior, or a bugfix) 
+please include a short message to add to the changelog.
+- Wait for a maintainer to review your PR and then address any comments they might have.
+
+If everything is okay, your changes will be merged into the project.
+
+## Setting up the development environment
+
+1. Install a [supported version of Python](https://www.python.org/downloads/). Cyberdrop-DL supports python `3.11` through `3.12`
+(python `3.13` is **NOT** supported yet)
+
+2. Clone the repo
+
+```shell
+git clone "https://github.com/jbsparrow/CyberDropDownloader"
+cd CyberDropDownloader
+```
+
+3. Install `pipx` (optional, but recommended): https://pipx.pypa.io/stable/installation/
+
+4. Install `poetry`, the project management package Cyberdrop-DL uses
+
+> If you installed `pipx`:
+
+```shell
+pipx install poetry
+```
+
+> With regular `pip`:
+
+```shell
+pip install poetry
+```
+
+5. Install the project's dependencies
+
+```shell
+poetry install
+```
+
+6. Install the pre-commit hooks:
+
+```shell
+poetry run pre-commit install
+```
+
+## Code Style
+
+### Standards
+
+`Formatting`: This project uses [ruff](https://docs.astral.sh/ruff) for formatting, linting and import sorting.
+
+`Typechecking`: Typechecking is not enforced but highly recommended.
+
+`Line Width`: We use a line width of 120.
+
+### Code formatting with pre-commit hooks
+
+This project uses git pre-commit hooks to perform formatting and linting before a commit is allowed,
+to ensure consistent style and catch some common issues early on.
+
+Once installed, hooks will run when you commit. If the formatting isn't quite right or a linter catches something,
+the commit will be rejected and `ruff` will try to fix the files. If `ruff` can not fix all the issues,
+you will need to look at the output and fix them manually. When everything is fixed (either by `ruff` itself or manually)
+all you need to do is `git add` those files again and retry your commit.
+
+### Manual code formatting
+
+We recommend [setting up your IDE](https://docs.astral.sh/ruff/editors/) to format and check with `ruff`, but you can always run
+`poetry run ruff check --fix` then `poetry run ruff format` in the root directory before submitting a pull request.
+If you're using VScode, you can set it to [auto format python files with ruff on save](#editor-settings) in your `settings.json`
+
+## Editor settings
+
+If you use VScode and have `ruff` installed as a formatter, you might find the following `settings.json` useful:
+
+```json
+{
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  }
+}
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -324,6 +324,17 @@ files = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+description = "Validate configuration and produce human readable error messages."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
+    {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -463,6 +474,17 @@ files = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.3.9"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+files = [
+    {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
+    {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
+]
+
+[[package]]
 name = "filedate"
 version = "3.0"
 description = ""
@@ -474,6 +496,22 @@ files = [
 
 [package.dependencies]
 python-dateutil = "*"
+
+[[package]]
+name = "filelock"
+version = "3.16.1"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
+    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.4)"]
+typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "frozenlist"
@@ -599,6 +637,20 @@ files = [
 
 [package.dependencies]
 pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_version >= \"3.8\""}
+
+[[package]]
+name = "identify"
+version = "2.6.1"
+description = "File identification library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "identify-2.6.1-py2.py3-none-any.whl", hash = "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0"},
+    {file = "identify-2.6.1.tar.gz", hash = "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98"},
+]
+
+[package.extras]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -891,6 +943,17 @@ pycryptodome = "*"
 requests = "*"
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
+    {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.2.2"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1032,6 +1095,24 @@ files = [
 docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
 type = ["mypy (>=1.11.2)"]
+
+[[package]]
+name = "pre-commit"
+version = "4.0.1"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pre_commit-4.0.1-py2.py3-none-any.whl", hash = "sha256:efde913840816312445dc98787724647c65473daefe420785f885e8ed9a06878"},
+    {file = "pre_commit-4.0.1.tar.gz", hash = "sha256:80905ac375958c0444c65e9cebebd948b3cdb518f335a091a670a89d652139d2"},
+]
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prompt-toolkit"
@@ -1412,6 +1493,33 @@ pygments = ">=2.13.0,<3.0.0"
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "ruff"
+version = "0.7.2"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.7.2-py3-none-linux_armv6l.whl", hash = "sha256:b73f873b5f52092e63ed540adefc3c36f1f803790ecf2590e1df8bf0a9f72cb8"},
+    {file = "ruff-0.7.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5b813ef26db1015953daf476202585512afd6a6862a02cde63f3bafb53d0b2d4"},
+    {file = "ruff-0.7.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:853277dbd9675810c6826dad7a428d52a11760744508340e66bf46f8be9701d9"},
+    {file = "ruff-0.7.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21aae53ab1490a52bf4e3bf520c10ce120987b047c494cacf4edad0ba0888da2"},
+    {file = "ruff-0.7.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ccc7e0fc6e0cb3168443eeadb6445285abaae75142ee22b2b72c27d790ab60ba"},
+    {file = "ruff-0.7.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd77877a4e43b3a98e5ef4715ba3862105e299af0c48942cc6d51ba3d97dc859"},
+    {file = "ruff-0.7.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e00163fb897d35523c70d71a46fbaa43bf7bf9af0f4534c53ea5b96b2e03397b"},
+    {file = "ruff-0.7.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3c54b538633482dc342e9b634d91168fe8cc56b30a4b4f99287f4e339103e88"},
+    {file = "ruff-0.7.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b792468e9804a204be221b14257566669d1db5c00d6bb335996e5cd7004ba80"},
+    {file = "ruff-0.7.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dba53ed84ac19ae4bfb4ea4bf0172550a2285fa27fbb13e3746f04c80f7fa088"},
+    {file = "ruff-0.7.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b19fafe261bf741bca2764c14cbb4ee1819b67adb63ebc2db6401dcd652e3748"},
+    {file = "ruff-0.7.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28bd8220f4d8f79d590db9e2f6a0674f75ddbc3847277dd44ac1f8d30684b828"},
+    {file = "ruff-0.7.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9fd67094e77efbea932e62b5d2483006154794040abb3a5072e659096415ae1e"},
+    {file = "ruff-0.7.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:576305393998b7bd6c46018f8104ea3a9cb3fa7908c21d8580e3274a3b04b691"},
+    {file = "ruff-0.7.2-py3-none-win32.whl", hash = "sha256:fa993cfc9f0ff11187e82de874dfc3611df80852540331bc85c75809c93253a8"},
+    {file = "ruff-0.7.2-py3-none-win_amd64.whl", hash = "sha256:dd8800cbe0254e06b8fec585e97554047fb82c894973f7ff18558eee33d1cb88"},
+    {file = "ruff-0.7.2-py3-none-win_arm64.whl", hash = "sha256:bb8368cd45bba3f57bb29cbb8d64b4a33f8415d0149d2655c5c8539452ce7760"},
+    {file = "ruff-0.7.2.tar.gz", hash = "sha256:2b14e77293380e475b4e3a7a368e14549288ed2931fce259a6f99978669e844f"},
+]
+
+[[package]]
 name = "send2trash"
 version = "1.8.3"
 description = "Send file to trash natively under Mac OS X, Windows and Linux"
@@ -1506,6 +1614,26 @@ brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "virtualenv"
+version = "20.27.1"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "virtualenv-20.27.1-py3-none-any.whl", hash = "sha256:f11f1b8a29525562925f745563bfd48b189450f61fb34c4f9cc79dd5aa32a1f4"},
+    {file = "virtualenv-20.27.1.tar.gz", hash = "sha256:142c6be10212543b32c6c45d3d3893dff89112cc588b7d0879ae5a1ec03a47ba"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<5"
+
+[package.extras]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
 name = "wcwidth"
@@ -1617,4 +1745,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "47bcd0b811906271081f3102b7c209a40652d1a9d980c5749bd849a8935f2be0"
+content-hash = "773f1e4dbdc32f5e67a96ecb1b1c2e924853fd1501662cb115d135fd3b115f2a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,36 @@ apprise = "^1.9.0"
 [tool.poetry.scripts]
 cyberdrop-dl = "cyberdrop_dl.main:main"
 
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^4.0.1"
+ruff = "^0.7.2"
+
+[tool.ruff]
+line-length = 120
+fix = true
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "UP", # pyupgrade
+    "N",  # PEP8 naming conventions
+]
+
+ignore = [
+    "N806", # Uppercase variables in functions
+    "E501", # Suppress line-too-long, let formatter decide
+]
+
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR is a proposal to integrate [ruff ](https://github.com/astral-sh/ruff) as a linter and auto formatter for the entire repo, to minimize `git diff` on new commits, use a standard style and remove the necessity for future PRs that are just reformats

> [!CAUTION]
> This PR will highlight a ***bunch of issues*** in the entire codebase and will prevent any new commits from being made until those issues are fixed. It will also ***break basically every branch*** after the issues are fixed cause it will be practically impossible to rebase from master. They will require a manual (***huge***) merge conflict resolution. However, it will only need to be done once and `ruff` will handle any new commits in the future.

I will create a new PR with all the necessary fixes after this PR is merged. This PR is mostly just to reach an agreement about ruff implementation, and the rules definition that it will use to check new commits and auto fix them when possible.

I put some standard lint rules in the config.  Rules can always be added later on, or removed if they are found to be too restrictive

Even if approved, the merge of this PR can be postponed until other currently working-on branches are merged to master, to reduce merge conflicts.



