### PR TITLE
refactor: move soup check up compare to original

### DIFF
--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -131,6 +131,18 @@ class ClientManager:
         if download and headers.get("ETag") in DOWNLOAD_ERROR_ETAGS:
             message = DOWNLOAD_ERROR_ETAGS.get(headers.get("ETag"))
             raise DownloadError(HTTPStatus.NOT_FOUND, message=message, origin=origin)
+        
+        response_text = None
+        with contextlib.suppress(UnicodeDecodeError):
+            response_text = await response.text()
+
+        if response_text:
+            soup = BeautifulSoup(response_text, "html.parser")
+            if cls.check_ddos_guard(soup) or cls.check_cloudflare(soup):
+                raise DDOSGuardError(origin=origin)
+
+        if HTTPStatus.OK <= status < HTTPStatus.BAD_REQUEST:
+            return
 
         if any(domain in response.url.host for domain in ("gofile", "imgur")):
             with contextlib.suppress(ContentTypeError):
@@ -140,16 +152,7 @@ class ClientManager:
                 if "data" in JSON_Resp and "error" in JSON_Resp["data"]:
                     raise ScrapeError(JSON_Resp["status"], JSON_Resp["data"]["error"], origin=origin)
 
-        response_text = None
-        with contextlib.suppress(UnicodeDecodeError):
-            response_text = await response.text()
-
-        if response_text:
-            soup = BeautifulSoup(response_text, "html.parser")
-            if cls.check_ddos_guard(soup) or cls.check_cloudflare(soup):
-                raise DDOSGuardError(origin=origin)
-        if HTTPStatus.OK <= status < HTTPStatus.BAD_REQUEST:
-            return
+        
 
         status = status if headers.get("Content-Type") else CustomHTTPStatus.IM_A_TEAPOT
         message = "No content-type in response header" if headers.get("Content-Type") else None


### PR DESCRIPTION
```
    @classmethod
    async def check_http_status(
        cls,
        response: ClientResponse,
        download: bool = False,
        origin: ScrapeItem | URL | None = None,
    ) -> None:
        """Checks the HTTP status code and raises an exception if it's not acceptable."""
        status = response.status
        headers = response.headers

        if download and headers.get("ETag") in DOWNLOAD_ERROR_ETAGS:
            message = DOWNLOAD_ERROR_ETAGS.get(headers.get("ETag"))
            raise DownloadError(HTTPStatus.NOT_FOUND, message=message, origin=origin)

        if HTTPStatus.OK <= status < HTTPStatus.BAD_REQUEST:
            return

        if any(domain in response.url.host for domain in ("gofile", "imgur")):
            with contextlib.suppress(ContentTypeError):
                JSON_Resp: dict = await response.json()
                if "status" in JSON_Resp and "notFound" in JSON_Resp["status"]:
                    raise ScrapeError(HTTPStatus.NOT_FOUND, origin=origin)
                if "data" in JSON_Resp and "error" in JSON_Resp["data"]:
                    raise ScrapeError(JSON_Resp["status"], JSON_Resp["data"]["error"], origin=origin)

        response_text = None
        with contextlib.suppress(UnicodeDecodeError):
            response_text = await response.text()

        if response_text:
            soup = BeautifulSoup(response_text, "html.parser")
            if cls.check_ddos_guard(soup):
                raise DDOSGuardError(origin=origin)

        status = status if headers.get("Content-Type") else CustomHTTPStatus.IM_A_TEAPOT
        message = "No content-type in response header" if headers.get("Content-Type") else None

        raise DownloadError(status=status, message=message, origin=origin)

```

only the ddos check is moved now with all other lines in original place