### PR TITLE
fix: log origin of download errors

### DIFF
--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from yaml.constructor import ConstructorError
 
     from cyberdrop_dl.scraper.crawler import ScrapeItem
+    from cyberdrop_dl.utils.dataclasses.url_objects import MediaItem
 
 
 class CDLBaseError(Exception):
@@ -21,7 +22,7 @@ class CDLBaseError(Exception):
         *,
         message: str | None = None,
         status: str | int | None = None,
-        origin: ScrapeItem | URL | Path | None = None,
+        origin: ScrapeItem | MediaItem | URL | Path | None = None,
     ) -> None:
         self.ui_message = ui_message
         self.message = message or ui_message
@@ -35,21 +36,21 @@ class CDLBaseError(Exception):
 
 
 class InvalidContentTypeError(CDLBaseError):
-    def __init__(self, *, message: str | None = None, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when the content type isn't as expected."""
         ui_message = "Invalid Content Type"
         super().__init__(ui_message, message=message, origin=origin)
 
 
 class NoExtensionError(CDLBaseError):
-    def __init__(self, *, message: str | None = None, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when no extension is given for a file."""
         ui_message = "No File Extension"
         super().__init__(ui_message, message=message, origin=origin)
 
 
 class PasswordProtectedError(CDLBaseError):
-    def __init__(self, *, message: str | None = None, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when a file is password protected."""
         ui_message = "Password Protected"
         message = message or "File/Folder is password protected"
@@ -57,7 +58,7 @@ class PasswordProtectedError(CDLBaseError):
 
 
 class MaxChildrenError(CDLBaseError):
-    def __init__(self, *, message: str | None = None, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when an scrape item reaches its max number or children."""
         ui_message = "Max Children Reached"
         message = message or "Max number of children reached"
@@ -65,7 +66,7 @@ class MaxChildrenError(CDLBaseError):
 
 
 class DDOSGuardError(CDLBaseError):
-    def __init__(self, *, message: str | None = None, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when DDoS-Guard is detected."""
         ui_message = "DDoS-Guard"
         message = message or "DDoS-Guard detected"
@@ -73,7 +74,9 @@ class DDOSGuardError(CDLBaseError):
 
 
 class DownloadError(CDLBaseError):
-    def __init__(self, status: str | int, message: str | None = None, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(
+        self, status: str | int, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None
+    ) -> None:
         """This error will be thrown when a download fails."""
         ui_message = str(status)
         if isinstance(status, int):
@@ -85,21 +88,23 @@ class DownloadError(CDLBaseError):
 
 
 class InsufficientFreeSpaceError(CDLBaseError):
-    def __init__(self, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(self, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when no enough storage is available."""
         ui_message = "Insufficient Free Space"
         super().__init__(ui_message, origin=origin)
 
 
 class RestrictedFiletypeError(CDLBaseError):
-    def __init__(self, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(self, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when has a filytpe not allowed by config."""
         ui_message = "Restricted Filetype"
         super().__init__(ui_message, origin=origin)
 
 
 class ScrapeError(CDLBaseError):
-    def __init__(self, status: str | int, message: str | None = None, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(
+        self, status: str | int, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None
+    ) -> None:
         """This error will be thrown when a scrape fails."""
         ui_message = str(status)
         if isinstance(status, int):
@@ -111,7 +116,7 @@ class ScrapeError(CDLBaseError):
 
 
 class LoginError(CDLBaseError):
-    def __init__(self, *, message: str | None = None, origin: ScrapeItem | URL | None = None) -> None:
+    def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when the login fails for a site."""
         ui_message = "Failed Login"
         super().__init__(ui_message, message=message, origin=origin)

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -88,11 +88,9 @@ class Crawler(ABC):
         download_folder = get_download_path(self.manager, scrape_item, self.folder_domain)
         media_item = MediaItem(
             url,
-            scrape_item.url,
-            scrape_item.album_id,
+            scrape_item,
             download_folder,
             filename,
-            ext,
             original_filename,
             debrid_link,
         )

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -559,8 +559,8 @@ class ScrapeMapper:
             scrape_item.add_to_parent_title("Loose Files")
             scrape_item.part_of_album = True
             download_folder = get_download_path(self.manager, scrape_item, "no_crawler")
-            filename, ext = get_filename_and_ext(scrape_item.url.name)
-            media_item = MediaItem(scrape_item.url, scrape_item.url, None, download_folder, filename, ext, filename)
+            filename, _ = get_filename_and_ext(scrape_item.url.name)
+            media_item = MediaItem(scrape_item.url, scrape_item, download_folder, filename)
             self.manager.task_group.create_task(self.no_crawler_downloader.run(media_item))
             return
 

--- a/cyberdrop_dl/utils/dataclasses/url_objects.py
+++ b/cyberdrop_dl/utils/dataclasses/url_objects.py
@@ -40,6 +40,7 @@ class MediaItem:
         self.original_filename: str = str(original_filename) if original_filename else self.filename
         self.file_lock_reference_name: str = field(init=False)
         self.datetime: str = field(init=False)
+        self.parents = origin.parents.copy()
 
         self.filesize: int = field(init=False)
         self.current_attempt: int = field(init=False)

--- a/cyberdrop_dl/utils/dataclasses/url_objects.py
+++ b/cyberdrop_dl/utils/dataclasses/url_objects.py
@@ -23,23 +23,21 @@ class MediaItem:
     def __init__(
         self,
         url: URL,
-        referer: URL,
-        album_id: str | None,
+        origin: ScrapeItem,
         download_folder: Path,
-        filename: str,
-        ext: str,
-        original_filename: str,
+        filename: Path | str,
+        original_filename: Path | str | None,
         debrid_link: URL | None = None,
     ) -> None:
         self.url: URL = url
-        self.referer: URL = referer
+        self.referer: URL = origin.url
         self.debrid_link: URL | None = debrid_link
-        self.album_id: str | None = album_id
+        self.album_id: str | None = origin.album_id
         self.download_folder: Path = download_folder
-        self.filename: str = filename
-        self.ext: str = ext
+        self.filename: str = str(filename)
+        self.ext: str = Path(filename).suffix
         self.download_filename: str = field(init=False)
-        self.original_filename: str = original_filename
+        self.original_filename: str = str(original_filename) if original_filename else self.filename
         self.file_lock_reference_name: str = field(init=False)
         self.datetime: str = field(init=False)
 


### PR DESCRIPTION
1. `MediaItem` objects are now created passing the original `ScrapeItem` as a parameter
2. Add `parents` property to `MediaItem`

This fixes an issue where `Download_Errors` logs were missing the `origin` value after the ruff refactor