### PR TITLE
refactor: get supported domains from crawlers

### DIFF
--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -190,6 +190,8 @@ class Manager:
 
         config_settings = self.config_manager.settings_data.model_dump_json(indent=4)
         global_settings = self.config_manager.global_settings_data.model_dump_json(indent=4)
+        cookie_files = self.path_manager.cookies_dir.rglob("*.txt")
+        cookie_files_json = json.dumps(cookie_files, indent=4, sort_keys=True) if cookie_files else None
 
         log("Starting Cyberdrop-DL Process", 10)
         log(f"Running Version: {__version__}", 10)
@@ -201,6 +203,7 @@ class Manager:
         log(f"Using Authentication: \n{json.dumps(auth_provided, indent=4, sort_keys=True)}", 10)
         log(f"Using Settings: \n{config_settings}", 10)
         log(f"Using Global Settings: \n{global_settings}", 10)
+        log(f"Using Cookies Files: \n{cookie_files_json}", 10)
 
     async def close(self) -> None:
         """Closes the manager."""

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -190,7 +190,7 @@ class Manager:
 
         config_settings = self.config_manager.settings_data.model_dump_json(indent=4)
         global_settings = self.config_manager.global_settings_data.model_dump_json(indent=4)
-        cookie_files = list(self.path_manager.cookies_dir.rglob("*.txt")) or None
+        cookie_files = [str(p) for p in self.path_manager.cookies_dir.rglob("*.txt")] or None
         if cookie_files:
             cookie_files = f"\n{json.dumps(cookie_files, indent=4, sort_keys=True)}"
 

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -190,8 +190,9 @@ class Manager:
 
         config_settings = self.config_manager.settings_data.model_dump_json(indent=4)
         global_settings = self.config_manager.global_settings_data.model_dump_json(indent=4)
-        cookie_files = self.path_manager.cookies_dir.rglob("*.txt")
-        cookie_files_json = json.dumps(cookie_files, indent=4, sort_keys=True) if cookie_files else None
+        cookie_files = list(self.path_manager.cookies_dir.rglob("*.txt")) or None
+        if cookie_files:
+            cookie_files = f"\n{json.dumps(cookie_files, indent=4, sort_keys=True)}"
 
         log("Starting Cyberdrop-DL Process", 10)
         log(f"Running Version: {__version__}", 10)
@@ -203,7 +204,7 @@ class Manager:
         log(f"Using Authentication: \n{json.dumps(auth_provided, indent=4, sort_keys=True)}", 10)
         log(f"Using Settings: \n{config_settings}", 10)
         log(f"Using Global Settings: \n{global_settings}", 10)
-        log(f"Using Cookies Files: \n{cookie_files_json}", 10)
+        log(f"Using Cookies Files: {cookie_files}", 10)
 
     async def close(self) -> None:
         """Closes the manager."""

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -19,7 +19,7 @@ from cyberdrop_dl.managers.path_manager import PathManager
 from cyberdrop_dl.managers.progress_manager import ProgressManager
 from cyberdrop_dl.managers.realdebrid_manager import RealDebridManager
 from cyberdrop_dl.utils.args import ParsedArgs
-from cyberdrop_dl.utils.data_enums_classes.supported_domains import FORUMS
+from cyberdrop_dl.utils.data_enums_classes.supported_domains import SUPPORTED_FORUMS
 from cyberdrop_dl.utils.logger import log, print_to_console
 from cyberdrop_dl.utils.transfer.db_setup import TransitionManager
 
@@ -174,7 +174,7 @@ class Manager:
         auth_data_forums = self.config_manager.authentication_data.forums.model_dump()
         auth_data_others: dict[str, dict] = self.config_manager.authentication_data.model_dump(exclude="forums")
 
-        for forum_name in FORUMS:
+        for forum_name in SUPPORTED_FORUMS:
             forum_xf_cookies_provided[forum_name] = bool(auth_data_forums[f"{forum_name}_xf_user_cookie"])
             forum_credentials_provided[forum_name] = bool(
                 auth_data_forums[f"{forum_name}_username"] and auth_data_forums[f"{forum_name}_password"],

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -192,7 +192,7 @@ class Manager:
         global_settings = self.config_manager.global_settings_data.model_dump_json(indent=4)
         cookie_files = [str(p) for p in self.path_manager.cookies_dir.rglob("*.txt")] or None
         if cookie_files:
-            cookie_files = f"\n{json.dumps(cookie_files, indent=4, sort_keys=True)}"
+            cookie_files = f"\n{json.dumps(sorted(cookie_files), indent=4, sort_keys=True)}"
 
         log("Starting Cyberdrop-DL Process", 10)
         log(f"Running Version: {__version__}", 10)

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 class Crawler(ABC):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {}
+    domain = None
+    primary_base_domain: URL = None
 
     def __init__(self, manager: Manager, domain: str, folder_domain: str | None = None) -> None:
         self.manager = manager

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -49,7 +49,7 @@ class Crawler(ABC):
         """Starts the crawler."""
         self.client = self.manager.client_manager.scraper_session
         self.downloader = Downloader(self.manager, self.domain)
-        self.cookiejar_file = self.manager.path_manager.cookies_dir / f"{self.domain}.txt"
+        self.cookiejar_file = self.manager.path_manager.cookies_dir / f"{self.primary_base_domain.host}.txt"
         if self.cookiejar_file.is_file():
             log(f"Found cookie file for: {self.domain}", 10)
             try:

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -47,10 +47,10 @@ CDN_POSSIBILITIES = re.compile(CDN_REGEX_STR)
 
 class BunkrrCrawler(Crawler):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {"bunkrr": ["bunkrr", "bunkr"]}
+    primary_base_domain = URL("https://bunkr.site")
 
     def __init__(self, manager: Manager, site: str) -> None:
         super().__init__(manager, site, "Bunkrr")
-        self.primary_base_domain = URL("https://bunkr.site")
         self.request_limiter = AsyncLimiter(10, 1)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/celebforum_crawler.py
@@ -16,6 +16,7 @@ class CelebForumCrawler(XenforoCrawler):
         date=Selector("time", "data-time"),
     )
     selectors = XenforoSelectors(posts=post_selectors)
