### PR TITLE
feat: import cookies from file (any supported site)

### DIFF
--- a/cyberdrop_dl/managers/log_manager.py
+++ b/cyberdrop_dl/managers/log_manager.py
@@ -32,7 +32,7 @@ class LogManager:
             if isinstance(var, Path):
                 var.unlink(missing_ok=True)
 
-    async def write_to_csv(self, file: Path, **kwargs):
+    async def write_to_csv(self, file: Path, **kwargs) -> None:
         """Write to the specified csv file. kwargs are columns for the CSV."""
         self._csv_locks[file] = self._csv_locks.get(file, Lock())
         async with self._csv_locks[file]:

--- a/cyberdrop_dl/managers/path_manager.py
+++ b/cyberdrop_dl/managers/path_manager.py
@@ -50,6 +50,7 @@ class PathManager:
 
         self.cache_dir = constants.APP_STORAGE / "Cache"
         self.config_dir = constants.APP_STORAGE / "Configs"
+        self.cookies_dir = constants.APP_STORAGE / "Cookies"
 
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.config_dir.mkdir(parents=True, exist_ok=True)

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import field
+from http.cookiejar import MozillaCookieJar
 from typing import TYPE_CHECKING, Any
 
 from bs4 import BeautifulSoup
@@ -41,6 +42,19 @@ class Crawler(ABC):
         """Starts the crawler."""
         self.client = self.manager.client_manager.scraper_session
         self.downloader = Downloader(self.manager, self.domain)
+        self.cookiejar_file = self.manager.path_manager.cookies_dir / f"{self.domain}.txt"
+        if self.cookiejar_file.is_file():
+            log(f"Found cookie file for: {self.domain}", 10)
+            try:
+                cookie_jar = MozillaCookieJar(self.cookiejar_file)
+                cookie_jar.load(ignore_discard=True)
+                for cookie in cookie_jar:
+                    self.manager.client_manager.cookies.update_cookies(
+                        {cookie.name: cookie.value}, response_url=URL(f"https://{cookie.domain}")
+                    )
+            except Exception:
+                log(f"Unable to apply cookies from {self.cookiejar_file}", 10, exc_info=True)
+
         self.downloader.startup()
 
     async def run(self, item: ScrapeItem) -> None:
@@ -192,6 +206,7 @@ class Crawler(ABC):
                     continue
                 self.logged_in = True
                 break
+
             except asyncio.exceptions.TimeoutError:
                 continue
 

--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -23,6 +23,7 @@ class CelebForumCrawler(Crawler):
         super().__init__(manager, "celebforum", "CelebForum")
         self.primary_base_domain = URL("https://celebforum.to")
         self.logged_in = False
+        self.login_attempts = 0
         self.request_limiter = AsyncLimiter(10, 1)
 
         self.title_selector = "h1[class=p-title-value]"
@@ -56,13 +57,18 @@ class CelebForumCrawler(Crawler):
         """Determines where to send the scrape item based on the url."""
         task_id = self.scraping_progress.add_task(scrape_item.url)
 
-        if not self.logged_in:
+        if not self.logged_in and self.login_attempts == 0:
             login_url = self.primary_base_domain / "login"
-            session_cookie = self.manager.config_manager.authentication_data["Forums"]["celebforum_xf_user_cookie"]
+            host_cookies = self.client.client_manager.cookies._cookies.get((self.primary_base_domain.host, ""), {})
+            session_cookie = host_cookies.get("xf_user").value if "xf_user" in host_cookies else None
+            if not session_cookie:
+                session_cookie = self.manager.config_manager.authentication_data["Forums"]["celebforum_xf_user_cookie"]
+
             username = self.manager.config_manager.authentication_data["Forums"]["celebforum_username"]
             password = self.manager.config_manager.authentication_data["Forums"]["celebforum_password"]
             wait_time = 5
 
+            self.login_attempts += 1
             await self.forum_login(login_url, session_cookie, username, password, wait_time)
 
         if self.logged_in:

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -23,6 +23,7 @@ class F95ZoneCrawler(Crawler):
         super().__init__(manager, "f95zone", "F95Zone")
         self.primary_base_domain = URL("https://f95zone.to")
         self.logged_in = False
+        self.login_attempts = 0
         self.request_limiter = AsyncLimiter(10, 1)
 
         self.title_selector = "h1[class=p-title-value]"
