### PR TITLE
fix: sorting

### DIFF
--- a/cyberdrop_dl/config_definitions/config_settings.py
+++ b/cyberdrop_dl/config_definitions/config_settings.py
@@ -132,7 +132,6 @@ class Sorting(BaseModel):
     sort_downloads: bool = False
     sort_folder: Path = DOWNLOAD_STORAGE / "Cyberdrop-DL Sorted Downloads"
     scan_folder: Path | None = None
-    sort_cdl_only: bool = True
     sort_incremementer_format: NonEmptyStr = " ({i})"
     sorted_audio: NonEmptyStr | None = "{sort_dir}/{base_dir}/Audio/{filename}{ext}"
     sorted_image: NonEmptyStr | None = "{sort_dir}/{base_dir}/Images/{filename}{ext}"

--- a/cyberdrop_dl/config_definitions/config_settings.py
+++ b/cyberdrop_dl/config_definitions/config_settings.py
@@ -134,12 +134,12 @@ class Sorting(BaseModel):
     scan_folder: Path | None = None
     sort_cdl_only: bool = True
     sort_incremementer_format: NonEmptyStr = " ({i})"
-    sorted_audio: NonEmptyStr = "{sort_dir}/{base_dir}/Audio/{filename}{ext}"
-    sorted_image: NonEmptyStr = "{sort_dir}/{base_dir}/Images/{filename}{ext}"
-    sorted_other: NonEmptyStr = "{sort_dir}/{base_dir}/Other/{filename}{ext}"
-    sorted_video: NonEmptyStr = "{sort_dir}/{base_dir}/Videos/{filename}{ext}"
+    sorted_audio: NonEmptyStr | None = "{sort_dir}/{base_dir}/Audio/{filename}{ext}"
+    sorted_image: NonEmptyStr | None = "{sort_dir}/{base_dir}/Images/{filename}{ext}"
+    sorted_other: NonEmptyStr | None = "{sort_dir}/{base_dir}/Other/{filename}{ext}"
+    sorted_video: NonEmptyStr | None = "{sort_dir}/{base_dir}/Videos/{filename}{ext}"
 
-    @field_validator("scan_folder", mode="before")
+    @field_validator("scan_folder", "sorted_audio", "sorted_image", "sorted_other", "sorted_video", mode="before")
     @classmethod
     def handle_falsy(cls, value: str) -> str | None:
         if not value or value == "None":

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -106,7 +106,7 @@ async def post_runtime(manager: Manager) -> None:
         await manager.hash_manager.hash_client.cleanup_dupes_after_download()
     if manager.config_manager.settings_data.sorting.sort_downloads and not manager.parsed_args.cli_only_args.retry_any:
         sorter = Sorter(manager)
-        await sorter.sort_files()
+        await sorter.run()
 
     await check_partials_and_empty_folders(manager)
 

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -106,7 +106,7 @@ async def post_runtime(manager: Manager) -> None:
         await manager.hash_manager.hash_client.cleanup_dupes_after_download()
     if manager.config_manager.settings_data.sorting.sort_downloads and not manager.parsed_args.cli_only_args.retry_any:
         sorter = Sorter(manager)
-        await sorter.sort()
+        await sorter.sort_files()
 
     await check_partials_and_empty_folders(manager)
 

--- a/cyberdrop_dl/managers/log_manager.py
+++ b/cyberdrop_dl/managers/log_manager.py
@@ -22,8 +22,8 @@ class LogManager:
         self.main_log: Path = manager.path_manager.main_log
         self.last_post_log: Path = manager.path_manager.last_forum_post_log
         self.unsupported_urls_log: Path = manager.path_manager.unsupported_urls_log
-        self.download_error_log: Path = manager.path_manager.download_error_urls_logs
-        self.scrape_error_log: Path = manager.path_manager.scrape_error_urls_logs
+        self.download_error_log: Path = manager.path_manager.download_error_urls_log
+        self.scrape_error_log: Path = manager.path_manager.scrape_error_urls_log
         self._csv_locks = {}
 
     def startup(self) -> None:

--- a/cyberdrop_dl/managers/path_manager.py
+++ b/cyberdrop_dl/managers/path_manager.py
@@ -42,8 +42,8 @@ class PathManager:
         self.main_log: Path = field(init=False)
         self.last_forum_post_log: Path = field(init=False)
         self.unsupported_urls_log: Path = field(init=False)