+    domain = "celebforum"
 
     def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, "celebforum", "CelebForum")
+        super().__init__(manager, self.domain, "CelebForum")

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -18,9 +18,10 @@ if TYPE_CHECKING:
 
 
 class CoomerCrawler(Crawler):
+    primary_base_domain = URL("https://coomer.su")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "coomer", "Coomer")
-        self.primary_base_domain = URL("https://coomer.su")
         self.ddos_guard_domain = URL("https://*.coomer.su")
         self.api_url = URL("https://coomer.su/api/v1")
         self.request_limiter = AsyncLimiter(4, 1)

--- a/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
@@ -24,11 +24,12 @@ CDN_POSSIBILITIES = re.compile(r"^(?:(?:k1)[0-9]{0,2})(?:redir)?\.cyberdrop?\.[a
 
 
 class CyberdropCrawler(Crawler):
+    primary_base_domain = URL("https://cyberdrop.me/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "cyberdrop", "Cyberdrop")
         self.api_url = URL("https://api.cyberdrop.me/api/")
-        self.primary_base_domain = URL("https://cyberdrop.me/")
-        self.request_limiter = AsyncLimiter(1.0, 2.0)
+        self.request_limiter = AsyncLimiter(1, 2)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class CyberfileCrawler(Crawler):
+    primary_base_domain = URL("https://cyberfile.me/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "cyberfile", "Cyberfile")
         self.api_load_files = URL("https://cyberfile.me/account/ajax/load_files")

--- a/cyberdrop_dl/scraper/crawlers/ehentai_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/ehentai_crawler.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 
 class EHentaiCrawler(Crawler):
+    primary_base_domain = URL("https://e-hentai.org/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "e-hentai", "E-Hentai")
         self.request_limiter = AsyncLimiter(10, 1)

--- a/cyberdrop_dl/scraper/crawlers/erome_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/erome_crawler.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 
 class EromeCrawler(Crawler):
+    primary_base_domain = URL("https://www.erome.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "erome", "Erome")
         self.request_limiter = AsyncLimiter(10, 1)

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -20,9 +20,10 @@ class F95ZoneCrawler(XenforoCrawler):
         number=Selector("a[class=u-concealed]", "href"),
     )
     selectors = XenforoSelectors(posts=post_selectors)
+    domain = "f95zone"
 
     def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, "f95zone", "F95Zone")
+        super().__init__(manager, self.domain, "F95Zone")
 
     async def is_confirmation_link(self, link: URL) -> bool:
         parts = link.parts

--- a/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/fapello_crawler.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 
 class FapelloCrawler(Crawler):
+    primary_base_domain = URL("https://fapello.su/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "fapello", "Fapello")
         self.request_limiter = AsyncLimiter(5, 1)

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -27,9 +27,10 @@ WT_REGEX = re.compile(r'appdata\.wt\s=\s"([^"]+)"')
 
 
 class GoFileCrawler(Crawler):
+    primary_base_domain = URL("https://gofile.io")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "gofile", "GoFile")
-        self.primary_base_domain = URL("https://gofile.io")
         self.api = URL("https://api.gofile.io")
         self.js_address = URL("https://gofile.io/dist/js/global.js")
         self.api_key = manager.config_manager.authentication_data.gofile.api_key

--- a/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
@@ -19,9 +19,10 @@ if TYPE_CHECKING:
 
 
 class HotPicCrawler(Crawler):
+    primary_base_domain = URL("https://hotpic.cc")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "hotpic", "HotPic")
-        self.primary_base_domain = URL("https://hotpic.cc")
         self.request_limiter = AsyncLimiter(10, 1)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/imageban_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imageban_crawler.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 
 
 class ImageBanCrawler(Crawler):
+    primary_base_domain = URL("https://www.imagebam.com/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "imageban", "ImageBan")
         self.request_limiter = AsyncLimiter(10, 1)

--- a/cyberdrop_dl/scraper/crawlers/imgbb_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgbb_crawler.py
@@ -21,9 +21,10 @@ if TYPE_CHECKING:
 
 
 class ImgBBCrawler(Crawler):
+    primary_base_domain = URL("https://ibb.co")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "imgbb", "ImgBB")
-        self.primary_base_domain = URL("https://ibb.co")
         self.request_limiter = AsyncLimiter(10, 1)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/imgbox_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgbox_crawler.py
@@ -20,9 +20,10 @@ if TYPE_CHECKING:
 
 
 class ImgBoxCrawler(Crawler):
+    primary_base_domain = URL("https://imgbox.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "imgbox", "ImgBox")
-        self.primary_base_domain = URL("https://imgbox.com")
         self.request_limiter = AsyncLimiter(10, 1)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
 
 class ImgurCrawler(Crawler):
+    primary_base_domain = URL("https://imgur.com/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "imgur", "Imgur")
         self.imgur_api = URL("https://api.imgur.com/3/")

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -19,9 +19,10 @@ if TYPE_CHECKING:
 
 
 class KemonoCrawler(Crawler):
+    primary_base_domain = URL("https://kemono.su")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "kemono", "Kemono")
-        self.primary_base_domain = URL("https://kemono.su")
         self.api_url = URL("https://kemono.su/api/v1")
         self.services = ["afdian", "boosty", "dlsite", "fanbox", "fantia", "gumroad", "patreon", "subscribestar"]
         self.request_limiter = AsyncLimiter(10, 1)

--- a/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/leakedmodels_crawler.py
@@ -16,6 +16,7 @@ class LeakedModelsCrawler(XenforoCrawler):
         date=Selector("time", "data-time"),
     )
     selectors = XenforoSelectors(posts=post_selectors)
+    domain = "leakedmodels"
 
     def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, "leakedmodels", "LeakedModels")
+        super().__init__(manager, self.domain, "LeakedModels")

--- a/cyberdrop_dl/scraper/crawlers/mediafire_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/mediafire_crawler.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 
 class MediaFireCrawler(Crawler):
+    primary_base_domain = URL("https://www.mediafire.com/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "mediafire", "mediafire")
         self.api = MediaFireApi()

--- a/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
@@ -19,9 +19,10 @@ if TYPE_CHECKING:
 
 
 class NekohouseCrawler(Crawler):
+    primary_base_domain = URL("https://nekohouse.su")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "nekohouse", "Nekohouse")
-        self.primary_base_domain = URL("https://nekohouse.su")
         self.services = ["fanbox", "fantia", "fantia_products", "subscribestar", "twitter"]
         self.request_limiter = AsyncLimiter(10, 1)
 

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -17,6 +17,7 @@ class NudoStarCrawler(XenforoCrawler):
         number=Selector("a[class=u-concealed]", "href"),
     )
     selectors = XenforoSelectors(posts=post_selectors)
