### PR TITLE
refactor: redact traceback logs

### DIFF
--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -19,12 +19,7 @@ from cyberdrop_dl.managers.manager import Manager
 from cyberdrop_dl.scraper.scraper import ScrapeMapper
 from cyberdrop_dl.ui.program_ui import ProgramUI
 from cyberdrop_dl.ui.prompts.user_prompts import get_cookies_from_browsers
-from cyberdrop_dl.utils.logger import (
-    log,
-    log_spacer,
-    log_with_color,
-    print_to_console,
-)
+from cyberdrop_dl.utils.logger import RedactedConsole, log, log_spacer, log_with_color, print_to_console
 from cyberdrop_dl.utils.sorting import Sorter
 from cyberdrop_dl.utils.utilities import (
     check_latest_pypi,
@@ -170,7 +165,7 @@ def setup_logger(manager: Manager, config_name: str) -> None:
 
     rich_file_handler = RichHandler(
         **constants.RICH_HANDLER_CONFIG,
-        console=Console(
+        console=RedactedConsole(
             file=manager.path_manager.main_log.open("w", encoding="utf8"),
             width=manager.config_manager.settings_data.logs.log_line_width,
         ),

--- a/cyberdrop_dl/utils/logger.py
+++ b/cyberdrop_dl/utils/logger.py
@@ -16,6 +16,12 @@ ERROR_PREFIX = "\n[bold red]ERROR: [/bold red]"
 USER_NAME = Path.home().resolve().parts[-1]
 
 
+class RedactedConsole(Console):
+    def _render_buffer(self, buffer) -> str:
+        output: str = super()._render_buffer(buffer)
+        return _redact_message(output)
+
+
 def print_to_console(text: Text | str, *, error: bool = False, **kwargs) -> None:
     msg = (ERROR_PREFIX + text) if error else text
     console.print(msg, **kwargs)
@@ -23,8 +29,7 @@ def print_to_console(text: Text | str, *, error: bool = False, **kwargs) -> None
 
 def log(message: Exception | str, level: int = 10, *, sleep: int | None = None, **kwargs) -> None:
     """Simple logging function."""
-    redacted_message = _redact_message(message)
-    logger.log(level, redacted_message, **kwargs)
+    logger.log(level, message, **kwargs)
     log_debug(message, level, **kwargs)
     log_debug_console(message, level, sleep=sleep)
 


### PR DESCRIPTION
Use custom `Console` object to redact any string before writing to the log file, including traceback logs