-        self.download_error_urls_logs: Path = field(init=False)
-        self.scrape_error_urls_logs: Path = field(init=False)
+        self.download_error_urls_log: Path = field(init=False)
+        self.scrape_error_urls_log: Path = field(init=False)
 
         self._logs_model_names = [
             "main_log",

--- a/cyberdrop_dl/managers/path_manager.py
+++ b/cyberdrop_dl/managers/path_manager.py
@@ -65,8 +65,10 @@ class PathManager:
         self.config_folder.mkdir(parents=True, exist_ok=True)
         self.cookies_dir.mkdir(parents=True, exist_ok=True)
 
-    def replace_config_in_path(self, path: Path) -> Path:
+    def replace_config_in_path(self, path: Path) -> Path | None:
         current_config = self.manager.config_manager.loaded_config
+        if path is None:
+            return
         return Path(str(path).replace("{config}", current_config))
 
     def startup(self) -> None:

--- a/cyberdrop_dl/ui/progress/sort_progress.py
+++ b/cyberdrop_dl/ui/progress/sort_progress.py
@@ -147,7 +147,7 @@ class SortProgress:
             raise ValueError(msg)
         self.redraw()
 
-    def advance_folder(self, task_id: TaskID, amount: int) -> None:
+    def advance_folder(self, task_id: TaskID, amount: int = 1) -> None:
         """Advances the progress of the given task by the given amount."""
         if task_id in self.uninitiated_tasks:
             self.uninitiated_tasks.remove(task_id)

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import itertools
 import subprocess
 from pathlib import Path
@@ -12,8 +13,8 @@ from PIL import Image
 from videoprops import get_audio_properties, get_video_properties
 
 from cyberdrop_dl.utils.constants import FILE_FORMATS
-from cyberdrop_dl.utils.logger import log, log_with_color
-from cyberdrop_dl.utils.utilities import clear_term, purge_dir_tree
+from cyberdrop_dl.utils.logger import log_with_color
+from cyberdrop_dl.utils.utilities import purge_dir_tree
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -47,37 +48,35 @@ class Sorter:
         self.video_count = 0
         self.other_count = 0
 
-    def find_files_in_dir(self, directory: Path) -> list[Path]:
+    def get_files(self, directory: Path) -> list[Path]:
         """Finds all files in a directory and returns them in a list."""
-        file_list = []
-        for x in directory.iterdir():
-            if x.is_file():
-                file_list.append(x)
-            elif x.is_dir():
-                file_list.extend(self.find_files_in_dir(x))
-        return file_list
+        return [file for file in directory.rglob("*") if file.is_file()]
 
-    def move_cd(self, file: Path, dest: Path) -> bool:
+    def move_file(self, old_path: Path, new_path: Path) -> bool:
         """Moves a file to a destination folder."""
+        if old_path.resolve() == new_path.resolve():
+            return
         try:
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            file.rename(dest)
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            old_path.rename(new_path)
 
         except FileExistsError:
-            if file.stat().st_size == dest.stat().st_size:
-                file.unlink()
-            for i in itertools.count(1):
-                dest_make = dest.parent / f"{dest.stem}{self.incrementer_format.format(i=i)}{dest.suffix}"
-                if not dest_make.is_file():
-                    file.rename(dest_make)
+            if old_path.stat().st_size == new_path.stat().st_size:
+                old_path.unlink()
+            for auto_index in itertools.count(1):
+                new_path = (
+                    new_path.parent / f"{new_path.stem}{self.incrementer_format.format(i=auto_index)}{new_path.suffix}"
+                )
+                if not new_path.is_file():
+                    old_path.rename(new_path)
                     break
         except OSError:
             return False
 
         return True
 
-    def check_dir_parents(self) -> bool:
-        """Checks if the sort dir is in the download dir."""
+    def check_sorted_dir_parents(self) -> bool:
+        """Checks if the sort dir a children of download dir"""
         if self.download_dir in self.sorted_downloads.parents:
             log_with_color("Sort Directory cannot be in the Download Directory", "red", 40)
             return True
@@ -92,126 +91,116 @@ class Sorter:
         # make sort dir
         self.sorted_downloads.mkdir(parents=True, exist_ok=True)
 
-        if self.check_dir_parents():
+        if self.check_sorted_dir_parents():
             return
 
         if not self.download_dir.is_dir():
             log_with_color("Download Directory does not exist", "red", 40)
             return
 
-        download_folders: list[Path] = await self.get_download_folder()
+        download_folders: list[Path] = await self.get_download_folders()
+        files_to_sort: dict[str, list[Path]] = {}
         with self.manager.live_manager.get_sort_live(stop=True):
-            all_scan_folders = list(filter(lambda x: x.is_dir(), self.download_dir.iterdir()))
-            queue_length = len(all_scan_folders)
-            self.manager.progress_manager.sort_progress.set_queue_length(queue_length)
-
-            for folder in all_scan_folders:
+            subfolders = [f for f in self.download_dir.iterdir() if f.is_dir()]
+            for folder in subfolders:
                 if self.sort_cdl_only and folder not in download_folders:
                     continue
-                files = self.find_files_in_dir(folder)
-                # add folder to progress and set number of files
-                task_id = self.manager.progress_manager.sort_progress.add_task(folder.name, len(files))
-                for file in files:
-                    ext = file.suffix.lower()
-                    if ".part" in ext:
-                        continue
-
-                    if ext in FILE_FORMATS["Audio"]:
-                        self.sort_audio(file, folder.name)
-                    elif ext in FILE_FORMATS["Images"]:
-                        self.sort_image(file, folder.name)
-                    elif ext in FILE_FORMATS["Videos"]:
-                        self.sort_video(file, folder.name)
-                    else:
-                        self.sort_other(file, folder.name)
-                    # advance folder progress by one file
-                    self.manager.progress_manager.sort_progress.advance_folder(
-                        task_id,
-                        1,
-                    )
-                purge_dir_tree(folder)
-                queue_length -= 1
-                self.manager.progress_manager.sort_progress.set_queue_length(queue_length)  # update queue length
-                self.manager.progress_manager.sort_progress.remove_folder(task_id)  # remove folder from progress
-
+                files_to_sort[folder.name] = self.get_files(folder)
         await asyncio.sleep(1)
         purge_dir_tree(self.download_dir)
 
-        clear_term()
+    def _sort_files(self, files_to_sort: dict[str, list[Path]]) -> None:
+        queue_length = len(files_to_sort)
+        self.manager.progress_manager.sort_progress.set_queue_length(queue_length)
+        for folder_name, files in files_to_sort.items():
+            task_id = self.manager.progress_manager.sort_progress.add_task(folder_name, len(files))
+            for file in files:
+                ext = file.suffix.lower()
+                if ".part" in ext:
+                    continue
 
-    async def get_download_folder(self) -> list[Path]:
+                if ext in FILE_FORMATS["Audio"]:
+                    self.sort_audio(file, folder_name)
+                elif ext in FILE_FORMATS["Images"]:
+                    self.sort_image(file, folder_name)
+                elif ext in FILE_FORMATS["Videos"]:
+                    self.sort_video(file, folder_name)
+                else:
+                    self.sort_other(file, folder_name)
+
+                self.manager.progress_manager.sort_progress.advance_folder(task_id)
+            self.manager.progress_manager.sort_progress.remove_folder(task_id)
+            queue_length -= 1
+            self.manager.progress_manager.sort_progress.set_queue_length(queue_length)
+
+    async def get_download_folders(self) -> list[Path]:
         """Gets the download folder."""
         if not self.sort_cdl_only:
             return []
-        unique_download_paths = await self.db_manager.history_table.get_unique_download_paths()
-        download_folders = [
-            Path(download_path[0])
-            for download_path in unique_download_paths
-            if Path(download_path[0]).is_dir() and Path(download_path[0]) != self.download_dir
+        download_paths = await self.db_manager.history_table.get_unique_download_paths()
+        download_paths = [Path(download_path[0]) for download_path in download_paths]
+        absolute_download_paths = [
+            self.download_dir.joinpath(p).resolve() for p in download_paths if p != self.download_dir
         ]
-        existing_folders = []
-        for folder in download_folders:
-            try:
-                relative_folder = folder.relative_to(self.download_dir)
-            except ValueError:
-                msg = f"Folder: {folder} if not relative to download_dir: {self.download_dir}"
-                log(msg, 40)
-                continue
+        existing_download_paths = [p for p in absolute_download_paths if self.download_dir in p.parents and p.is_dir()]
+        existing_folders = set()
+        for folder in existing_download_paths:
+            relative_folder = folder.relative_to(self.download_dir)
             base_folder = self.download_dir / relative_folder.parts[0]
-            if base_folder.exists():
-                existing_folders.append(base_folder)
+            existing_folders.add(base_folder)
 
-        download_folders.extend(existing_folders)
-        return list(set(download_folders))
+        return list(existing_folders)
 
     def sort_audio(self, file: Path, base_name: str) -> None:
         """Sorts an audio file into the sorted audio folder."""
         self.audio_count += 1
-
-        try:
+        length = bitrate = sample_rate = "Unknown"
+        with contextlib.suppress(RuntimeError, subprocess.CalledProcessError):
             props = get_audio_properties(str(file))
-            length = str(props.get("duration", "Unknown"))
-            bitrate = str(props.get("bit_rate", "Unknown"))
-            sample_rate = str(props.get("sample_rate", "Unknown"))
-        except (RuntimeError, subprocess.CalledProcessError):
-            length = "Unknown"
-            bitrate = "Unknown"
-            sample_rate = "Unknown"
+            length = props.get("duration", "Unknown")
+            bitrate = props.get("bit_rate", "Unknown")
+            sample_rate = props.get("sample_rate", "Unknown")
 
-        parent_name = file.parent.name
-        filename, ext = file.stem, file.suffix
-        file_date_us, file_date_ca = get_file_date_in_us_ca_formats(file)
-
-        new_file = Path(
-            self.audio_format.format(
-                sort_dir=self.sorted_downloads,
-                base_dir=base_name,
-                parent_dir=parent_name,
-                filename=filename,
-                ext=ext,
-                length=length,
-                bitrate=bitrate,
-                sample_rate=sample_rate,
-                file_date_us=file_date_us,
-                file_date_ca=file_date_ca,
-            ),
-        )
-
-        if self.move_cd(file, new_file):
+        if self._process_file_move(file, base_name, length=length, bitrate=bitrate, sample_rate=sample_rate):
             self.manager.progress_manager.sort_progress.increment_audio()
 
     def sort_image(self, file: Path, base_name: str) -> None:
         """Sorts an image file into the sorted image folder."""
         self.image_count += 1
-
-        try:
+        resolution = "Unknown"
+        with contextlib.suppress(PIL.UnidentifiedImageError, PIL.Image.DecompressionBombError):  # type: ignore
             image = Image.open(file)
             width, height = image.size
             resolution = f"{width}x{height}"
             image.close()
-        except (PIL.UnidentifiedImageError, PIL.Image.DecompressionBombError):  # type: ignore
-            resolution = "Unknown"
 
+        if self._process_file_move(file, base_name, resolution=resolution):
+            self.manager.progress_manager.sort_progress.increment_image()
+
+    def sort_video(self, file: Path, base_name: str) -> None:
+        """Sorts a video file into the sorted video folder."""
+        self.video_count += 1
+        resolution = frames_per_sec = codec = "Unknown"
+
+        with contextlib.suppress(RuntimeError, subprocess.CalledProcessError):
+            props = get_video_properties(str(file))
+            width = props.get("width")
+            height = props.get("height")
+            if width and height:
+                resolution = f"{width}x{height}"
+            frames_per_sec = props.get("avg_frame_rate", "Unknown")
+            codec = props.get("codec_name", "Unknown")
+
+        if self._process_file_move(file, base_name, resolution=resolution, fps=frames_per_sec, codec=codec):
+            self.manager.progress_manager.sort_progress.increment_video()
+
+    def sort_other(self, file: Path, base_name: str) -> None:
+        """Sorts an other file into the sorted other folder."""
+        self.other_count += 1
+        if self._process_file_move(file, base_name):
+            self.manager.progress_manager.sort_progress.increment_other()
+
+    def _process_file_move(self, file: Path, base_name: str, **kwargs) -> None:
         parent_name = file.parent.name
         filename, ext = file.stem, file.suffix
         file_date_us, file_date_ca = get_file_date_in_us_ca_formats(file)
@@ -223,75 +212,10 @@ class Sorter:
                 parent_dir=parent_name,
                 filename=filename,
                 ext=ext,
-                resolution=resolution,
                 file_date_us=file_date_us,
                 file_date_ca=file_date_ca,
+                **kwargs,
             ),
         )
 
