### PR TITLE
chore: pin aiolimiter to v1.1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1988,4 +1988,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "1520fb7ab11e3b0365315586d76872af510b0b366b8d79c92e1fabae1fe37a8d"
+content-hash = "f86cb5c58394afc923bdc1154f66edbf51f842fd67a9c4d5b0e30790574be8ce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ include = ["CHANGELOG.md"]
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"
 aiohttp = "^3.9.1"
-aiolimiter = "^1.1.0"
 inquirerpy = "^0.3.4"
 platformdirs = "^4.2.2"
 rich = "^13.7.0"
@@ -38,6 +37,7 @@ xxhash = "^3.5.0"
 pyreadline3 = "^3.5.4"
 pydantic = "^2.10.2"
 aenum = "^3.1.15"
+aiolimiter = "1.1.0"
 
 [tool.poetry.scripts]
 cyberdrop-dl = "cyberdrop_dl.main:main"

--- a/scripts/release/start_linux.sh
+++ b/scripts/release/start_linux.sh
@@ -57,5 +57,6 @@ echo
 
 echo Installing / Updating Cyberdrop-DL
 pip uninstall -y -q -q cyberdrop-dl
+pip install aiolimiter==1.1.0
 pip install --upgrade "cyberdrop-dl-patched>=5.7,<6.0" && clear && cyberdrop-dl $COMMANDLINE_ARGS
 echo

--- a/scripts/release/start_macOS.command
+++ b/scripts/release/start_macOS.command
@@ -57,5 +57,6 @@ echo
 
 echo Installing / Updating Cyberdrop-DL
 pip uninstall -y -q -q cyberdrop-dl
+pip install aiolimiter==1.1.0
 pip install --upgrade "cyberdrop-dl-patched>=5.7,<6.0" && clear && cyberdrop-dl $COMMANDLINE_ARGS
 echo

--- a/scripts/release/start_windows.bat
+++ b/scripts/release/start_windows.bat
@@ -46,5 +46,6 @@ echo:
 
 echo Installing / Updating Cyberdrop-DL
 pip uninstall -y -q -q cyberdrop-dl
+pip install aiolimiter==1.1.0
 pip install --upgrade "cyberdrop-dl-patched>=5.7,<6.0" && cls && cyberdrop-dl %COMMANDLINE_ARGS%
 pause


### PR DESCRIPTION
`aiolimiter` released v1.1.1 today (2024-11-30), which breaks some functionality of CDL.

This is a temporary workaround, pining the version to v1.1.0. We need to update the actual code at some point to properly use v1.1.1