+    domain = "nudostar"
 
     def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, "nudostar", "NudoStar")
+        super().__init__(manager, self.domain, "NudoStar")

--- a/cyberdrop_dl/scraper/crawlers/nudostartv_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostartv_crawler.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 
 class NudoStarTVCrawler(Crawler):
+    primary_base_domain = URL("https://nudostar.tv/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "nudostartv", "NudoStarTV")
         self.request_limiter = AsyncLimiter(10, 1)

--- a/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
@@ -21,9 +21,10 @@ if TYPE_CHECKING:
 
 
 class OmegaScansCrawler(Crawler):
+    primary_base_domain = URL("https://omegascans.org")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "omegascans", "OmegaScans")
-        self.primary_base_domain = URL("https://omegascans.org")
         self.api_url = "https://api.omegascans.org/chapter/query?page={}&perPage={}&series_id={}"
         self.request_limiter = AsyncLimiter(10, 1)
 

--- a/cyberdrop_dl/scraper/crawlers/pimpandhost_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pimpandhost_crawler.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 
 
 class PimpAndHostCrawler(Crawler):
+    primary_base_domain = URL("https://pimpandhost.com/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "pimpandhost", "PimpAndHost")
         self.request_limiter = AsyncLimiter(10, 1)

--- a/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixeldrain_crawler.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 
 class PixelDrainCrawler(Crawler):
+    primary_base_domain = URL("https://pixeldrain.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "pixeldrain", "PixelDrain")
         self.api_address = URL("https://pixeldrain.com/api/")

--- a/cyberdrop_dl/scraper/crawlers/postimg_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/postimg_crawler.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class PostImgCrawler(Crawler):
+    primary_base_domain = URL("https://postimages.org/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "postimg", "PostImg")
         self.api_address = URL("https://postimg.cc/json")

--- a/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 
 
 class RealBooruCrawler(Crawler):
+    primary_base_domain = URL("https://realbooru.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "realbooru", "RealBooru")
-        self.primary_base_url = URL("https://realbooru.com")
         self.request_limiter = AsyncLimiter(10, 1)
-
         self.cookies_set = False
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
@@ -64,7 +64,7 @@ class RealBooruCrawler(Crawler):
         for file_page in content:
             link = file_page.get("href")
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link, encoded=True)
             new_scrape_item = self.create_scrape_item(scrape_item, link, title, True, add_parent=scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
@@ -103,6 +103,8 @@ class RealBooruCrawler(Crawler):
         if self.cookies_set:
             return
 
-        self.client.client_manager.cookies.update_cookies({"resize-original": "1"}, response_url=self.primary_base_url)
+        self.client.client_manager.cookies.update_cookies(
+            {"resize-original": "1"}, response_url=self.primary_base_domain
+        )
 
         self.cookies_set = True

--- a/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
@@ -17,10 +17,11 @@ if TYPE_CHECKING:
 
 
 class RealDebridCrawler(Crawler):
+    primary_base_domain = URL("https://real-debrid.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "real-debrid", "RealDebrid")
         self.headers = {}
-        self.primary_base_domain = URL("https://real-debrid.com")
         self.request_limiter = AsyncLimiter(RATE_LIMIT, 60)
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 class RedditCrawler(Crawler):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {"reddit": ["reddit", "redd.it"]}
+    primary_base_domain = URL("https://www.reddit.com/")
 
     def __init__(self, manager: Manager, site: str) -> None:
         super().__init__(manager, site, "Reddit")

--- a/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/redgifs_crawler.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 
 class RedGifsCrawler(Crawler):
+    primary_base_domain = URL("https://redgifs.com/")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "redgifs", "RedGifs")
         self.redgifs_api = URL("https://api.redgifs.com/")

--- a/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class Rule34VaultCrawler(Crawler):
-    primary_base_url = URL("https://rule34vault.com")
+    primary_base_domain = URL("https://rule34vault.com")
 
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "rule34vault", "Rule34Vault")
@@ -62,7 +62,7 @@ class Rule34VaultCrawler(Crawler):
         for file_page in content:
             link = file_page.get("href")
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, title, True, add_parent=scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
@@ -106,7 +106,7 @@ class Rule34VaultCrawler(Crawler):
         for file_page in content:
             link = file_page.get("href")
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, title, True, add_parent=scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
@@ -138,7 +138,7 @@ class Rule34VaultCrawler(Crawler):
         if image:
             link = image.get("src").replace(".small", "").replace(".thumbnail", "")
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link)
             filename, ext = get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)
@@ -152,7 +152,7 @@ class Rule34VaultCrawler(Crawler):
                 .replace(".hevc", "")
             )
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link)
             filename, ext = get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34vault_crawler.py