-        if self.move_cd(file, new_file):
-            self.manager.progress_manager.sort_progress.increment_image()
-
-    def sort_video(self, file: Path, base_name: str) -> None:
-        """Sorts a video file into the sorted video folder."""
-        self.video_count += 1
-
-        try:
-            props = get_video_properties(str(file))
-            if "width" in props and "height" in props:
-                width = str(props["width"])
-                height = str(props["height"])
-                resolution = f"{width}x{height}"
-            else:
-                resolution = "Unknown"
-            frames_per_sec = str(props.get("avg_frame_rate", "Unknown"))
-            codec = str(props.get("codec_name", "Unknown"))
-        except (RuntimeError, subprocess.CalledProcessError):
-            resolution = "Unknown"
-            frames_per_sec = "Unknown"
-            codec = "Unknown"
-
-        parent_name = file.parent.name
-        filename, ext = file.stem, file.suffix
-        file_date_us, file_date_ca = get_file_date_in_us_ca_formats(file)
-
-        new_file = Path(
-            self.video_format.format(
-                sort_dir=self.sorted_downloads,
-                base_dir=base_name,
-                parent_dir=parent_name,
-                filename=filename,
-                ext=ext,
-                resolution=resolution,
-                fps=frames_per_sec,
-                codec=codec,
-                file_date_us=file_date_us,
-                file_date_ca=file_date_ca,
-            ),
-        )
-
-        if self.move_cd(file, new_file):
-            self.manager.progress_manager.sort_progress.increment_video()
-
-    def sort_other(self, file: Path, base_name: str) -> None:
-        """Sorts an other file into the sorted other folder."""
-        self.other_count += 1
-
-        parent_name = file.parent.name
-        filename, ext = file.stem, file.suffix
-        file_date_us, file_date_ca = get_file_date_in_us_ca_formats(file)
-
-        new_file = Path(
-            self.other_format.format(
-                sort_dir=self.sorted_downloads,
-                base_dir=base_name,
-                parent_dir=parent_name,
-                filename=filename,
-                ext=ext,
-                file_date_us=file_date_us,
-                file_date_ca=file_date_ca,
-            ),
-        )
-
-        if self.move_cd(file, new_file):
-            self.manager.progress_manager.sort_progress.increment_other()
+        return self.move_file(file, new_file)

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -132,8 +132,8 @@ class Sorter:
         download_paths = {Path(download_path[0]) for download_path in download_paths}
         absolute_download_paths = {p for p in download_paths if p.is_absolute()}
         relative_paths = download_paths - absolute_download_paths
