### PR TITLE
fix: open config files when running without DE (linux)

### DIFF
--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -379,8 +379,8 @@ async def send_webhook_message(manager: Manager) -> None:
 def open_in_text_editor(file_path: Path) -> bool:
     """Opens file in OS text editor."""
     using_desktop_enviroment = (
-        os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
-    ) and "SSH_CONNECTION" not in os.environ
+        any(var in os.environ for var in ("DISPLAY", "WAYLAND_DISPLAY")) and "SSH_CONNECTION" not in os.environ
+    )
     default_editor = os.environ.get("EDITOR")
     if platform.system() == "Darwin":
         subprocess.Popen(["open", "-a", "TextEdit", file_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
1. Fallback to `$EDITOR`  when running without DE or over SSH (linux)
2. Fallback to `micro` if `$EDITOR` is not set
3. Fallback to `nano` if micro is not installed
4. Fallback to `vim` if nano is not installed
5. Throw `No default text editor found` error if every check fails

Fixes #307 