### PR TITLE
ci/cd: update workflows, ruff rules and pre-commit hooks

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -8,12 +8,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ruff lint
-        uses: astral-sh/ruff-action@v1
+        uses: astral-sh/ruff-action@v3
         with:
           version: v0.8.0
 
       - name: ruff format check
-        uses: astral-sh/ruff-action@v1
+        uses: astral-sh/ruff-action@v3
         with:
           args: "format --check"
           version: v0.8.0

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -10,10 +10,10 @@ jobs:
       - name: ruff lint
         uses: astral-sh/ruff-action@v3
         with:
-          version: v0.8.0
+          version: "0.8.0"
 
       - name: ruff format check
         uses: astral-sh/ruff-action@v3
         with:
           args: "format --check"
-          version: v0.8.0
+          version: "0.8.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,20 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
-      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-illegal-windows-names
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
       - id: check-toml
       - id: check-yaml
       - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: name-tests-test
+        args: [ --pytest-test-first ]
+      - id: trailing-whitespace
+        args: [ --markdown-linebreak-ext=md ]
 
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,12 @@ repos:
       - id: check-yaml
       - id: detect-private-key
 
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.2
+    hooks:
+      - id: toml-sort-fix
+        files: ^(.*\.toml)$
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "cyberdrop-dl-patched"
-version = "6.0.1"
-description = "Bulk downloader for multiple file hosts"
 authors = ["Jacob B <admin@script-ware.net>"]
+description = "Bulk downloader for multiple file hosts"
+documentation = "https://script-ware.gitbook.io/cyberdrop-dl/"
+include = ["CHANGELOG.md"]
+packages = [{include = "cyberdrop_dl"}]
 readme = "README.md"
 repository = "https://github.com/jbsparrow/CyberDropDownloader"
-documentation = "https://script-ware.gitbook.io/cyberdrop-dl/"
-packages = [{ include = "cyberdrop_dl" }]
-include = ["CHANGELOG.md"]
+version = "6.0.1"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
@@ -24,15 +24,15 @@ certifi = "^2024.12.14"
 filedate = "^3.0"
 get-video-properties = "^0.1.1"
 inquirerpy = "^0.3.4"
-jeepney =   [{platform = "linux", version = "^0.8.0"},{platform = "bsd", version = "^0.8.0"}]
+jeepney = [{platform = "bsd", version = "^0.8.0"}, {platform = "linux", version = "^0.8.0"}]
 mediafire = "^0.6.1"
 myjdapi = "^1.1.7"
 pillow = "^11.0.0"
 platformdirs = "^4.3.6"
 pycryptodomex = "^3.21.0"
 pydantic = "^2.10.4"
+pywin32 = {platform = "win32", version = "^308"}
 pyyaml = "^6.0.2"
-pywin32 = {version = "^308", platform = "win32"}
 rich = "^13.9.4"
 send2trash = "^1.8.3"
 xxhash = "^3.5.0"
@@ -53,42 +53,49 @@ cyberdrop-dl = "cyberdrop_dl.main:main"
 [tool.poetry.urls]
 Changelog = "https://github.com/jbsparrow/CyberDropDownloader/blob/master/CHANGELOG.md"
 
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "module"
+asyncio_mode = "auto"
+minversion = "8.3"
+testpaths = ["tests"]
+
 [tool.ruff]
+exclude = ["cyberdrop_dl/dependencies/browser_cookie3/__init__.py"]
 line-length = 120
 target-version = "py311"
-exclude = ["cyberdrop_dl/dependencies/browser_cookie3/__init__.py"]
 
 [tool.ruff.lint]
 select = [
-    "E",    # pycodestyle errors
-    "W",    # pycodestyle warnings
-    "F",    # pyflakes
-    "I",    # isort
-    "B",    # flake8-bugbear
-    "C4",   # flake8-comprehensions
-    "UP",   # pyupgrade
-    "N",    # PEP8 naming conventions
-    "TCH",  # flake8-type-checking
-    "COM8", # flake8-commas linter
+    "B",  # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "COM8",  # flake8-commas linter
+    "E",  # pycodestyle errors
+    "F",  # pyflakes
+    "I",  # isort
+    "N",  # PEP8 naming conventions
+    "Q",  # flake8-quotes
     "RUF",  # RUF specific fixes
-    "Q",    # flake8-quotes
+    "TCH",  # flake8-type-checking
+    "UP",  # pyupgrade
+    "W"  # pycodestyle warnings
 ]
