### PR TITLE
Autofix: [BUG]Cannot save content items with no date in nekohouse

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
@@ -189,7 +189,7 @@ class NekohouseCrawler(Crawler):
     @error_handling_wrapper
     async def handle_post_content(self, scrape_item: ScrapeItem, post: Dict, user: str, user_str: str) -> None:
         """Handles the content of a post"""
-        date = post["published"].replace("T", " ")
+        date = post.get("published", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")).replace("T", " ")
         post_id = post["id"]
         post_title = post.get("title", "")
 


### PR DESCRIPTION
Modified the `handle_post_content` method in the `NekohouseCrawler` class to use a default date when the post's published date is not available. This allows the scraper to save posts even when they don't have a date, fixing the issue with saving posts from URLs like https://nekohouse.su/fantia_products/user/19729. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    