### PR TITLE
fix: external links call from crawlers

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -203,7 +203,7 @@ class CelebForumCrawler(Crawler):
             try:
                 if self.domain not in link.host:
                     new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                    await self.handle_external_links(new_scrape_item)
+                    self.handle_external_links(new_scrape_item)
                 elif self.attachment_url_part in link.parts:
                     await self.handle_internal_links(link, scrape_item)
                 else:
@@ -242,7 +242,7 @@ class CelebForumCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:
@@ -271,7 +271,7 @@ class CelebForumCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -291,7 +291,7 @@ class CelebForumCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -322,7 +322,7 @@ class CelebForumCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -207,7 +207,7 @@ class F95ZoneCrawler(Crawler):
             try:
                 if self.domain not in link.host:
                     new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                    await self.handle_external_links(new_scrape_item)
+                    self.handle_external_links(new_scrape_item)
                 elif self.attachment_url_part in link.host:
                     await self.handle_internal_links(link, scrape_item)
                 else:
@@ -245,7 +245,7 @@ class F95ZoneCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.host:
                 await self.handle_internal_links(link, scrape_item)
             else:
@@ -274,7 +274,7 @@ class F95ZoneCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -295,7 +295,7 @@ class F95ZoneCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -326,7 +326,7 @@ class F95ZoneCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.host:
                 await self.handle_internal_links(link, scrape_item)
             else:

--- a/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
@@ -75,7 +75,7 @@ class FapelloCrawler(Crawler):
                     True,
                     add_parent=scrape_item.url,
                 )
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             else:
                 link = URL(post.get("href"))
                 new_scrape_item = self.create_scrape_item(
@@ -85,7 +85,7 @@ class FapelloCrawler(Crawler):
                     True,
                     add_parent=scrape_item.url,
                 )
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             if scrape_item.children_limit and scrape_item.children >= scrape_item.children_limit:
                 raise MaxChildrenError(origin=scrape_item)
 

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -140,8 +140,6 @@ class KemonoCrawler(Crawler):
         scrape_item.album_id = post_id
         scrape_item.part_of_album = True
 
-        await self.get_content_links(scrape_item, post, user_str)
-
         scrape_item.children += await self.get_content_links(scrape_item, post, user_str)
 
         async def handle_file(file_obj: dict):
@@ -217,7 +215,7 @@ class KemonoCrawler(Crawler):
                 "",
                 add_parent=scrape_item.url.joinpath("post", post_id),
             )
-            await self.handle_external_links(scrape_item)
+            self.handle_external_links(scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -214,7 +214,7 @@ class LeakedModelsCrawler(Crawler):
             try:
                 if self.domain not in link.host:
                     new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                    await self.handle_external_links(new_scrape_item)
+                    self.handle_external_links(new_scrape_item)
                 elif self.attachment_url_part in link.parts:
                     await self.handle_internal_links(link, scrape_item)
                 else:
@@ -248,7 +248,7 @@ class LeakedModelsCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:
@@ -277,7 +277,7 @@ class LeakedModelsCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -297,7 +297,7 @@ class LeakedModelsCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -327,7 +327,7 @@ class LeakedModelsCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -203,7 +203,7 @@ class NudoStarCrawler(Crawler):
             try:
                 if self.domain not in link.host:
                     new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                    await self.handle_external_links(new_scrape_item)
+                    self.handle_external_links(new_scrape_item)
                 elif self.attachment_url_part in link.parts:
                     await self.handle_internal_links(link, scrape_item)
                 else:
@@ -239,7 +239,7 @@ class NudoStarCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:
@@ -266,7 +266,7 @@ class NudoStarCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -301,7 +301,7 @@ class NudoStarCrawler(Crawler):
                     link = link[:-1]
                 link = URL(link)
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
                 new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -328,7 +328,7 @@ class NudoStarCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:

--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -121,7 +121,7 @@ class PixelDrainCrawler(Crawler):
                         date,
                         add_parent=scrape_item.url,
                     )