@@ -20,9 +20,10 @@ if TYPE_CHECKING:
 
 
 class Rule34VaultCrawler(Crawler):
+    primary_base_url = URL("https://rule34vault.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "rule34vault", "Rule34Vault")
-        self.primary_base_url = URL("https://rule34vault.com")
         self.request_limiter = AsyncLimiter(10, 1)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 
 
 class Rule34XXXCrawler(Crawler):
+    primary_base_url = URL("https://rule34.xxx")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "rule34.xxx", "Rule34XXX")
-        self.primary_base_url = URL("https://rule34.xxx")
         self.request_limiter = AsyncLimiter(10, 1)
-
         self.cookies_set = False
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class Rule34XXXCrawler(Crawler):
-    primary_base_url = URL("https://rule34.xxx")
+    primary_base_domain = URL("https://rule34.xxx")
 
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "rule34.xxx", "Rule34XXX")
@@ -66,7 +66,7 @@ class Rule34XXXCrawler(Crawler):
         for file_page in content:
             link = file_page.get("href")
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link, encoded=True)
             new_scrape_item = self.create_scrape_item(scrape_item, link, title, True, add_parent=scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
@@ -104,6 +104,8 @@ class Rule34XXXCrawler(Crawler):
         if self.cookies_set:
             return
 
-        self.client.client_manager.cookies.update_cookies({"resize-original": "1"}, response_url=self.primary_base_url)
+        self.client.client_manager.cookies.update_cookies(
+            {"resize-original": "1"}, response_url=self.primary_base_domain
+        )
 
         self.cookies_set = True

--- a/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class Rule34XYZCrawler(Crawler):
-    primary_base_url = URL("https://rule34.xyz")
+    primary_base_domain = URL("https://rule34.xyz")
 
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "rule34.xyz", "Rule34XYZ")
@@ -61,7 +61,7 @@ class Rule34XYZCrawler(Crawler):
         for file_page in content:
             link = file_page.get("href")
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link)
             new_scrape_item = self.create_scrape_item(scrape_item, link, title, True, add_parent=scrape_item.url)
             self.manager.task_group.create_task(self.run(new_scrape_item))
@@ -93,7 +93,7 @@ class Rule34XYZCrawler(Crawler):
         if image:
             link = image.get("src")
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link)
             filename, ext = get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)
