### PR TITLE
fix: config settings errors

### DIFF
--- a/cyberdrop_dl/managers/args_manager.py
+++ b/cyberdrop_dl/managers/args_manager.py
@@ -153,7 +153,7 @@ class ArgsManager:
         del self.parsed_args["download_dir"]
         del self.parsed_args["appdata_dir"]
         del self.parsed_args["config_file"]
-        del self.parsed_args["log_folder"]
+        del self.parsed_args["log_dir"]
         del self.parsed_args["proxy"]
         del self.parsed_args["links"]
         del self.parsed_args["sort_downloads"]

--- a/cyberdrop_dl/managers/config_manager.py
+++ b/cyberdrop_dl/managers/config_manager.py
@@ -121,10 +121,10 @@ class ConfigManager:
             self.write_updated_settings_config()
 
     def return_verified(self, value) -> any:
-        if isinstance(value, int):
-            return int(value)
         if isinstance(value, bool):
             return bool(value)
+        if isinstance(value, int):
+            return int(value)
         if isinstance(value, str):
             return str(value)
         if isinstance(value, list):

--- a/cyberdrop_dl/utils/args/args.py
+++ b/cyberdrop_dl/utils/args/args.py
@@ -77,6 +77,7 @@ def parse_args() -> argparse.Namespace:
     )
     file_paths.add_argument(
         "--log-folder",
+        dest="log_dir",
         type=str,
         help="path to where you want CDL to store it's log files",
         default="",


### PR DESCRIPTION
1. fix `--log-folder` not overriding config value
2. fix `bool` values being replaced by numbers in the config