### PR TITLE
Switch domain selection to fuzzy choices

### DIFF
--- a/cyberdrop_dl/ui/prompts/basic_prompts.py
+++ b/cyberdrop_dl/ui/prompts/basic_prompts.py
@@ -31,16 +31,22 @@ def ask_checkbox(choices: list[Choice], *, message: str = "Select multiple optio
     return inquirer.checkbox(message=message, choices=choices, **options).execute()
 
 
-def ask_choice_fuzzy(message: str, choices: list[Choice], validate_empty: bool = True, **kwargs):
+def ask_choice_fuzzy(choices: list[Choice], message: str, validate_empty: bool = True, **kwargs):
     options = (
         DEFAULT_OPTIONS
         | {"long_instruction": "ARROW KEYS: Navigate | TYPE: Filter | TAB: select, ENTER: Finish Selection"}
         | kwargs
     )
+    custom_validate = options.pop("validate", None)
+    validate = (
+        EmptyInputValidator("Input should not be empty")
+        if validate_empty and custom_validate is None
+        else custom_validate
+    )
     return inquirer.fuzzy(
         message=message,
         choices=choices,
-        validate=EmptyInputValidator("Input should not be empty") if validate_empty else None,
+        validate=validate,
         **options,
     ).execute()
 

--- a/cyberdrop_dl/ui/prompts/user_prompts.py
+++ b/cyberdrop_dl/ui/prompts/user_prompts.py
@@ -6,6 +6,10 @@ from typing import TYPE_CHECKING
 
 from InquirerPy import get_style
 from InquirerPy.base.control import Choice
+from InquirerPy.enum import (
+    INQUIRERPY_EMPTY_CIRCLE_SEQUENCE,
+    INQUIRERPY_FILL_CIRCLE_SEQUENCE,
+)
 from rich.console import Console
 
 from cyberdrop_dl import __version__
@@ -93,8 +97,8 @@ def create_new_config(manager: Manager, *, title: str = "Create a new config fil
 def select_config(configs: list) -> str:
     """Asks the user to select an existing config name."""
     return basic_prompts.ask_choice_fuzzy(
-        message="Select a config file:",
         choices=configs,
+        message="Select a config file:",
         validate_empty=True,
         long_instruction="ARROW KEYS: Navigate | TYPE: Filter | TAB: select, ENTER: Finish Selection",
         invalid_message="Need to select a config.",
@@ -145,7 +149,26 @@ def domains_prompt(*, domain_message: str = "Select site(s):") -> list[str]:
     all_domains = list(SUPPORTED_FORUMS.values() if domain_type == DomainType.FORUM else SUPPORTED_WEBSITES.values())
     domain_choices = [Choice(site) for site in all_domains] + [ALL_CHOICE]
 
-    domains = basic_prompts.ask_checkbox(domain_choices, message=domain_message)
+    domains = basic_prompts.ask_choice_fuzzy(
+        choices=domain_choices,
+        message=domain_message,
+        validate_empty=True,
+        multiselect=True,
+        marker_pl=f" {INQUIRERPY_EMPTY_CIRCLE_SEQUENCE} ",
+        marker=f" {INQUIRERPY_FILL_CIRCLE_SEQUENCE} ",
+        style=get_style(
+            {
+                "marker": "#98c379",
+                "questionmark": "#e5c07b",
+                "pointer": "#61afef",
+                "long_instruction": "#abb2bf",
+                "fuzzy_prompt": "#c678dd",
+                "fuzzy_info": "#abb2bf",
+                "fuzzy_border": "#4b5263",
+                "fuzzy_match": "#c678dd",
+            }
+        ),
+    )
     if ALL_CHOICE.value in domains:
         domains = all_domains
     return domains, all_domains

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -208,7 +208,10 @@ async def check_partials_and_empty_folders(manager: Manager) -> None:
     if not manager.config_manager.settings_data.runtime_options.skip_check_for_empty_folders:
         log_with_color("Checking for empty folders...", "yellow", 20)
         purge_dir_tree(manager.path_manager.download_folder)
-        if isinstance(manager.path_manager.sorted_folder, Path) and manager.config_manager.settings_data.sorting.sort_downloads:
+        if (
+            isinstance(manager.path_manager.sorted_folder, Path)
+            and manager.config_manager.settings_data.sorting.sort_downloads
+        ):
             purge_dir_tree(manager.path_manager.sorted_folder)
 
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -208,7 +208,7 @@ async def check_partials_and_empty_folders(manager: Manager) -> None:
     if not manager.config_manager.settings_data.runtime_options.skip_check_for_empty_folders:
         log_with_color("Checking for empty folders...", "yellow", 20)
         purge_dir_tree(manager.path_manager.download_folder)
-        if isinstance(manager.path_manager.sorted_folder, Path):
+        if isinstance(manager.path_manager.sorted_folder, Path) and manager.config_manager.settings_data.sorting.sort_downloads:
             purge_dir_tree(manager.path_manager.sorted_folder)
 
 


### PR DESCRIPTION
Switched the domain selection prompt to use fuzzy choices with checkbox styles to allow the user to search for websites.

Also rearranged fuzzy search arguments to match other prompts from `basic_prompts.py` (choices before message) and added the ability to use a custom validator for fuzzy search.