@@ -101,7 +101,7 @@ class Rule34XYZCrawler(Crawler):
         if video:
             link = video.get("src")
             if link.startswith("/"):
-                link = f"{self.primary_base_url}{link}"
+                link = f"{self.primary_base_domain}{link}"
             link = URL(link)
             filename, ext = get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xyz_crawler.py
@@ -20,9 +20,10 @@ if TYPE_CHECKING:
 
 
 class Rule34XYZCrawler(Crawler):
+    primary_base_url = URL("https://rule34.xyz")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "rule34.xyz", "Rule34XYZ")
-        self.primary_base_url = URL("https://rule34.xyz")
         self.request_limiter = AsyncLimiter(10, 1)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -20,9 +20,10 @@ if TYPE_CHECKING:
 
 
 class SaintCrawler(Crawler):
+    primary_base_domain = URL("https://saint2.su")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "saint", "Saint")
-        self.primary_base_domain = URL("https://saint2.su")
         self.request_limiter = AsyncLimiter(10, 1)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/scrolller_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/scrolller_crawler.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 
 class ScrolllerCrawler(Crawler):
+    primary_base_domain = URL("https://scrolller.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "scrolller", "Scrolller")
         self.scrolller_api = URL("https://api.scrolller.com/api/v2/graphql")

--- a/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/simpcity_crawler.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 class SimpCityCrawler(XenforoCrawler):
     primary_base_domain = URL("https://simpcity.su")
     login_required = False
+    domain = "simpcity"
 
     def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, "simpcity", "SimpCity")
+        super().__init__(manager, self.domain, "SimpCity")

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 class SocialMediaGirlsCrawler(XenforoCrawler):
     primary_base_domain = URL("https://forums.socialmediagirls.com")
+    domain = "socialmediagirls"
     post_selectors = PostSelectors(
         content=Selector("div[class=bbWrapper]", None),
         images=Selector("img[class*=bbImage]", "data-src"),
@@ -20,4 +21,4 @@ class SocialMediaGirlsCrawler(XenforoCrawler):
     selectors = XenforoSelectors(posts=post_selectors)
 
     def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, "socialmediagirls", "SocialMediaGirls")
+        super().__init__(manager, self.domain, "SocialMediaGirls")

--- a/cyberdrop_dl/scraper/crawlers/tokyomotion_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/tokyomotion_crawler.py
@@ -25,11 +25,11 @@ DATE_PATTERN = re.compile(r"(\d+)\s*(weeks?|days?|hours?|minutes?|seconds?)", re
 
 
 class TokioMotionCrawler(Crawler):
+    primary_base_domain = URL("https://www.tokyomotion.net")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "tokyomotion", "Tokyomotion")
-        self.primary_base_domain = URL("https://www.tokyomotion.net")
         self.request_limiter = AsyncLimiter(10, 1)
-
         self.album_selector = 'a[href^="/album/"]'
         self.image_div_selector = "div[id*='_photo_']"
         self.image_selector = 'a[href^="/photo/"]'

--- a/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/toonily_crawler.py
@@ -20,9 +20,10 @@ if TYPE_CHECKING:
 
 
 class ToonilyCrawler(Crawler):
