### PR TITLE
refactor: use alternate screen for rich.live + handle critical errors

### DIFF
--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -140,8 +140,11 @@ class ClientManager:
                 if "data" in JSON_Resp and "error" in JSON_Resp["data"]:
                     raise ScrapeError(JSON_Resp["status"], JSON_Resp["data"]["error"], origin=origin)
 
+        response_text = None
         with contextlib.suppress(UnicodeDecodeError):
             response_text = await response.text()
+
+        if response_text:
             soup = BeautifulSoup(response_text, "html.parser")
             if cls.check_ddos_guard(soup):
                 raise DDOSGuardError(origin=origin)
@@ -161,10 +164,11 @@ class ClientManager:
 
     @staticmethod
     def check_ddos_guard(soup: BeautifulSoup) -> bool:
-        for title in DDOS_GUARD_CHALLENGE_TITLES:
-            challenge_found = title.casefold() == soup.title.string.casefold()
-            if challenge_found:
-                return True
+        if soup.title:
+            for title in DDOS_GUARD_CHALLENGE_TITLES:
+                challenge_found = title.casefold() == soup.title.string.casefold()
+                if challenge_found:
+                    return True
 
         for selector in DDOS_GUARD_CHALLENGE_SELECTORS:
             challenge_found = soup.find(selector)

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -263,7 +263,7 @@ class Flaresolverr:
             raise DDOSGuardError(message="Invalid response from flaresolverr", origin=origin)
         response = BeautifulSoup(solution.get("response"), "html.parser")
         response_url = URL(solution.get("url"))
-        cookies: list [dict] = solution.get("cookies")
+        cookies: list[dict] = solution.get("cookies")
         user_agent = client_session.headers.get("User-Agent").strip()
         flaresolverr_user_agent = solution.get("userAgent").strip()
         mismatch_msg = f"Config user_agent and flaresolverr user_agent do not match:\n  Cyberdrop-DL: {user_agent}\n  Flaresolverr: {flaresolverr_user_agent}"
@@ -279,6 +279,8 @@ class Flaresolverr:
                 log(f"{mismatch_msg}\nResponse was successful but cookies will not be valid", 30)
 
             for cookie in cookies:
-                self.client_manager.cookies.update_cookies({cookie['name']: cookie['value']}, URL(f"https://{cookie['domain']}"))
+                self.client_manager.cookies.update_cookies(
+                    {cookie["name"]: cookie["value"]}, URL(f"https://{cookie['domain']}")
+                )
 
         return response, response_url

--- a/cyberdrop_dl/managers/live_manager.py
+++ b/cyberdrop_dl/managers/live_manager.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from rich.live import Live
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
-from cyberdrop_dl.utils.logger import console, log
+from cyberdrop_dl.utils.logger import console
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -40,15 +40,6 @@ class LiveManager:
             self.live.start()
             self.live.update(show, refresh=True)
             yield self.live
-
-        except* Exception as e:
-            msg = f"Issue with rich live: {e}"
-            log(msg, 50, exc_info=True)
-            if isinstance(e, ExceptionGroup):
-                for sub_exception in e.exceptions:
-                    msg = f"Multiple exception caught: {type(sub_exception).__name__} - {sub_exception}"
-                    log(msg, 50, exc_info=sub_exception)
-            raise
         finally:
             if stop:
                 self.live.stop()

--- a/cyberdrop_dl/managers/live_manager.py
+++ b/cyberdrop_dl/managers/live_manager.py
@@ -24,6 +24,7 @@ class LiveManager:
             refresh_per_second=self.manager.config_manager.global_settings_data["UI_Options"]["refresh_rate"],
             console=console,
             transient=True,
+            screen=not self.manager.args_manager.no_ui,
         )
 
         self.placeholder = Progress(

--- a/cyberdrop_dl/scraper/crawlers/chevereto_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/chevereto_crawler.py
@@ -180,7 +180,7 @@ class CheveretoCrawler(Crawler):
                     album_id,
                     add_parent=scrape_item.url,
                 )
-                if not await self.check_album_results(link, results):
+                if not self.check_album_results(link, results):
                     await self.handle_direct_link(new_scrape_item)
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/crawlers/erome_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/erome_crawler.py
@@ -102,7 +102,7 @@ class EromeCrawler(Crawler):
 
         for link in image_links + video_links:
             filename, ext = get_filename_and_ext(link.name)
-            if not await self.check_album_results(link, results):
+            if not self.check_album_results(link, results):
                 await self.handle_file(link, scrape_item, filename, ext)
             scrape_item.children += 1
             if scrape_item.children_limit and scrape_item.children >= scrape_item.children_limit:

--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -79,7 +79,7 @@ class PixelDrainCrawler(Crawler):
                 date,
                 add_parent=scrape_item.url,
             )
-            if not await self.check_album_results(link, results):
+            if not self.check_album_results(link, results):
                 await self.handle_file(link, new_scrape_item, filename, ext)
             scrape_item.children += 1
             if scrape_item.children_limit and scrape_item.children >= scrape_item.children_limit:

--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -62,7 +62,7 @@ class SaintCrawler(Crawler):
             match: Match = re.search(r"\('(.+?)'\)", video.get("onclick"))
             link = URL(match.group(1)) if match else None
             filename, ext = get_filename_and_ext(link.name)
-            if not await self.check_album_results(link, results):
+            if not self.check_album_results(link, results):
                 await self.handle_file(link, scrape_item, filename, ext)
 
     @error_handling_wrapper

--- a/cyberdrop_dl/scraper/jdownloader.py
+++ b/cyberdrop_dl/scraper/jdownloader.py
@@ -93,5 +93,5 @@ class JDownloader:
                     },
                 ],
             )
-        except (AssertionError, myjdapi.MYJDApiException) as e:
+        except (AssertionError, myjdapi.MYJDException) as e:
             raise JDownloaderError(e) from e


### PR DESCRIPTION
1. Use an alternate console screen for every `rich.live` instance. This solves some flickering issues and prevents leftover UI elements from appearing when CDL exits, even if CDL crashed
2. Handle all critical errors from within `main:director()`
3. Always execute `manager.close()`, even is CDL crashed
4. Do not use `await` with `check_album_results()`
5. Fix flaresolverr default session not getting closed
6. Do not throw a `DDosGuardError` if flaresolverr response is valid but its `user-agent` does not match CDL's `user-agent`