### PR TITLE
fix: parsing arrows

### DIFF
--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -184,9 +184,11 @@ class ScrapeMapper:
 
     async def load_all_links(self) -> None:
         """Loads all links from database."""
+        after=self.manager.parsed_args.cli_only_args.completed_after or arrow.get(0)
+        before=self.manager.parsed_args.cli_only_args.completed_before or arrow.now().shift(days=1)
         entries = await self.manager.db_manager.history_table.get_all_items(
-            self.manager.parsed_args.cli_only_args.completed_after,
-            self.manager.parsed_args.cli_only_args.completed_before,
+            after,
+            before,
         )
         items = []
         for entry in entries:

--- a/cyberdrop_dl/utils/args.py
+++ b/cyberdrop_dl/utils/args.py
@@ -21,8 +21,8 @@ def _check_mutually_exclusive(group: set, msg: str) -> None:
 class CommandLineOnlyArgs(BaseModel):
     links: list[HttpURL] = Field([], description="link(s) to content to download (passing multiple links is supported)")
     appdata_folder: Path | None = Field(None, description="AppData folder path")
-    completed_after: int | None = Field(None, description="only download completed downloads at or after this date")
-    completed_before: int | None = Field(None, description="only download completed downloads at or before this date")
+    completed_after: str | None = Field(None, description="only download completed downloads at or after this date")
+    completed_before: str | None = Field(None, description="only download completed downloads at or before this date")
     config: str | None = Field(None, description="name of config to load")
     config_file: Path | None = Field(None, description="path to the CDL settings.yaml file to load")
     download: bool = Field(False, description="skips UI, start download inmediatly")


### PR DESCRIPTION
--completed-after and --completed-before use arrow parsing, and should accept strings so values like 
2023.10.15 can be be input

Arrow will raise an expection if t can't parse a str