### PR TITLE
feat: add `--separate-posts-format`

### DIFF
--- a/cyberdrop_dl/config_definitions/config_settings.py
+++ b/cyberdrop_dl/config_definitions/config_settings.py
@@ -21,7 +21,7 @@ class DownloadOptions(BaseModel):
     remove_generated_id_from_filenames: bool = False
     scrape_single_forum_post: bool = False
     separate_posts: bool = False
-    separate_posts_format: str = "{default}"
+    separate_posts_format: NonEmptyStr = "{default}"
     skip_download_mark_completed: bool = False
     skip_referer_seen_before: bool = False
     maximum_number_of_children: list[NonNegativeInt] = []

--- a/cyberdrop_dl/config_definitions/config_settings.py
+++ b/cyberdrop_dl/config_definitions/config_settings.py
@@ -21,6 +21,7 @@ class DownloadOptions(BaseModel):
     remove_generated_id_from_filenames: bool = False
     scrape_single_forum_post: bool = False
     separate_posts: bool = False
+    separate_posts_format: str = "{default}"
     skip_download_mark_completed: bool = False
     skip_referer_seen_before: bool = False
     maximum_number_of_children: list[NonNegativeInt] = []

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -38,7 +38,7 @@ class Crawler(ABC):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {}
     domain = None
     primary_base_domain: URL = None
-    DEFAULT_POST_TITLE_FORMAT = "{date} - {number} - {id} - {title}"
+    DEFAULT_POST_TITLE_FORMAT = "{date} - {number} - {title}"
 
     def __init__(self, manager: Manager, domain: str, folder_domain: str | None = None) -> None:
         self.manager = manager

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -4,9 +4,10 @@ import asyncio
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import field
+from datetime import datetime
 from functools import wraps
 from http.cookiejar import MozillaCookieJar
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 from bs4 import BeautifulSoup
 from yarl import URL
@@ -26,10 +27,18 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
+class Post(Protocol):
+    number: int
+    id: str
+    title: str
+    date: datetime | int
+
+
 class Crawler(ABC):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {}
     domain = None
     primary_base_domain: URL = None
+    DEFAULT_POST_TITLE_FORMAT = "{date} - {number} - {id} - {title}"
 
     def __init__(self, manager: Manager, domain: str, folder_domain: str | None = None) -> None:
         self.manager = manager
@@ -296,6 +305,23 @@ class Crawler(ABC):
             title = f"{title} ({self.folder_domain})"
 
         return title
+
+    def add_separate_post_title(self, scrape_item: ScrapeItem, post: Post) -> None:
+        if not self.manager.config_manager.settings_data.download_options.separate_posts:
+            return
+        title_format = self.manager.config_manager.settings_data.download_options.separate_posts_format
+        if title_format.casefold() == "{default}":
+            title_format = self.DEFAULT_POST_TITLE_FORMAT
+        date = post.date
+        if isinstance(post.date, int):
+            date = datetime.fromtimestamp(date)
+        if isinstance(date, datetime):
+            date = date.isoformat()
+        id = "Unknown" if post.id is None else post.id
+        title = "Untitled" if post.title is None else post.title
+        date = "NO_DATE" if date is None else date
+        title = title_format.format(id=id, number=id, date=date, title=title)
+        scrape_item.add_to_parent_title(title)
 
 
 def create_task_id(func: Callable) -> None:

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -6,9 +6,7 @@ from abc import ABC, abstractmethod
 from dataclasses import field
 from datetime import datetime
 from functools import wraps
-from http.cookiejar import MozillaCookieJar
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol
-
 
 from bs4 import BeautifulSoup
 from yarl import URL

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -4,6 +4,7 @@ import calendar
 import contextlib
 import datetime
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from aiolimiter import AsyncLimiter
@@ -17,8 +18,6 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
-
-from dataclasses import dataclass
 
 
 @dataclass

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -31,6 +31,7 @@ class Post:
 
 class CoomerCrawler(Crawler):
     primary_base_domain = URL("https://coomer.su")
+    DEFAULT_POST_TITLE_FORMAT = "{date} - {title}"
 
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "coomer", "Coomer")

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -19,6 +19,16 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
+class Post:
+    id: int
+    title: str
+    date: int
+
+    @property
+    def number(self):
+        return self.id
+
+
 class CoomerCrawler(Crawler):
     primary_base_domain = URL("https://coomer.su")
 
@@ -193,12 +203,7 @@ class CoomerCrawler(Crawler):
         add_parent: URL | None = None,
     ) -> None:
         """Creates a new scrape item with the same parent as the old scrape item."""
-        post_title = None
-        if self.manager.config_manager.settings_data.download_options.separate_posts:
-            post_title = f"{date} - {title}"
-            if self.manager.config_manager.settings_data.download_options.include_album_id_in_folder_name:
-                post_title = post_id + " - " + post_title
-
+        post = Post(id=post_id, title=title, date=date)
         new_title = self.create_title(user, None, None)
         new_scrape_item = self.create_scrape_item(
             old_scrape_item,
@@ -206,10 +211,10 @@ class CoomerCrawler(Crawler):
             new_title,
             True,
             None,
-            self.parse_datetime(date),
+            post.date,
             add_parent=add_parent,
         )
