### PR TITLE
refactor: only log "download finished" if the download was successful

### DIFF
--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -144,8 +144,6 @@ class Downloader:
                     log(f"{self.log_prefix} failed: {media_item.url} with error {e}", 40, exc_info=True)
                     self.manager.progress_manager.download_stats_progress.add_failure("Unknown")
                     self.manager.progress_manager.download_progress.add_failed()
-                else:
-                    log(f"{self.log_prefix} finished: {media_item.url}", 20)
                 finally:
                     await self._file_lock.release_lock(media_item.file_lock_reference_name)
         self._semaphore.release()
@@ -195,6 +193,7 @@ class Downloader:
                 self.set_file_datetime(media_item, media_item.complete_file)
                 self.attempt_task_removal(media_item)
                 self.manager.progress_manager.download_progress.add_completed()
+                log(f"Download finished: {media_item.url}", 20)
 
         except RestrictedFiletypeError:
             self.manager.progress_manager.download_progress.add_skipped()

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -66,10 +66,9 @@ class Crawler(ABC):
         await self._lock.acquire()
         self.waiting_items -= 1
         if item.url.path_qs not in self.scraped_items:
-            log(f"Scrape Starting: {item.url}", 20)
+            log(f"Scraping: {item.url}", 20)
             self.scraped_items.append(item.url.path_qs)
             await self.fetch(item)
-            log(f"Scrape Finished: {item.url}", 20)
         else:
             log(f"Skipping {item.url} as it has already been scraped", 10)
         self._lock.release()

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -38,7 +38,7 @@ def error_handling_wrapper(func: Callable) -> None:
             return await func(self, *args, **kwargs)
         except CDLBaseError as e:
             log_message_short = e_ui_failure = e.ui_message
-            log_message = e.message
+            log_message = f"{e.ui_message} - {e.message}" if e.ui_message != e.message else e.message
             origin = e.origin
         except RealDebridError as e:
             log_message_short = log_message = f"RealDebridError - {e.error}"


### PR DESCRIPTION
1. Only log `Download finished` if the download was successful
2. Tried to do the same for the `Scrape finished` log message but this will require modifying every crawler to make them return if the scrape was successful or not. Instead, I just removed the log entirely and changed `Scrape starting: <URL>` to `Scraping <URL>`
3. Any error while scraping/downloading would still be logged

Resolves #259 