### PR TITLE
Fix: Syntax error fix for jeepney

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ arrow = "^1.3.0"
 apprise = "^1.9.0"
 lz4 = "^4.3.3"
 pycryptodomex = "^3.21.0"
-jeepney = {version = "^0.8.0", extras = ["python_version", ">=", "\"3.7\"", "and", "(\"bsd\"", "in", "sys_platform", "or", "sys_platform", "==", "\"linux\")"]}
+jeepney =   [{platform = "linux", version = "^0.8.0"},{platform = "bsd", version = "^0.8.0"}]
 
 [tool.poetry.scripts]
 cyberdrop-dl = "cyberdrop_dl.main:main"


### PR DESCRIPTION
The previous syntax for specifying  jeepney was not compatible with pip