-        new_scrape_item.add_to_parent_title(post_title)
+        self.add_separate_post_title(new_scrape_item, post)
         await self.handle_direct_link(new_scrape_item)
 
     async def get_user_info(self, scrape_item: ScrapeItem) -> dict:

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -18,7 +18,10 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
+from dataclasses import dataclass
 
+
+@dataclass
 class Post:
     id: int
     title: str

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -32,6 +32,7 @@ class Post:
 
 class KemonoCrawler(Crawler):
     primary_base_domain = URL("https://kemono.su")
+    DEFAULT_POST_TITLE_FORMAT = "{date} - {title}"
 
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "kemono", "Kemono")

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -5,6 +5,7 @@ import contextlib
 import datetime
 import json
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from aiolimiter import AsyncLimiter
@@ -18,8 +19,6 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
-
-from dataclasses import dataclass
 
 
 @dataclass

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -19,7 +19,10 @@ from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_an
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
+from dataclasses import dataclass
 
+
+@dataclass
 class Post:
     id: int
     title: str

--- a/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/kemono_crawler.py
@@ -20,6 +20,16 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
+class Post:
+    id: int
+    title: str
+    date: int
+
+    @property
+    def number(self):
+        return self.id
+
+
 class KemonoCrawler(Crawler):
     primary_base_domain = URL("https://kemono.su")
 
@@ -181,12 +191,7 @@ class KemonoCrawler(Crawler):
         post_id = post["id"]
         title = post.get("title", "")
 
-        post_title = None
-        if self.manager.config_manager.settings_data.download_options.separate_posts:
-            post_title = f"{date} - {title}"
-            if self.manager.config_manager.settings_data.download_options.include_album_id_in_folder_name:
-                post_title = post_id + " - " + post_title
-
+        post_obj = Post(id=post_id, title=title, date=self.parse_datetime(date))
         new_title = self.create_title(user, None, None)
         scrape_item = self.create_scrape_item(
             scrape_item,
@@ -196,7 +201,7 @@ class KemonoCrawler(Crawler):
             None,
             self.parse_datetime(date),
         )
-        scrape_item.add_to_parent_title(post_title)
+        self.add_separate_post_title(scrape_item, post_obj)
         scrape_item.add_to_parent_title("Loose Files")
 
         yarl_links: list[URL] = []
@@ -249,12 +254,8 @@ class KemonoCrawler(Crawler):
         add_parent: URL | None = None,
     ) -> None:
         """Creates a new scrape item with the same parent as the old scrape item."""
-        post_title = None
-        if self.manager.config_manager.settings_data.download_options.separate_posts:
-            post_title = f"{date} - {title}"
-            if self.manager.config_manager.settings_data.download_options.include_album_id_in_folder_name:
-                post_title = post_id + " - " + post_title
 
+        post = Post(id=post_id, title=title, date=date)
         new_title = self.create_title(user, None, None)
         new_scrape_item = self.create_scrape_item(
             old_scrape_item,
@@ -262,10 +263,10 @@ class KemonoCrawler(Crawler):
             new_title,
             True,
             None,
-            self.parse_datetime(date),
+            post.date,
             add_parent=add_parent,
         )
-        new_scrape_item.add_to_parent_title(post_title)
+        self.add_separate_post_title(new_scrape_item, post)
         await self.handle_direct_link(new_scrape_item)
 
     async def get_user_info(self, scrape_item: ScrapeItem) -> dict:

--- a/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import calendar
 import contextlib
 import datetime
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from aiolimiter import AsyncLimiter
@@ -16,8 +17,6 @@ if TYPE_CHECKING:
 
     from cyberdrop_dl.managers.manager import Manager
     from cyberdrop_dl.utils.data_enums_classes.url_objects import ScrapeItem
-
-from dataclasses import dataclass
 
 
 @dataclass

--- a/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
@@ -17,7 +17,10 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
     from cyberdrop_dl.utils.data_enums_classes.url_objects import ScrapeItem
 
+from dataclasses import dataclass
 
+
+@dataclass
 class Post:
     id: int
     title: str

--- a/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
@@ -18,6 +18,16 @@ if TYPE_CHECKING:
     from cyberdrop_dl.utils.data_enums_classes.url_objects import ScrapeItem
 
 
+class Post:
+    id: int
+    title: str
+    date: int
+
+    @property
+    def number(self):
+        return self.id
+
+
 class NekohouseCrawler(Crawler):
     primary_base_domain = URL("https://nekohouse.su")
 
@@ -214,22 +224,18 @@ class NekohouseCrawler(Crawler):
         add_parent: URL | None = None,
     ) -> None:
         """Creates a new scrape item with the same parent as the old scrape item."""