-                    await self.handle_external_links(new_scrape_item)
+                    self.handle_external_links(new_scrape_item)
             elif "image" in JSON_Resp["mime_type"] or "video" in JSON_Resp["mime_type"]:
                 filename, ext = get_filename_and_ext(
                     JSON_Resp["name"] + "." + JSON_Resp["mime_type"].split("/")[-1],

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -156,7 +156,7 @@ class RedditCrawler(Crawler):
                 date,
                 add_parent=scrape_item.url,
             )
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
 
     async def gallery(self, scrape_item: ScrapeItem, submission: Submission, reddit: asyncpraw.Reddit) -> None:
         """Scrapes galleries."""

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -211,7 +211,7 @@ class SimpCityCrawler(Crawler):
             try:
                 if self.domain not in link.host:
                     new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                    await self.handle_external_links(new_scrape_item)
+                    self.handle_external_links(new_scrape_item)
                 elif self.attachment_url_part in link.parts:
                     await self.handle_internal_links(link, scrape_item)
                 else:
@@ -249,7 +249,7 @@ class SimpCityCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts:
                 continue
             else:
@@ -278,7 +278,7 @@ class SimpCityCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -313,7 +313,7 @@ class SimpCityCrawler(Crawler):
                     link = link[:-1]
                 link = URL(link)
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
                 new_children += 1
                 if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                     break
@@ -343,7 +343,7 @@ class SimpCityCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -210,7 +210,7 @@ class SocialMediaGirlsCrawler(Crawler):
             try:
                 if self.domain not in link.host:
                     new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                    await self.handle_external_links(new_scrape_item)
+                    self.handle_external_links(new_scrape_item)
                 elif self.attachment_url_part in link.parts or "smgmedia" in link.host:
                     await self.handle_internal_links(link, scrape_item)
                 else:
@@ -249,7 +249,7 @@ class SocialMediaGirlsCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts or "smgmedia" in link.host:
                 await self.handle_internal_links(link, scrape_item)
             else:
@@ -279,7 +279,7 @@ class SocialMediaGirlsCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -314,7 +314,7 @@ class SocialMediaGirlsCrawler(Crawler):
                     link = link[:-1]
                 link = URL(link)
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
                 new_children += 1
                 if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                     break
@@ -344,7 +344,7 @@ class SocialMediaGirlsCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts or "smgmedia" in link.host:
                 await self.handle_internal_links(link, scrape_item)
             else:

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -209,7 +209,7 @@ class XBunkerCrawler(Crawler):
             try:
                 if self.domain not in link.host:
                     new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                    await self.handle_external_links(new_scrape_item)
+                    self.handle_external_links(new_scrape_item)
                 elif self.attachment_url_part in link.parts or self.extra_attachment_url_part in link.parts:
                     await self.handle_internal_links(link, scrape_item)
                 else:
@@ -247,7 +247,7 @@ class XBunkerCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts or self.extra_attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:
@@ -277,7 +277,7 @@ class XBunkerCrawler(Crawler):
 
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-            await self.handle_external_links(new_scrape_item)
+            self.handle_external_links(new_scrape_item)
             new_children += 1
             if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                 break
@@ -312,7 +312,7 @@ class XBunkerCrawler(Crawler):
                     link = link[:-1]
                 link = URL(link)
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
                 new_children += 1
                 if scrape_item.children_limit and (new_children + scrape_item.children) >= scrape_item.children_limit:
                     break
@@ -342,7 +342,7 @@ class XBunkerCrawler(Crawler):
 
             if self.domain not in link.host:
                 new_scrape_item = self.create_scrape_item(scrape_item, link, "")
-                await self.handle_external_links(new_scrape_item)
+                self.handle_external_links(new_scrape_item)
             elif self.attachment_url_part in link.parts or self.extra_attachment_url_part in link.parts:
                 await self.handle_internal_links(link, scrape_item)
             else:


### PR DESCRIPTION
Do not use await when calling `crawler.handle_external_link()`

Fixes #255 