### PR TITLE
fix: general crawler fixes

### DIFF
--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -105,6 +105,15 @@ class RestrictedFiletypeError(CDLBaseError):
         super().__init__(ui_message, origin=origin)
 
 
+class MediaFireError(CDLBaseError):
+    def __init__(
+        self, status: str | int, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None
+    ) -> None:
+        """This error will be thrown when a scrape fails."""
+        ui_message = f"{status} MediaFire Error"
+        super().__init__(ui_message, message=message, status=status, origin=origin)
+
+
 class ScrapeError(CDLBaseError):
     def __init__(
         self, status: str | int, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -6,16 +6,14 @@ from typing import TYPE_CHECKING
 
 from yarl import URL
 
+from cyberdrop_dl.utils.constants import VALIDATION_ERROR_FOOTER
+
 if TYPE_CHECKING:
     from requests import Response
     from yaml.constructor import ConstructorError
 
     from cyberdrop_dl.scraper.crawler import ScrapeItem
     from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem
-
-VALIDATION_ERROR_FOOTER = """
-Read the documentation for guidance on how to resolve this error: https://script-ware.gitbook.io/cyberdrop-dl/reference/configuration-options
-Please note, this is not a bug. Do not open issues related to this"""
 
 
 class CDLBaseError(Exception):

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from yarl import URL
 
 if TYPE_CHECKING:
+    from requests import Response
     from yaml.constructor import ConstructorError
 
     from cyberdrop_dl.scraper.crawler import ScrapeItem
@@ -112,6 +113,30 @@ class MediaFireError(CDLBaseError):
         """This error will be thrown when a scrape fails."""
         ui_message = f"{status} MediaFire Error"
         super().__init__(ui_message, message=message, status=status, origin=origin)
+
+
+class RealDebridError(CDLBaseError):
+    """Base RealDebrid API error."""
+
+    def __init__(self, response: Response, error_codes: dict[int, str]) -> None:
+        url = URL(response.url)
+        self.path = url.path
+        try:
+            JSONResp: dict = response.json()
+            code = JSONResp.get("error_code")
+            if code == 16:
+                code = 7
+            error = error_codes.get(code, "Unknown error")
+
+        except AttributeError:
+            code = response.status_code
+            error = f"{code} - {HTTPStatus(code).phrase}"
+
+        error = error.capitalize()
+
+        """This error will be thrown when a scrape fails."""
+        ui_message = f"{code} RealDebrid Error"
+        super().__init__(ui_message, message=error, status=code, origin=url)
 
 
 class ScrapeError(CDLBaseError):

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -163,7 +163,7 @@ class ClientManager:
             with contextlib.suppress(ContentTypeError):
                 JSON_Resp: dict = await response.json()
                 if "status" in JSON_Resp and "notFound" in JSON_Resp["status"]:
-                    raise ScrapeError(HTTPStatus.NOT_FOUND, origin=origin)
+                    raise ScrapeError(404, origin=origin)
                 if "data" in JSON_Resp and "error" in JSON_Resp["data"]:
                     raise ScrapeError(JSON_Resp["status"], JSON_Resp["data"]["error"], origin=origin)
 

--- a/cyberdrop_dl/managers/real_debrid/api.py
+++ b/cyberdrop_dl/managers/real_debrid/api.py
@@ -9,7 +9,8 @@ from requests import Session
 from requests.exceptions import RequestException
 from yarl import URL
 
-from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
+from cyberdrop_dl.clients.errors import RealDebridError
+from cyberdrop_dl.managers.real_debrid.errors import ERROR_CODES
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -84,7 +85,7 @@ class RealDebridApi:
             response.raise_for_status()
             JSONResp: dict = response.json()
         except RequestException:
-            raise RealDebridError(response) from None
+            raise RealDebridError(response, ERROR_CODES) from None
         except AttributeError:
             return response.text
         else:

--- a/cyberdrop_dl/managers/real_debrid/errors.py
+++ b/cyberdrop_dl/managers/real_debrid/errors.py
@@ -1,15 +1,3 @@
-from __future__ import annotations
-
-from http import HTTPStatus
-from typing import TYPE_CHECKING
-
-from yarl import URL
-
-from cyberdrop_dl.clients.errors import CDLBaseError
-
-if TYPE_CHECKING:
-    from requests import Response
-
 ERROR_CODES = {
     -1: "Internal error",
     1: "Missing parameter",
@@ -49,27 +37,3 @@ ERROR_CODES = {
     35: "Infringing file",
     36: "Fair Usage Limit",
 }
-
-
-class RealDebridError(CDLBaseError):
-    """Base RealDebrid API error."""
-
-    def __init__(self, response: Response) -> None:
-        url = URL(response.url)
-        self.path = url.path
-        try:
-            JSONResp: dict = response.json()
-            code = JSONResp.get("error_code")
-            if code == 16:
-                code = 7
-            error = ERROR_CODES.get(code, "Unknown error")
-
-        except AttributeError:
-            code = response.status_code
-            error = f"{code} - {HTTPStatus(code).phrase}"
-
-        error = error.capitalize()
-
-        """This error will be thrown when a scrape fails."""
-        ui_message = f"{code} RealDebrid Error"
-        super().__init__(ui_message, message=error, status=code, origin=url)

--- a/cyberdrop_dl/managers/realdebrid_manager.py
+++ b/cyberdrop_dl/managers/realdebrid_manager.py
@@ -6,8 +6,8 @@ from dataclasses import field
 from re import Pattern
 from typing import TYPE_CHECKING
 
+from cyberdrop_dl.clients.errors import RealDebridError
 from cyberdrop_dl.managers.real_debrid.api import RealDebridApi
-from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
 from cyberdrop_dl.utils.logger import log
 
 warnings.simplefilter(action="ignore", category=FutureWarning)

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -44,7 +44,7 @@ class Crawler(ABC):
         self.downloader = field(init=False)
         self.scraping_progress = manager.progress_manager.scraping_progress
         self.client: ScraperClient = field(init=False)
-        self._lock = asyncio.Semaphore(20)
+        self._lock = asyncio.Lock()
 
         self.domain = domain
         self.folder_domain = folder_domain or domain.capitalize()

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -44,7 +44,7 @@ class Crawler(ABC):
         self.downloader = field(init=False)
         self.scraping_progress = manager.progress_manager.scraping_progress
         self.client: ScraperClient = field(init=False)
-        self._lock = asyncio.Lock()
+        self._lock = asyncio.Semaphore(20)
 
         self.domain = domain
         self.folder_domain = folder_domain or domain.capitalize()

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -163,7 +163,7 @@ class BunkrrCrawler(Crawler):
 
         link = link_container.get(src_selector) if link_container else None
         if not link:
-            raise ScrapeError(422, f"Could not find source for: {scrape_item.url}", origin=scrape_item)
+            raise ScrapeError(422, "Couldn't find source", origin=scrape_item)
 
         link = URL(link)
         date = None

--- a/cyberdrop_dl/scraper/crawlers/chevereto_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/chevereto_crawler.py
@@ -200,7 +200,7 @@ class CheveretoCrawler(Crawler):
             link = URL(soup.select_one("div[id=image-viewer] img").get("src"))
             link = link.with_name(link.name.replace(".md.", ".").replace(".th.", "."))
         except AttributeError:
-            raise ScrapeError(422, f"Could not find img source for {scrape_item.url}", origin=scrape_item) from None
+            raise ScrapeError(422, "Couldn't find img source", origin=scrape_item) from None
 
         desc_rows = soup.select("p[class*=description-meta]")
         date = None

--- a/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberdrop_crawler.py
@@ -66,8 +66,8 @@ class CyberdropCrawler(Crawler):
             title = self.create_title(soup.select_one("h1[id=title]").text, scrape_item.album_id, None)
         except AttributeError:
             raise ScrapeError(
-                404,
-                message="No album information found in response content",
+                422,
+                message="Unable to parse album information from response content",
                 origin=scrape_item,
             ) from None
 

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -106,7 +106,7 @@ class GoFileCrawler(Crawler):
     def check_json_response(self, json_resp: dict, scrape_item: ScrapeItem | None = None) -> None:
         """Parses and raises errors from json response."""
         if json_resp["status"] == "error-notFound":
-            raise ScrapeError(404, "Album not found", origin=scrape_item)
+            raise ScrapeError(404, origin=scrape_item)
 
         json_resp: dict = json_resp["data"]
         is_password_protected = json_resp.get("password")
@@ -150,7 +150,7 @@ class GoFileCrawler(Crawler):
             async with self.request_limiter:
                 json_resp = await self.client.post_data(self.domain, create_account_address, data={})
                 if json_resp["status"] != "ok":
-                    raise ScrapeError(403, "Couldn't generate GoFile token", origin=scrape_item)
+                    raise ScrapeError(401, "Couldn't generate GoFile API token", origin=scrape_item)
 
             self.api_key = json_resp["data"]["token"]
         self.headers["Authorization"] = f"Bearer {self.api_key}"
@@ -170,6 +170,6 @@ class GoFileCrawler(Crawler):
             text = await self.client.get_text(self.domain, self.js_address, origin=scrape_item)
         match = re.search(WT_REGEX, str(text))
         if not match:
-            raise ScrapeError(403, "Couldn't generate GoFile websiteToken", origin=scrape_item)
+            raise ScrapeError(401, "Couldn't generate GoFile websiteToken", origin=scrape_item)
         self.website_token = match.group(1)
         self.manager.cache_manager.save("gofile_website_token", self.website_token)

--- a/cyberdrop_dl/scraper/crawlers/imgbox_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgbox_crawler.py
@@ -52,7 +52,7 @@ class ImgBoxCrawler(Crawler):
             soup: BeautifulSoup = await self.client.get_soup(self.domain, scrape_item.url, origin=scrape_item)
 
         if "The specified gallery could not be found" in soup.text:
-            raise ScrapeError(404, f"Gallery not found: {scrape_item.url}", origin=scrape_item)
+            raise ScrapeError(404, origin=scrape_item)
 
         scrape_item.album_id = scrape_item.url.parts[2]
         scrape_item.part_of_album = True

--- a/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/omegascans_crawler.py
@@ -11,7 +11,6 @@ from yarl import URL
 from cyberdrop_dl.clients.errors import MaxChildrenError, ScrapeError
 from cyberdrop_dl.scraper.crawler import Crawler
 from cyberdrop_dl.utils.data_enums_classes.url_objects import FILE_HOST_ALBUM, ScrapeItem
-from cyberdrop_dl.utils.logger import log
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
 
 if TYPE_CHECKING:
@@ -65,7 +64,7 @@ class OmegaScansCrawler(Crawler):
                 break
 
         if not series_id:
-            raise ScrapeError(404, "series_id not found", origin=scrape_item)
+            raise ScrapeError(422, "Unable to parse series_id from html", origin=scrape_item)
 
         page_number = 1
         number_per_page = 30
@@ -101,7 +100,6 @@ class OmegaScansCrawler(Crawler):
             soup: BeautifulSoup = await self.client.get_soup(self.domain, scrape_item.url, origin=scrape_item)
 
         if "This chapter is premium" in soup.get_text():
-            log("Scrape Failed: This chapter is premium", 40)
             raise ScrapeError(401, "This chapter is premium", origin=scrape_item)
 
         title_parts = soup.select_one("title").get_text().split(" - ")

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 import asyncpraw
@@ -23,10 +24,11 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
+@dataclass
 class Post:
-    id: int = None
     title: str
     date: int
+    id: int = None
 
     @property
     def number(self):

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -210,9 +210,9 @@ class RedditCrawler(Crawler):
             try:
                 post = await reddit.submission(url=head["location"])
             except asyncprawcore.exceptions.Forbidden:
-                raise ScrapeError(403, "Forbidden", origin=scrape_item) from None
+                raise ScrapeError(403, origin=scrape_item) from None
             except asyncprawcore.exceptions.NotFound:
-                raise ScrapeError(404, "Not Found", origin=scrape_item) from None
+                raise ScrapeError(404, origin=scrape_item) from None
 
             await self.post(scrape_item, post, reddit)
             return

--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -77,6 +77,6 @@ class SaintCrawler(Crawler):
         try:
             link = URL(soup.select_one("video[id=main-video] source").get("src"))
         except AttributeError:
-            raise ScrapeError(404, f"Could not find video source for {scrape_item.url}", origin=scrape_item) from None
+            raise ScrapeError(422, "Couldn't find video source", origin=scrape_item) from None
         filename, ext = get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -109,15 +109,15 @@ class XXXBunkerCrawler(Crawler):
 
         except (AttributeError, TypeError):
             if ajax_soup and "You must be registered to download this video" in ajax_soup.text:
-                raise ScrapeError(403, f"Invalid PHPSESSID: {scrape_item.url}", origin=scrape_item) from None
+                raise ScrapeError(403, "Invalid cookies, PHPSESSID", origin=scrape_item) from None
 
             if "TRAFFIC VERIFICATION" in soup.text:
                 await asyncio.sleep(self.wait_time)
                 self.wait_time = min(self.wait_time + 10, MAX_WAIT)
                 self.rate_limit = max(self.rate_limit * 0.8, MIN_RATE_LIMIT)
                 self.request_limiter = AsyncLimiter(self.rate_limit, 60)
-                raise ScrapeError(429, f"Too many request: {scrape_item.url}", origin=scrape_item) from None
-            raise ScrapeError(404, f"Could not find video source for {scrape_item.url}", origin=scrape_item) from None
+                raise ScrapeError(429, origin=scrape_item) from None
+            raise ScrapeError(422, "Couldn't find video source", origin=scrape_item) from None
 
         # NOTE: hardcoding the extension to prevent quering the final server URL
         # final server URL is always different so it can not be saved to db.
@@ -145,11 +145,11 @@ class XXXBunkerCrawler(Crawler):
 
         # Not a valid URL
         else:
-            raise ScrapeError(400, f"Unsupported URL format: {scrape_item.url}", origin=scrape_item)
+            raise ScrapeError(400, "Unsupported URL format", origin=scrape_item)
 
         scrape_item.part_of_album = True
 
-        async for soup in self.web_pager(scrape_item.url):
+        async for soup in self.web_pager(scrape_item):
             videos = soup.select("a[data-anim='4']")
             for video in videos:
                 link = video.get("href")
@@ -163,9 +163,9 @@ class XXXBunkerCrawler(Crawler):
                 new_scrape_item = self.create_scrape_item(scrape_item, link, title, add_parent=scrape_item.url)
                 await self.video(new_scrape_item)
 
-    async def web_pager(self, url: URL) -> AsyncGenerator[BeautifulSoup]:
+    async def web_pager(self, scrape_item: ScrapeItem) -> AsyncGenerator[BeautifulSoup]:
         """Generator of website pages."""
-        page_url = url
+        page_url = scrape_item.url
         rate_limited = True
         while True:
             attempt = 1
@@ -189,7 +189,7 @@ class XXXBunkerCrawler(Crawler):
                 await asyncio.sleep(self.wait_time)
 
             if rate_limited:
-                raise ScrapeError(429, f"Too many request: {url}")
+                raise ScrapeError(429, origin=scrape_item)
 
             next_page = soup.select_one("div.page-list")
             next_page = next_page.find("a", string="Next") if next_page else None

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -154,8 +154,9 @@ class ScrapeMapper:
         for title in links:
             for url in links[title]:
                 item = self.create_item_from_link(url)
-                item.add_to_parent_title(title)
-                item.part_of_album = True
+                if title:
+                    item.add_to_parent_title(title)
+                    item.part_of_album = True
                 if self.filter_items(item):
                     items.append(item)
         for item in items:

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -21,6 +21,8 @@ RICH_HANDLER_DEBUG_CONFIG = {
     "tracebacks_extra_lines": 2,
     "locals_max_length": 20,
 }
+VALIDATION_ERROR_FOOTER = """Please read the documentation for guidance on how to resolve this error: https://script-ware.gitbook.io/cyberdrop-dl/reference/configuration-options
+This is not a bug. Do not open issues related to this"""
 
 
 # regex

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -17,7 +17,6 @@ from rich.text import Text
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import CDLBaseError, NoExtensionError
-from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.logger import log, log_debug, log_spacer, log_with_color
 
@@ -44,9 +43,6 @@ def error_handling_wrapper(func: Callable) -> Callable:
             log_message_short = e_ui_failure = e.ui_message
             log_message = f"{e.ui_message} - {e.message}" if e.ui_message != e.message else e.message
             origin = e.origin
-        except RealDebridError as e:
-            log_message_short = log_message = f"RealDebridError - {e.error}"
-            e_ui_failure = f"RD - {e.error}"
         except TimeoutError:
             log_message_short = log_message = e_ui_failure = "Timeout"
         except ClientConnectorError as e:

--- a/cyberdrop_dl/utils/yaml.py
+++ b/cyberdrop_dl/utils/yaml.py
@@ -12,6 +12,7 @@ from yaml.error import YAMLError
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import InvalidYamlError
+from cyberdrop_dl.utils.constants import VALIDATION_ERROR_FOOTER
 
 
 class TimedeltaSerializer(BaseModel):
@@ -38,9 +39,6 @@ yaml.add_multi_representer(Enum, _save_as_str)
 yaml.add_multi_representer(date, _save_date)
 yaml.add_representer(timedelta, _save_timedelta)
 yaml.add_representer(URL, _save_as_str)
-
-VALIDATION_ERROR_FOOTER = """Please read the documentation for guidance on how to resolve this error: https://script-ware.gitbook.io/cyberdrop-dl/reference/configuration-options
-Please note, this is not a bug. Do not open issues related to this"""
 
 
 def save(file: Path, data: BaseModel | dict) -> None:


### PR DESCRIPTION
- Use dataclasses for posts (reddit)
- Pass `scrape_item` as origin for `web_pager` to log them with errors (if any) (chevereto) 
- Fix "Loose Files" folder not being created (all crawlers)
- Add custom `MediaFireError` (mediafire)
- Use the correct HTTP error codes for `ScrapeError`. Do not overload `403` or `404` unless that's the actual response. Use `422` for errors found while parsing the HTML
- Make `RealDebridError` inherit from `CDLBaseError`
- Move all custom errors to `clients.errors`. However, this needs to be moved (to it own module maybe?) cause not all errors are from clients (ex: YAML errors)
- Should fix #426