### PR TITLE
fix: cookie import error log

### DIFF
--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -182,7 +182,7 @@ class ProgramUI:
 
     def _edit_config(self) -> None:
         if self.manager.multiconfig:
-            self.print_error("Cannot eddit 'ALL' config")
+            self.print_error("Cannot edit 'ALL' config")
             return
         config_file = (
             self.manager.path_manager.config_folder / self.manager.config_manager.loaded_config / "settings.yaml"

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -164,7 +164,7 @@ class ProgramUI:
         return self._process_answer(answer, options_map)
 
     def _clear_cookies(self) -> None:
-        domains = user_prompts.domains_prompt(domain_message="Select site(s) to clear cookies for:")
+        domains, _ = user_prompts.domains_prompt(domain_message="Select site(s) to clear cookies for:")
         clear_cookies(self.manager, domains)
         console.print("Finished clearing cookies", style="green")
         enter_to_continue()

--- a/cyberdrop_dl/ui/prompts/user_prompts.py
+++ b/cyberdrop_dl/ui/prompts/user_prompts.py
@@ -160,7 +160,7 @@ def extract_cookies(manager: Manager, *, dry_run: bool = False) -> None:
     if dry_run:
         manager.config_manager.settings_data.browser_cookies.browsers = browsers
         current_sites = set(manager.config_manager.settings_data.browser_cookies.sites)
-        new_sites = current_sites - set(all_domains) + set(domains)
+        new_sites = (current_sites - set(all_domains)) | set(domains)
         manager.config_manager.settings_data.browser_cookies.sites = sorted(new_sites)
         return
 

--- a/cyberdrop_dl/utils/cookie_management.py
+++ b/cyberdrop_dl/utils/cookie_management.py
@@ -43,7 +43,7 @@ def cookie_wrapper(func) -> None:
             Browser extraction ran into an error, the selected browser(s) may not be available on your system
             If you are still having issues, make sure all browsers processes are closed in Task Manager.
             """
-            msg = dedent(msg) + f"\nERROR: {e.s}\n\nNothing has been saved."
+            msg = dedent(msg) + f"\nERROR: {e!s}\n\nNothing has been saved."
 
             raise browser_cookie3.BrowserCookieError(msg) from None
 

--- a/cyberdrop_dl/utils/cookie_management.py
+++ b/cyberdrop_dl/utils/cookie_management.py
@@ -34,10 +34,9 @@ def cookie_wrapper(func) -> None:
             If you are still having issues, make sure all browsers processes are closed in Task Manager.
             """
             msg = dedent(msg) + footer
-            raise browser_cookie3.BrowserCookieError(msg) from None
+
         except ValueError as e:
             msg = str(e) + footer
-            raise browser_cookie3.BrowserCookieError(msg) from None
 
         except browser_cookie3.BrowserCookieError as e:
             msg = """
@@ -46,7 +45,7 @@ def cookie_wrapper(func) -> None:
             """
             msg = dedent(msg) + f"\nERROR: {e!s}" + footer
 
-            raise browser_cookie3.BrowserCookieError(msg) from None
+        raise browser_cookie3.BrowserCookieError(msg)
 
     return wrapper
 

--- a/cyberdrop_dl/utils/cookie_management.py
+++ b/cyberdrop_dl/utils/cookie_management.py
@@ -25,6 +25,7 @@ def cookie_wrapper(func) -> None:
     @wraps(func)
     def wrapper(self, *args, **kwargs) -> None:
         msg = ""
+        footer = "\n\nNothing has been saved."
         try:
             return func(self, *args, **kwargs)
         except PermissionError:
@@ -32,10 +33,10 @@ def cookie_wrapper(func) -> None:
             We've encountered a Permissions Error. Please close all browsers and try again
             If you are still having issues, make sure all browsers processes are closed in Task Manager.
             """
-            msg = dedent(msg) + "\n\nNothing has been saved."
+            msg = dedent(msg) + footer
             raise browser_cookie3.BrowserCookieError(msg) from None
         except ValueError as e:
-            msg = f"{e}\n\nNothing has been saved."
+            msg = str(e) + footer
             raise browser_cookie3.BrowserCookieError(msg) from None
 
         except browser_cookie3.BrowserCookieError as e:
@@ -43,7 +44,7 @@ def cookie_wrapper(func) -> None:
             Browser extraction ran into an error, the selected browser(s) may not be available on your system
             If you are still having issues, make sure all browsers processes are closed in Task Manager.
             """
-            msg = dedent(msg) + f"\nERROR: {e!s}\n\nNothing has been saved."
+            msg = dedent(msg) + f"\nERROR: {e!s}" + footer
 
             raise browser_cookie3.BrowserCookieError(msg) from None
 


### PR DESCRIPTION
- Fix syntax error while logging failed cookie imports
- Only override config sites of the same type as the user selected on the UI (FORUMS or WEBSITES)