-        with contextlib.suppress(ValueError):
-            for path in relative_paths:
+        for path in relative_paths:
+            with contextlib.suppress(ValueError):
                 proper_relative_path = path.relative_to(self.download_folder)
                 absolute_download_paths.add(self.download_folder.joinpath(proper_relative_path).resolve())
 

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -34,10 +34,6 @@ class Sorter:
         self.download_folder = manager.path_manager.scan_folder or manager.path_manager.download_folder
         self.sorted_folder = manager.path_manager.sorted_folder
         self.incrementer_format: str = manager.config_manager.settings_data.sorting.sort_incremementer_format
-        self.sort_cdl_only = (
-            manager.config_manager.settings_data.sorting.sort_cdl_only
-            and not manager.config_manager.settings_data.download_options.skip_download_mark_completed
-        )
         self.db_manager = manager.db_manager
 
         self.audio_format: str = manager.config_manager.settings_data.sorting.sorted_audio

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -148,6 +148,8 @@ class Sorter:
 
     def sort_audio(self, file: Path, base_name: str) -> None:
         """Sorts an audio file into the sorted audio folder."""
+        if not self.audio_format:
+            return
         self.audio_count += 1
         length = bitrate = sample_rate = "Unknown"
         with contextlib.suppress(RuntimeError, subprocess.CalledProcessError):