+    primary_base_domain = URL("https://toonily.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "toonily", "Toonily")
-        self.primary_base_domain = URL("https://toonily.com")
         self.request_limiter = AsyncLimiter(10, 1)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 class XBunkerCrawler(XenforoCrawler):
     primary_base_domain = URL("https://xbunker.nu/")
+    domain = "xbunker"
     post_selectors = PostSelectors(
         content=Selector("div[class=bbWrapper]", None),
         images=Selector("img[class*=bbImage], a[class*=js-lbImage]", "data-src"),
@@ -20,5 +21,5 @@ class XBunkerCrawler(XenforoCrawler):
     selectors = XenforoSelectors(posts=post_selectors)
 
     def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, "xbunker", "XBunker")
+        super().__init__(manager, self.domain, "XBunker")
         self.attachment_url_part += "data"

--- a/cyberdrop_dl/scraper/crawlers/xbunkr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunkr_crawler.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class XBunkrCrawler(Crawler):
+    primary_base_domain = URL("https://xbunkr.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "xbunkr", "XBunkr")
         self.request_limiter = AsyncLimiter(10, 1)

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -28,9 +28,10 @@ MAX_RETRIES = 3
 
 
 class XXXBunkerCrawler(Crawler):
+    primary_base_domain = URL("https://xxxbunker.com")
+
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "xxxbunker", "XXXBunker")
-        self.primary_base_domain = URL("https://xxxbunker.com")
         self.api_download = URL("https://xxxbunker.com/ajax/downloadpopup")
         self.rate_limit = self.wait_time = 10
         self.request_limiter = AsyncLimiter(self.rate_limit, 60)

--- a/cyberdrop_dl/ui/prompts/user_prompts.py
+++ b/cyberdrop_dl/ui/prompts/user_prompts.py
@@ -11,7 +11,7 @@ from cyberdrop_dl.ui.prompts import basic_prompts
 from cyberdrop_dl.ui.prompts.defaults import ALL_CHOICE, DONE_CHOICE, EXIT_CHOICE
 from cyberdrop_dl.utils.constants import BROWSERS, RESERVED_CONFIG_NAMES
 from cyberdrop_dl.utils.cookie_management import get_cookies_from_browsers
-from cyberdrop_dl.utils.data_enums_classes.supported_domains import FORUMS, WEBSITES
+from cyberdrop_dl.utils.data_enums_classes.supported_domains import SUPPORTED_FORUMS, SUPPORTED_WEBSITES
 from cyberdrop_dl.utils.utilities import clear_term
 
 if TYPE_CHECKING:
@@ -133,7 +133,7 @@ def domains_prompt(*, domain_message: str = "Select site(s):") -> list[str]:
     if domain_type == DONE_CHOICE.value:
         return []
 
-    all_domains = list(FORUMS.values()) if domain_type == 1 else list(WEBSITES.values())
+    all_domains = list(SUPPORTED_FORUMS.values()) if domain_type == 1 else list(SUPPORTED_WEBSITES.values())
     domain_choices = [Choice(site) for site in all_domains] + [ALL_CHOICE]
 
     domains = basic_prompts.ask_checkbox(domain_choices, message=domain_message)

--- a/cyberdrop_dl/utils/cookie_management.py
+++ b/cyberdrop_dl/utils/cookie_management.py
@@ -88,8 +88,8 @@ def update_forum_config_cookies(manager: Manager, forum: str, cookie: CookieJar)
     forum_domain = SUPPORTED_FORUMS[forum]
     forum_dict = auth_args.forums.model_dump()
     with contextlib.suppress(KeyError):
-        forum_dict[f"{forum_domain}_xf_user_cookie"] = cookie._cookies[forum_domain]["/"]["xf_user"].value
-        forum_dict[f"{forum_domain}_xf_user_cookie"] = cookie._cookies["www." + forum_domain]["/"]["xf_user"].value
+        forum_dict[f"{forum}_xf_user_cookie"] = cookie._cookies[forum_domain]["/"]["xf_user"].value
+        forum_dict[f"{forum}_xf_user_cookie"] = cookie._cookies["www." + forum_domain]["/"]["xf_user"].value
     auth_args.forums = auth_args.forums.model_copy(update=forum_dict)
 
 

--- a/cyberdrop_dl/utils/cookie_management.py
+++ b/cyberdrop_dl/utils/cookie_management.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from rich.console import Console
 
 from cyberdrop_dl.dependencies import browser_cookie3
-from cyberdrop_dl.utils.data_enums_classes.supported_domains import FORUMS
+from cyberdrop_dl.utils.data_enums_classes.supported_domains import SUPPORTED_FORUMS
 
 if TYPE_CHECKING:
     from http.cookiejar import CookieJar
@@ -82,10 +82,10 @@ def get_cookies_from_browsers(
 
 
 def update_forum_config_cookies(manager: Manager, forum: str, cookie: CookieJar) -> None:
-    if forum not in FORUMS:
+    if forum not in SUPPORTED_FORUMS:
         return
     auth_args = manager.config_manager.authentication_data
-    forum_domain = FORUMS[forum]
+    forum_domain = SUPPORTED_FORUMS[forum]
     forum_dict = auth_args.forums.model_dump()
     with contextlib.suppress(KeyError):
         forum_dict[f"{forum_domain}_xf_user_cookie"] = cookie._cookies[forum_domain]["/"]["xf_user"].value

--- a/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
+++ b/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
@@ -23,11 +23,14 @@ def get_supported_sites_from(crawlers: set[type[Crawler]]) -> dict[str, str]:
     support_sites_dict = {}
     for crawler in crawlers:
         if not crawler.SUPPORTED_SITES:
-            support_sites_dict[crawler.domain] = crawler.primary_base_domain.host
+            site = crawler.domain or crawler.primary_base_domain.host
+            support_sites_dict[site] = crawler.primary_base_domain.host
             continue
 
         for site, domains in crawler.SUPPORTED_SITES.items():
             support_sites_dict[site] = domains[0]
+
+    return support_sites_dict
 
 
 SUPPORTED_FORUMS = get_supported_sites_from(forum_crawlers)

--- a/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
+++ b/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
@@ -22,7 +22,7 @@ website_crawlers = crawlers - forum_crawlers
 def get_supported_sites_from(crawlers: set[type[Crawler]]) -> dict[str, str]:
     support_sites_dict = {}
     for crawler in crawlers:
-        if not crawler.SUPPORTED_SITES:
+        if not crawler.SUPPORTED_SITES or crawler.primary_base_domain:
             site = crawler.domain or crawler.primary_base_domain.host
             support_sites_dict[site] = crawler.primary_base_domain.host
             continue
@@ -30,10 +30,12 @@ def get_supported_sites_from(crawlers: set[type[Crawler]]) -> dict[str, str]:
         for site, domains in crawler.SUPPORTED_SITES.items():
             support_sites_dict[site] = domains[0]
 
+    support_sites_dict = {key: support_sites_dict[key] for key in sorted(support_sites_dict)}
+
     return support_sites_dict
 
 
 SUPPORTED_FORUMS = get_supported_sites_from(forum_crawlers)
 SUPPORTED_WEBSITES = get_supported_sites_from(website_crawlers)
 SUPPORTED_SITES = SUPPORTED_FORUMS | SUPPORTED_WEBSITES
-SUPPORTED_SITES_DOMAINS = list(SUPPORTED_SITES.values())
+SUPPORTED_SITES_DOMAINS = sorted(SUPPORTED_SITES.values())

--- a/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
+++ b/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
@@ -15,7 +15,7 @@ is_testing = next((tag for tag in PRERELEASE_TAGS if tag in current_version), Fa
 if not is_testing:
     crawlers -= DEBUG_CRAWLERS
 
-forum_crawlers = [crawler for crawler in crawlers if issubclass(crawler, XenforoCrawler)]
+forum_crawlers = {crawler for crawler in crawlers if issubclass(crawler, XenforoCrawler)}
 website_crawlers = crawlers - forum_crawlers
 
 

--- a/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
+++ b/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
@@ -1,7 +1,7 @@
 from cyberdrop_dl import __version__ as current_version
 from cyberdrop_dl.utils.constants import PRERELEASE_TAGS
 
-FORUMS = {
+SUPPORTED_FORUMS = {
     "celebforum": "celebforum.to",
     "f95zone": "f95zone.to",
     "leakedmodels": "leakedmodels.com",
@@ -10,7 +10,7 @@ FORUMS = {
     "socialmediagirls": "socialmediagirls.com",
 }
 
-WEBSITES = {
+SUPPORTED_WEBSITES = {
     "bunkr": "bunkr",
     "bunkrr": "bunkrr",
     "coomer": "coomer",
@@ -63,8 +63,8 @@ WEBSITES = {
 }
 
 if next((tag for tag in PRERELEASE_TAGS if tag in current_version), False):
-    FORUMS["simpcity"] = "simpcity"
+    SUPPORTED_FORUMS["simpcity"] = "simpcity"
 
-SUPPORTED_SITES = FORUMS | WEBSITES
+SUPPORTED_SITES = SUPPORTED_FORUMS | SUPPORTED_WEBSITES
 
 SUPPORTED_SITES_DOMAINS = list(SUPPORTED_SITES.values())

--- a/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
+++ b/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
@@ -1,70 +1,37 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from cyberdrop_dl import __version__ as current_version
+from cyberdrop_dl.scraper import ALL_CRAWLERS, DEBUG_CRAWLERS
+from cyberdrop_dl.scraper.crawlers.xxxbunker_crawler import XXXBunkerCrawler
 from cyberdrop_dl.utils.constants import PRERELEASE_TAGS
 
-SUPPORTED_FORUMS = {
-    "celebforum": "celebforum.to",
-    "f95zone": "f95zone.to",
-    "leakedmodels": "leakedmodels.com",
-    "nudostar": "nudostar.com",
-    "xbunker": "xbunker.nu",
-    "socialmediagirls": "socialmediagirls.com",
-}
+if TYPE_CHECKING:
+    from cyberdrop_dl.scraper.crawler import Crawler
 
-SUPPORTED_WEBSITES = {
-    "bunkr": "bunkr",
-    "bunkrr": "bunkrr",
-    "coomer": "coomer",
-    "cyberdrop": "cyberdrop",
-    "cyberfile": "cyberfile",
-    "e-hentai": "e-hentai",
-    "erome": "erome",
-    "fapello": "fapello",
-    "gofile": "gofile",
-    "host.church": "host.church",
-    "hotpic": "hotpic",
-    "ibb.co": "ibb.co",
-    "imageban": "imageban",
-    "imagepond.net": "imagepond.net",
-    "img.kiwi": "img.kiwi",
-    "imgbox": "imgbox",
-    "imgur": "imgur",
-    "jpeg.pet": "jpeg.pet",
-    "jpg.church": "jpg.church",
-    "jpg.fish": "jpg.fish",
-    "jpg.fishing": "jpg.fishing",
-    "jpg.homes": "jpg.homes",
-    "jpg.pet": "jpg.pet",
-    "jpg1.su": "jpg1.su",
-    "jpg2.su": "jpg2.su",
-    "jpg3.su": "jpg3.su",
-    "jpg4.su": "jpg4.su",
-    "jpg5.su": "jpg5.su",
-    "kemono": "kemono",
-    "mediafire": "mediafire",
-    "nudostar.tv": "nudostar.tv",
-    "omegascans": "omegascans",
-    "pimpandhost": "pimpandhost",
-    "pixeldrain": "pixeldrain",
-    "postimg": "postimg",
-    "realbooru": "realbooru",
-    "real-debrid": "real-debrid",
-    "redd.it": "redd.it",
-    "reddit": "reddit",
-    "redgifs": "redgifs",
-    "rule34.xxx": "rule34.xxx",
-    "rule34.xyz": "rule34.xyz",
-    "rule34vault": "rule34vault",
-    "saint": "saint",
-    "scrolller": "scrolller",
-    "toonily": "toonily",
-    "tokyomotion.net": "tokyomotion.net",
-    "xbunkr": "xbunkr",
-    "xxxbunker": "xxxbunker",
-}
+crawlers = ALL_CRAWLERS
+is_testing = next((tag for tag in PRERELEASE_TAGS if tag in current_version), False)
+if not is_testing:
+    crawlers -= DEBUG_CRAWLERS
 
-if next((tag for tag in PRERELEASE_TAGS if tag in current_version), False):
-    SUPPORTED_FORUMS["simpcity"] = "simpcity"
+forum_crawlers = [crawler for crawler in crawlers if issubclass(crawler, XXXBunkerCrawler)]
+website_crawlers = crawlers - forum_crawlers
 
+
+def get_supported_sites_from(crawlers: set[type[Crawler]]) -> dict[str, str]:
+    support_sites_dict = {}
+    for crawler in crawlers:
+        if not crawler.SUPPORTED_SITES:
+            support_sites_dict[crawler.domain] = crawler.primary_base_domain.host
+            continue
+
+        for domains in crawler.SUPPORTED_SITES.values():
+            for domain in domains:
+                support_sites_dict[domain] = domain
+
+
+SUPPORTED_FORUMS = get_supported_sites_from(forum_crawlers)
+SUPPORTED_WEBSITES = get_supported_sites_from(website_crawlers)
 SUPPORTED_SITES = SUPPORTED_FORUMS | SUPPORTED_WEBSITES
-
 SUPPORTED_SITES_DOMAINS = list(SUPPORTED_SITES.values())

--- a/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
+++ b/cyberdrop_dl/utils/data_enums_classes/supported_domains.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from cyberdrop_dl import __version__ as current_version
 from cyberdrop_dl.scraper import ALL_CRAWLERS, DEBUG_CRAWLERS
-from cyberdrop_dl.scraper.crawlers.xxxbunker_crawler import XXXBunkerCrawler
+from cyberdrop_dl.scraper.crawlers.xenforo_crawler import XenforoCrawler
 from cyberdrop_dl.utils.constants import PRERELEASE_TAGS
 
 if TYPE_CHECKING:
@@ -15,7 +15,7 @@ is_testing = next((tag for tag in PRERELEASE_TAGS if tag in current_version), Fa
 if not is_testing:
     crawlers -= DEBUG_CRAWLERS
 
-forum_crawlers = [crawler for crawler in crawlers if issubclass(crawler, XXXBunkerCrawler)]
+forum_crawlers = [crawler for crawler in crawlers if issubclass(crawler, XenforoCrawler)]
 website_crawlers = crawlers - forum_crawlers
 
 
@@ -26,9 +26,8 @@ def get_supported_sites_from(crawlers: set[type[Crawler]]) -> dict[str, str]:
             support_sites_dict[crawler.domain] = crawler.primary_base_domain.host
             continue
 
-        for domains in crawler.SUPPORTED_SITES.values():
-            for domain in domains:
-                support_sites_dict[domain] = domain
+        for site, domains in crawler.SUPPORTED_SITES.items():
+            support_sites_dict[site] = domains[0]
 
 
 SUPPORTED_FORUMS = get_supported_sites_from(forum_crawlers)

--- a/docs/reference/configuration-options/settings/browser_cookies.md
+++ b/docs/reference/configuration-options/settings/browser_cookies.md
@@ -56,4 +56,10 @@ List of domains to extract cookies from. You can put any domain on the list, but
 
 ## Manual Cookie Extraction
 
-If cookie extraction fails, you can manually extract the cookies from your browser using tools like [cookie-editor](https://cookie-editor.com) and save them at `AppData/Cookies/<domain>.txt`, where domain is the domain of the site you exported the cookies from. The file must be a Netscape formatted cookie file
+If cookie extraction fails, you can manually extract the cookies from your browser using tools like [cookie-editor](https://cookie-editor.com) and save them at `AppData/Cookies/<domain>.txt`, where domain is the full primary base domain of the site you exported the cookies from. The file must be a Netscape formatted cookie file
+
+### Examples
+
+- For SocialMediaGirls, the name should be `forums.socialmediagirls.com.txt`
+- For bunkrr, the name should be `bunkr.site.txt`
+- For cyberdrop, the name should be `cyberdrop.me.txt`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "5.7.3.dev1"
+version = "6.0.0.rc0"
 description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
 readme = "README.md"


### PR DESCRIPTION
## TODO
 - [x] Needs #354 
 - [x] Update to use `XenforoCrawler` as base to filter forum crawlers
 - [x] Update forum cookies import to use the proper key for the names
 - [ ] Update cookies import logic to use any of the possible domains
 - [x] Make `primary_base_domain` a class property for all crawlers