-        post_title = None
-        if self.manager.config_manager.settings_data.download_options.separate_posts:
-            post_title = f"{date} - {title}"
-            if self.manager.config_manager.settings_data.download_options.include_album_id_in_folder_name:
-                post_title = post_id + " - " + post_title
-
+        post = Post(id=post_id, title=title, date=date)
         new_title = self.create_title(user, None, None)
         new_scrape_item = self.create_scrape_item(
             old_scrape_item,
-            url=link,
-            new_title_part=new_title,
-            part_of_album=True,
-            possible_datetime=self.parse_datetime(date),
+            link,
+            new_title,
+            True,
+            None,
+            post.date,
             add_parent=add_parent,
         )
-        new_scrape_item.add_to_parent_title(post_title)
+        self.add_separate_post_title(new_scrape_item, post)
         await self.handle_direct_link(new_scrape_item)
 
     async def get_maximum_offset(self, soup: BeautifulSoup) -> int:

--- a/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nekohouse_crawler.py
@@ -30,6 +30,7 @@ class Post:
 
 class NekohouseCrawler(Crawler):
     primary_base_domain = URL("https://nekohouse.su")
+    DEFAULT_POST_TITLE_FORMAT = "{date} - {title}"
 
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "nekohouse", "Nekohouse")

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -23,6 +23,16 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
+class Post:
+    id: int = None
+    title: str
+    date: int
+
+    @property
+    def number(self):
+        return self.id
+
+
 class RedditCrawler(Crawler):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {"reddit": ["reddit", "redd.it"]}
     primary_base_domain = URL("https://www.reddit.com/")
@@ -217,6 +227,7 @@ class RedditCrawler(Crawler):
         add_parent: URL | None = None,
     ) -> ScrapeItem:
         """Creates a new scrape item with the same parent as the old scrape item."""
+        post = Post(title=title, date=date)
         new_scrape_item = self.create_scrape_item(
             old_scrape_item,
             link,
@@ -226,6 +237,5 @@ class RedditCrawler(Crawler):
             date,
             add_parent=add_parent,
         )
-        if self.manager.config_manager.settings_data.download_options.separate_posts:
-            new_scrape_item.add_to_parent_title(title)
+        self.add_separate_post_title(new_scrape_item, post)
         return new_scrape_item

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -35,6 +35,7 @@ class Post:
 
 class RedditCrawler(Crawler):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {"reddit": ["reddit", "redd.it"]}
+    DEFAULT_POST_TITLE_FORMAT = "{title}"
     primary_base_domain = URL("https://www.reddit.com/")
 
     def __init__(self, manager: Manager, site: str) -> None:

--- a/docs/reference/cli-arguments.md
+++ b/docs/reference/cli-arguments.md
@@ -171,6 +171,7 @@ download_options:
   --remove-generated-id-from-filenames, --no-remove-generated-id-from-filenames
   --scrape-single-forum-post, --no-scrape-single-forum-post
   --separate-posts, --no-separate-posts
+  --separate-posts-format SEPARATE_POSTS_FORMAT
   --skip-download-mark-completed, --no-skip-download-mark-completed
   --skip-referer-seen-before, --no-skip-referer-seen-before
   --maximum-number-of-children [MAXIMUM_NUMBER_OF_CHILDREN ...]

--- a/docs/reference/configuration-options/settings/download_options.md
+++ b/docs/reference/configuration-options/settings/download_options.md
@@ -84,7 +84,37 @@ Setting this to `true` will prevent Cyberdrop-DL to scrape entire thread if an i
 |----------------|----------|
 | `bool` | `false` |
 
-Setting this to `true` will separate content from forum posts into separate folders.
+Setting this to `true` will separate content from forum and site posts into separate folders. Only affects sites which have 'posts': `Forums`, `reddit`, `coomer`, `kemono` and `nekohouse`.
+
+## `separate_posts_format`
+
+| Type           | Default  |
+|----------------|----------|
+| `NonEmptyStr`  | `{default}`|
+
+This is the format for the directory created when using `--separate-posts`.
+
+Unique Path Flags:
+
+> `date`: date of the post
+>
+> `number`: post number
+>
+> `id`: same as `number`
+>
+> `title`: post title
+
+{% hint style="warning" %}
+Not all sites support all possible flags. Ex: Posts from reddit only support the `title` flag
+{% endhint %}
+
+Setting it to `{default}` will use the default format, which is different for each crawler:
+
+| Site          | Default Format |
+|----------------|----------|
+| `Coomer`, `Kemono` an `Nekohouse` | `{date} - {title}`|
+| `Forums` | `post-{number}`|
+| `Reddit` | `{title}`|
 
 ## `skip_download_mark_complete`
 


### PR DESCRIPTION
Allow defining a custom format for the name of the folder created when using `--separate-posts`

| Type           | Default  |
|----------------|----------|
| `NonEmptyStr`  | `{default}`|

Unique Path Flags:

> `date`: date of the post
>
> `number`: post number
>
> `id`: same as `number`
>
> `title`: post title

Setting it to `{default}` will use the default format, which is different for each crawler:

| Site          | Default Format |
|----------------|----------|
| `Coomer`, `Kemono` and `Nekohouse` | `{date} - {title}`|
| `Forums` | `post-{number}`|
| `Reddit` | `{title}`|