@@ -161,6 +163,8 @@ class Sorter:
 
     def sort_image(self, file: Path, base_name: str) -> None:
         """Sorts an image file into the sorted image folder."""
+        if not self.image_format:
+            return
         self.image_count += 1
         resolution = "Unknown"
         with contextlib.suppress(PIL.UnidentifiedImageError, PIL.Image.DecompressionBombError):  # type: ignore
@@ -174,6 +178,8 @@ class Sorter:
 
     def sort_video(self, file: Path, base_name: str) -> None:
         """Sorts a video file into the sorted video folder."""
+        if not self.video_format:
+            return
         self.video_count += 1
         resolution = frames_per_sec = codec = "Unknown"
 
@@ -191,6 +197,8 @@ class Sorter:
 
     def sort_other(self, file: Path, base_name: str) -> None:
         """Sorts an other file into the sorted other folder."""
+        if not self.other_format:
+            return
         self.other_count += 1
         if self._process_file_move(file, base_name):
             self.manager.progress_manager.sort_progress.increment_other()


### PR DESCRIPTION
1. Always resolve paths before sorting
2. Allow inplace sorting by saving the list of all files to sort before doing anything. This allows for `scan_dir` and `download_dir` to be the same
3. Refactor and simplify sorting logic
4. Allow selective sorting: skip sorting a type of file by setting the format to `null`