-
 ignore = [
-    "N806",   # Uppercase variables in functions
-    "E501",   # Suppress line-too-long, let formatter decide
-    "COM812", # missing-trailing-comma
+    "COM812",  # missing-trailing-comma
+    "E501",  # Suppress line-too-long, let formatter decide
+    "N806"  # Uppercase variables in functions
 ]
-
-[tool.pytest.ini_options]
-minversion = "8.3"
-testpaths = ["tests"]
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "module"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.tomlsort]
+all = true
+ignore_case = true
+in_place = true
+sort_first = ["name", "python", "select", "tool"]
+spaces_before_inline_comment = 2
+spaces_indent_inline_array = 4
+
 [build-system]
-requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ select = [
     "COM8",  # flake8-commas linter
     "E",  # pycodestyle errors
     "F",  # pyflakes
-    "FA100",  # future annotations
+    "FA102",  # future annotations
     "I",  # isort
     "N",  # PEP8 naming conventions
     "PTH",  # use pathlib instead of os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,24 +66,39 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = [
+    "ASYNC",  # async calls that do not await anything or use blocking methods
     "B",  # flake8-bugbear
     "C4",  # flake8-comprehensions
     "COM8",  # flake8-commas linter
     "E",  # pycodestyle errors
     "F",  # pyflakes
+    "FA100",  # future annotations
     "I",  # isort
     "N",  # PEP8 naming conventions
+    "PTH",  # use pathlib instead of os
     "Q",  # flake8-quotes
     "RUF",  # RUF specific fixes
-    "TCH",  # flake8-type-checking
+    "T20",  # flake8-print
+    "TC",  # flake8-type-checking
+    "TID",  # flake8-tidy-imports
     "UP",  # pyupgrade
     "W"  # pycodestyle warnings
 ]
+extend-safe-fixes = [
+    "TC"  # move import from and to TYPE_CHECKING blocks
+]
 ignore = [
     "COM812",  # missing-trailing-comma
-    "E501",  # Suppress line-too-long, let formatter decide
-    "N806"  # Uppercase variables in functions
+    "E501",  # suppress line-too-long, let formatter decide
+    "N806"  # uppercase variables in functions
 ]
+unfixable = [
+    "ERA"  # do not autoremove commented out code
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/{tests,docs}/*" = ["E402"]  # imports not at the top of the file.
+"__init__.py" = ["E402"]  # imports not at the top of the file.
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ unfixable = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"**/{tests,docs}/*" = ["E402"]  # imports not at the top of the file.
+"**/{tests,docs}/*" = ["E402", "T20"]  # imports not at the top of the file.
 "__init__.py" = ["E402"]  # imports not at the top of the file.
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
# 1. Add new pre-commits
## General purpose
- `toml-sort`
- `check-merge-conflict`
- `name-tests-test`
- `check-illegal-windows-names`
- `check-case-conflict`

## These are for release scripts
- `check-executables-have-shebangs`
- `check-shebang-scripts-are-executable`
- `check-added-large-files`

# 2. Add new ruff rules
## New:
- `ASYNC` # `async` calls that do not `await` anything or use blocking methods ([link](https://docs.astral.sh/ruff/rules/#flake8-async-async))
- `FA102`  # future annotations ([link](https://docs.astral.sh/ruff/rules/future-required-type-annotation/))
- `PTH`  # use `pathlib` instead of `os` ([link](https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth))
- `T20`  # flake8-print ([link](https://docs.astral.sh/ruff/rules/#flake8-print-t20))
- `TID`  # flake8-tidy-imports ([link](https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid))

## Changed
- Replace `TCH` with `TC` (new name for type checking imports) and add it as a safe fix
- Marked `ERA` (commented out code) as unfixable

## Ignore:
- Ignore `E402` on `__init__.py` files, `tests` and `docs` folders
- Ignore `T20` on `tests` and `docs` folders

# 3.  Update ruff action to v3

***

> [!NOTE]
> The ruff check on this PR may fail cause of the new rules. I will make a PR with the fixes after this PR is merged (if required)