### PR TITLE
ci/cd: update GH release workflow + ruff pre-commit hook

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -16,15 +16,17 @@ jobs:
       - name: Check for tag
         id: check_tag
         run: |
-          if [ -z "${GITHUB_REF##*/}" ]; then
+          TAG_NAME=${GITHUB_REF##*/}
+          if [ -z "$TAG_NAME" ]; then
             echo "Error: No tag provided. Please provide a tag to run this workflow."
             exit 1
           fi
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
 
       - name: Extract version number
         id: extract_version
         run: |
-          TAG_NAME=${GITHUB_REF##*/}
+          TAG_NAME=${{ env.TAG_NAME }}
           VERSION_NUMBER=$(echo "$TAG_NAME" | grep -oE '^[0-9]+' | head -n 1)
           if [ -z "$VERSION_NUMBER" ]; then
             echo "Error: No numeric version found in tag name."
@@ -39,13 +41,25 @@ jobs:
           cd zip
           zip -r ../Cyberdrop-DL.v${{ env.VERSION_NUMBER }}.zip *
 
+      - name: Extract changelog content
+        id: extract_changelog
+        run: |
+          TAG_NAME=${{ env.TAG_NAME }}
+          CHANGELOG_CONTENT=$(awk -v version="$TAG_NAME" '
+          /^#+ \[/ { if (p) { exit }; if ($2 == "["version"]") { p=1; next} } p && NF
+          ' "CHANGELOG.md")
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            echo "Error: No changelog content found for tag $TAG_NAME."
+            exit 1
+          fi
+          echo "CHANGELOG_CONTENT<<EOF" >> $GITHUB_ENV
+          echo "$CHANGELOG_CONTENT" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           name: Cyberdrop-DL V${{ env.VERSION_NUMBER }} Start Files
-          body: |
-            If you install and run the program with PIP yourself, you do not need anything here.
-            Download the Cyberdrop-DL zip file below, you do not need to download the source code zip files.
-            The zip file contains start files that will download and install Cyberdrop-DL and keep it up to date.
+          body: ${{ env.CHANGELOG_CONTENT }}
           files: Cyberdrop-DL.v${{ env.VERSION_NUMBER }}.zip

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -34,9 +34,10 @@ jobs:
 
       - name: Create zip from subfolder
         run: |
-          mkdir -p zip/Cyberdrop-DL.v${VERSION_NUMBER}
-          cp -r scripts/release/* zip/Cyberdrop-DL.v${VERSION_NUMBER}
-          zip -r Cyberdrop-DL.v${VERSION_NUMBER}.zip zip/*
+          mkdir -p zip/Cyberdrop-DL.v${{ env.VERSION_NUMBER }}
+          cp -r scripts/release/* zip/Cyberdrop-DL.v${{ env.VERSION_NUMBER }}
+          cd zip
+          zip -r ../Cyberdrop-DL.v${{ env.VERSION_NUMBER }}.zip *
 
       - name: Create release
         id: create_release

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check for tag
+      - name: Check for version tag
         id: check_tag
         run: |
           TAG_NAME=${GITHUB_REF##*/}
@@ -34,13 +34,6 @@ jobs:
           fi
           echo "VERSION_NUMBER=$VERSION_NUMBER" >> $GITHUB_ENV
 
-      - name: Create zip from subfolder
-        run: |
-          mkdir -p zip/Cyberdrop-DL.v${{ env.VERSION_NUMBER }}
-          cp -r scripts/release/* zip/Cyberdrop-DL.v${{ env.VERSION_NUMBER }}
-          cd zip
-          zip -r ../Cyberdrop-DL.v${{ env.VERSION_NUMBER }}.zip *
-
       - name: Extract changelog content
         id: extract_changelog
         run: |
@@ -56,7 +49,14 @@ jobs:
           echo "$CHANGELOG_CONTENT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Create release
+      - name: Create start scripts zip
+        run: |
+          mkdir -p zip/Cyberdrop-DL.v${{ env.VERSION_NUMBER }}
+          cp -r scripts/release/* zip/Cyberdrop-DL.v${{ env.VERSION_NUMBER }}
+          cd zip
+          zip -r ../Cyberdrop-DL.v${{ env.VERSION_NUMBER }}.zip *
+
+      - name: Create GH release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -25,7 +25,7 @@ jobs:
         id: extract_version
         run: |
           TAG_NAME=${GITHUB_REF##*/}
-          VERSION_NUMBER=$(echo "$TAG_NAME" | grep -o '[0-9]' | head -n 1)
+          VERSION_NUMBER=$(echo "$TAG_NAME" | grep -oE '^[0-9]+' | head -n 1)
           if [ -z "$VERSION_NUMBER" ]; then
             echo "Error: No numeric version found in tag name."
             exit 1

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -42,9 +42,9 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          name: Cyberdrop-DL V${VERSION_NUMBER} Start Files
+          name: Cyberdrop-DL V${{ env.VERSION_NUMBER }} Start Files
           body: |
             If you install and run the program with PIP yourself, you do not need anything here.
             Download the Cyberdrop-DL zip file below, you do not need to download the source code zip files.
             The zip file contains start files that will download and install Cyberdrop-DL and keep it up to date.
-          files: Cyberdrop-DL.v${VERSION_NUMBER}.zip
+          files: Cyberdrop-DL.v${{ env.VERSION_NUMBER }}.zip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.8.4
     hooks:
       - id: ruff
         args: [ --fix ]


### PR DESCRIPTION
1. Fix some parsing issues on GH release action
2. Extract the content for the release from `CHANGELOG.md` [^1] [^2] [^3]
3. Update ruff pre-commit hook to v0.8.4

[^1]: The logic is not robust. If `CHANGELOG.md` is incorrectly formatted, it will fail. 
[^2]: If `CHANGELOG.md` does not have an entry for the same tag as the input tag for the workflow, it will fail. This is intentional
[^3]: Workflow is still manually triggered. This is intentional