### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,4 +1,4 @@
-name: Create Release
+name: Create GH Release
 
 on:
   workflow_dispatch:
@@ -34,8 +34,9 @@ jobs:
 
       - name: Create zip from subfolder
         run: |
-          cd scripts/release
-          zip -r ../../Cyberdrop-DL.v${VERSION_NUMBER}.zip .
+          mkdir -p zip/Cyberdrop-DL.v${VERSION_NUMBER}
+          cp -r scripts/release/* zip/Cyberdrop-DL.v${VERSION_NUMBER}
+          zip -r Cyberdrop-DL.v${VERSION_NUMBER}.zip zip/*
 
       - name: Create release
         id: create_release
@@ -45,5 +46,5 @@ jobs:
           body: |
             If you install and run the program with PIP yourself, you do not need anything here.
             Download the Cyberdrop-DL zip file below, you do not need to download the source code zip files.
-            The zip file contains start files that will download and install Cyberdrop-DL and keep it up to date. 
-          files: Cyberdrop-DL.v${VERSION_NUMBER}.zip 
+            The zip file contains start files that will download and install Cyberdrop-DL and keep it up to date.
+          files: Cyberdrop-DL.v${VERSION_NUMBER}.zip

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.11.4
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11.4"
 
@@ -50,7 +50,7 @@ jobs:
           else
             echo "tag_exists=false" >> $GITHUB_ENV
           fi
-      
+
       - name: Create Tag
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.tag_exists == 'false' }}
         run: |

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -9,11 +9,8 @@ jobs:
 
       - name: ruff lint
         uses: astral-sh/ruff-action@v1
-        with:
-          changed-files: "true"
 
       - name: ruff format check
         uses: astral-sh/ruff-action@v1
         with:
           args: "format --check"
-          changed-files: "true"


### PR DESCRIPTION
1. Update version of deprecated actions
2. Create sub-folder inside zip for GH releases action
3. Remove `changed-files: "true"` from ruff action now that the entire repo passes the check