### PR TITLE
fix: allow duplicate files download on the same run with --ignore-history

### DIFF
--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -127,7 +127,10 @@ class Downloader:
 
         await self._semaphore.acquire()
         self.waiting_items -= 1
-        if media_item.url.path not in self.processed_items:
+        if (
+            media_item.url.path not in self.processed_items
+            or self.manager.config_manager.settings_data.runtime_options.ignore_history
+        ):
             self.processed_items.append(media_item.url.path)
             self.manager.progress_manager.download_progress.update_total()
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -145,7 +145,7 @@ class ClientManager:
             if cls.check_ddos_guard(soup) and cls.check_cloudflare(soup):
                 raise DDOSGuardError(origin=origin)
         status = status if headers.get("Content-Type") else CustomHTTPStatus.IM_A_TEAPOT
-        message = "No content-type in response header" if headers.get("Content-Type") else None
+        message = None if headers.get("Content-Type") else "No content-type in response header"
 
         raise DownloadError(status=status, message=message, origin=origin)
 


### PR DESCRIPTION
The same `MediaItem` URL can be downloaded multiple times if `--ignore-history` is used

Duplicate `ScrapeItem` URLs are still skipped, to prevent loops.

- Fixes #337