@@ -56,13 +57,18 @@ class F95ZoneCrawler(Crawler):
         """Determines where to send the scrape item based on the url."""
         task_id = self.scraping_progress.add_task(scrape_item.url)
 
-        if not self.logged_in:
+        if not self.logged_in and self.login_attempts == 0:
             login_url = self.primary_base_domain / "login"
-            session_cookie = self.manager.config_manager.authentication_data["Forums"]["f95zone_xf_user_cookie"]
+            host_cookies = self.client.client_manager.cookies._cookies.get((self.primary_base_domain.host, ""), {})
+            session_cookie = host_cookies.get("xf_user").value if "xf_user" in host_cookies else None
+            if not session_cookie:
+                session_cookie = self.manager.config_manager.authentication_data["Forums"]["f95zone_xf_user_cookie"]
+
             username = self.manager.config_manager.authentication_data["Forums"]["f95zone_username"]
             password = self.manager.config_manager.authentication_data["Forums"]["f95zone_password"]
             wait_time = 5
 
+            self.login_attempts += 1
             await self.forum_login(login_url, session_cookie, username, password, wait_time)
 
         if self.logged_in:

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -23,6 +23,7 @@ class LeakedModelsCrawler(Crawler):
         super().__init__(manager, "leakedmodels", "LeakedModels")
         self.primary_base_domain = URL("https://LeakedModels.com")
         self.logged_in = False
+        self.login_attempts = 0
         self.request_limiter = AsyncLimiter(10, 1)
 
         self.title_selector = "h1[class=p-title-value]"
@@ -57,15 +58,19 @@ class LeakedModelsCrawler(Crawler):
         task_id = self.scraping_progress.add_task(scrape_item.url)
 
         if "threads" in scrape_item.url.parts:
-            if not self.logged_in:
+            if not self.logged_in and self.login_attempts == 0:
                 login_url = self.primary_base_domain / "forum" / "login"
-                session_cookie = self.manager.config_manager.authentication_data["Forums"][
-                    "leakedmodels_xf_user_cookie"
-                ]
+                host_cookies = self.client.client_manager.cookies._cookies.get((self.primary_base_domain.host, ""), {})
+                session_cookie = host_cookies.get("xf_user").value if "xf_user" in host_cookies else None
+                if not session_cookie:
+                    session_cookie = self.manager.config_manager.authentication_data["Forums"][
+                        "leakedmodels_xf_user_cookie"
+                    ]
                 username = self.manager.config_manager.authentication_data["Forums"]["leakedmodels_username"]
                 password = self.manager.config_manager.authentication_data["Forums"]["leakedmodels_password"]
                 wait_time = 5
 
+                self.login_attempts += 1
                 await self.forum_login(login_url, session_cookie, username, password, wait_time)
 
             if self.logged_in:

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -24,6 +24,7 @@ class NudoStarCrawler(Crawler):
         super().__init__(manager, "nudostar", "NudoStar")
         self.primary_base_domain = URL("https://nudostar.com")
         self.logged_in = False
+        self.login_attempts = 0
         self.request_limiter = AsyncLimiter(10, 1)
 
         self.title_selector = "h1[class=p-title-value]"
@@ -57,13 +58,18 @@ class NudoStarCrawler(Crawler):
         """Determines where to send the scrape item based on the url."""
         task_id = self.scraping_progress.add_task(scrape_item.url)
 
-        if not self.logged_in:
+        if not self.logged_in and self.login_attempts == 0:
             login_url = self.primary_base_domain / "forum/login"
-            session_cookie = self.manager.config_manager.authentication_data["Forums"]["nudostar_xf_user_cookie"]
+            host_cookies = self.client.client_manager.cookies._cookies.get((self.primary_base_domain.host, ""), {})
+            session_cookie = host_cookies.get("xf_user").value if "xf_user" in host_cookies else None
+            if not session_cookie:
+                session_cookie = self.manager.config_manager.authentication_data["Forums"]["nudostar_xf_user_cookie"]
+
             username = self.manager.config_manager.authentication_data["Forums"]["nudostar_username"]
             password = self.manager.config_manager.authentication_data["Forums"]["nudostar_password"]
             wait_time = 5
 
+            self.login_attempts += 1
             await self.forum_login(login_url, session_cookie, username, password, wait_time)
 
         if self.logged_in:

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -60,6 +60,13 @@ class SimpCityCrawler(Crawler):
 
         if not self.logged_in and self.login_attempts == 0:
             login_url = self.primary_base_domain / "login"
+            host_cookies = self.client.client_manager.cookies._cookies.get((self.primary_base_domain.host, ""), {})
+            session_cookie = host_cookies.get("xf_user").value if "xf_user" in host_cookies else None
+            if not session_cookie:
+                session_cookie = self.manager.config_manager.authentication_data["Forums"].get(
+                    "simpcity_xf_user_cookie"
+                )
+
             session_cookie = self.manager.config_manager.authentication_data["Forums"]["simpcity_xf_user_cookie"]
             username = self.manager.config_manager.authentication_data["Forums"]["simpcity_username"]
             password = self.manager.config_manager.authentication_data["Forums"]["simpcity_password"]
@@ -98,6 +105,7 @@ class SimpCityCrawler(Crawler):
 
         current_post_number = 0
         while True:
+            thread_url = scrape_item.url if current_post_number == 0 else thread_url
             async with self.request_limiter:
                 soup: BeautifulSoup = await self.client.get_soup(self.domain, thread_url, origin=scrape_item)
 

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -24,6 +24,7 @@ class SocialMediaGirlsCrawler(Crawler):
         super().__init__(manager, "socialmediagirls", "SocialMediaGirls")
         self.primary_base_domain = URL("https://forums.socialmediagirls.com")
         self.logged_in = False
+        self.login_attempts = 0
         self.request_limiter = AsyncLimiter(10, 1)
 
         self.title_selector = "h1[class=p-title-value]"
@@ -57,15 +58,20 @@ class SocialMediaGirlsCrawler(Crawler):
         """Determines where to send the scrape item based on the url."""
         task_id = self.scraping_progress.add_task(scrape_item.url)
 
-        if not self.logged_in:
+        if not self.logged_in and self.login_attempts == 0:
             login_url = self.primary_base_domain / "login"
-            session_cookie = self.manager.config_manager.authentication_data["Forums"][
-                "socialmediagirls_xf_user_cookie"
-            ]
+            host_cookies = self.client.client_manager.cookies._cookies.get((self.primary_base_domain.host, ""), {})
+            session_cookie = host_cookies.get("xf_user").value if "xf_user" in host_cookies else None
+            if not session_cookie:
+                session_cookie = self.manager.config_manager.authentication_data["Forums"][
+                    "socialmediagirls_xf_user_cookie"
+                ]
+
             username = self.manager.config_manager.authentication_data["Forums"]["socialmediagirls_username"]
             password = self.manager.config_manager.authentication_data["Forums"]["socialmediagirls_password"]
-            wait_time = 15
+            wait_time = 10
 
+            self.login_attempts += 1
             await self.forum_login(login_url, session_cookie, username, password, wait_time)
 
         if self.logged_in:

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -24,6 +24,7 @@ class XBunkerCrawler(Crawler):
         super().__init__(manager, "xbunker", "XBunker")
         self.primary_base_domain = URL("https://xbunker.nu/")
         self.logged_in = False
+        self.login_attempts = 0
         self.request_limiter = AsyncLimiter(10, 1)
 
         self.title_selector = "h1[class=p-title-value]"
@@ -61,13 +62,18 @@ class XBunkerCrawler(Crawler):
         """Determines where to send the scrape item based on the url."""
         task_id = self.scraping_progress.add_task(scrape_item.url)
 
-        if not self.logged_in:
+        if not self.logged_in and self.login_attempts == 0:
             login_url = self.primary_base_domain / "login"
-            session_cookie = self.manager.config_manager.authentication_data["Forums"]["xbunker_xf_user_cookie"]
+            host_cookies = self.client.client_manager.cookies._cookies.get((self.primary_base_domain.host, ""), {})
+            session_cookie = host_cookies.get("xf_user").value if "xf_user" in host_cookies else None
+            if not session_cookie:
+                session_cookie = self.manager.config_manager.authentication_data["Forums"]["xbunker_xf_user_cookie"]
+
             username = self.manager.config_manager.authentication_data["Forums"]["xbunker_username"]
             password = self.manager.config_manager.authentication_data["Forums"]["xbunker_password"]
             wait_time = 5
 
+            self.login_attempts += 1
             await self.forum_login(login_url, session_cookie, username, password, wait_time)
 
         if self.logged_in:


### PR DESCRIPTION
Same changes as #166 except it does not include any of the UI prompts to import cookies. 

User have to manually create the cookies file inside `AppData / Cookies`. I will add the prompt on a later PR with the rework of all the prompts.

Related to #250 