### PR TITLE
perf: use deque for file, scrape and sort progress

### DIFF
--- a/cyberdrop_dl/clients/hash_client.py
+++ b/cyberdrop_dl/clients/hash_client.py
@@ -51,7 +51,7 @@ class HashClient:
         self.md5 = "md5"
         self.sha256 = "sha256"
         self.hashed_media_items: set[MediaItem] = set()
-        self.hashes_dict: defaultdict[defaultdict[set[Path]]] = defaultdict(lambda: defaultdict(set))
+        self.hashes_dict: defaultdict[str, defaultdict[str, set[Path]]] = defaultdict(lambda: defaultdict(set))
 
     async def startup(self) -> None:
         pass
@@ -168,9 +168,9 @@ class HashClient:
         downloads = self.manager.path_manager.completed_downloads - self.hashed_media_items
         for media_item in downloads:
             if not media_item.complete_file.is_file():
-                return
+                continue
             try:
-                self.hash_item(media_item)
+                await self.hash_item(media_item)
             except Exception as e:
                 msg = f"Unable to hash file = {media_item.complete_file.resolve()}: {e}"
                 log(msg, 40)

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -125,7 +125,7 @@ class Downloader:
         """Attempts to remove the task from the progress bar."""
         if media_item.task_id is not None:
             with contextlib.suppress(ValueError):
-                self.manager.progress_manager.file_progress.remove_file(media_item.task_id)
+                self.manager.progress_manager.file_progress.remove_task(media_item.task_id)
         media_item.task_id = None
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -33,7 +33,7 @@ STARTUP_LOGGER_FILE = Path().cwd().joinpath("startup.log")
 STARTUP_LOGGER_CONSOLE = None
 
 
-def startup() -> Manager:
+def startup() -> Manager | None:
     """Starts the program and returns the manager.
 
     This will also run the UI for the program
@@ -188,7 +188,7 @@ def setup_logger(manager: Manager, config_name: str) -> None:
     logger.addHandler(rich_handler)
 
 
-def ui_error_handling_wrapper(func: Callable) -> None:
+def ui_error_handling_wrapper(func: Callable) -> Callable:
     """Wrapper handles errors from the main UI."""
 
     @wraps(func)

--- a/cyberdrop_dl/managers/live_manager.py
+++ b/cyberdrop_dl/managers/live_manager.py
@@ -11,7 +11,7 @@ from cyberdrop_dl.utils.logger import console
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from rich.layout import Layout
+    from rich.console import RenderableType
 
     from cyberdrop_dl.managers.manager import Manager
 
@@ -35,7 +35,7 @@ class LiveManager:
         self.placeholder.add_task("running with no UI", total=100, completed=0)
 
     @contextmanager
-    def get_live(self, layout: Layout, stop: bool = False) -> Generator[Live]:
+    def get_live(self, layout: RenderableType, stop: bool = False) -> Generator[Live]:
         show = self.placeholder if self.no_ui else layout
         try:
             self.live.start()

--- a/cyberdrop_dl/managers/live_manager.py
+++ b/cyberdrop_dl/managers/live_manager.py
@@ -48,7 +48,7 @@ class LiveManager:
     @contextmanager
     def get_main_live(self, stop: bool = False) -> Generator[Live]:
         """Main UI startup and context manager."""
-        layout = self.manager.progress_manager.layout
+        layout = self.manager.progress_manager.main_runtime_layout
         with self.get_live(layout, stop=stop) as live:
             yield live
 

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -17,6 +17,8 @@ from cyberdrop_dl.ui.progress.statistic_progress import DownloadStatsProgress, S
 from cyberdrop_dl.utils.logger import log, log_spacer, log_with_color
 
 if TYPE_CHECKING:
+    from rich.console import RenderableType
+
     from cyberdrop_dl.managers.manager import Manager
 
 
@@ -45,17 +47,17 @@ class ProgressManager:
         self.ui_refresh_rate = manager.config_manager.global_settings_data.ui_options.refresh_rate
 
         self.layout: Layout = field(init=False)
-        self.hash_remove_layout: Layout = field(init=False)
-        self.hash_layout: Layout = field(init=False)
-        self.sort_layout: Layout = field(init=False)
+        self.hash_remove_layout: RenderableType = field(init=False)
+        self.hash_layout: RenderableType = field(init=False)
+        self.sort_layout: RenderableType = field(init=False)
 
     def startup(self) -> None:
         """Startup process for the progress manager."""
         progress_layout = Layout()
         progress_layout.split_column(
             Layout(name="upper", ratio=2, minimum_size=8),
-            Layout(renderable=self.scraping_progress.get_progress(), name="Scraping", ratio=2),
-            Layout(renderable=self.file_progress.get_progress(), name="Downloads", ratio=2),
+            Layout(renderable=self.scraping_progress.get_renderable(), name="Scraping", ratio=2),
+            Layout(renderable=self.file_progress.get_renderable(), name="Downloads", ratio=2),
         )
         progress_layout["upper"].split_row(
             Layout(renderable=self.download_progress.get_progress(), name="Files", ratio=1),
@@ -69,7 +71,7 @@ class ProgressManager:
         self.layout = progress_layout
         self.hash_remove_layout = hash_remove_layout
         self.hash_layout = self.hash_progress.get_hash_progress()
-        self.sort_layout = self.sort_progress.get_progress()
+        self.sort_layout = self.sort_progress.get_renderable()
 
     def print_stats(self, start_time: timedelta | float) -> None:
         """Prints the stats of the program."""

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -46,7 +46,7 @@ class ProgressManager:
 
         self.ui_refresh_rate = manager.config_manager.global_settings_data.ui_options.refresh_rate
 
-        self.layout: Layout = field(init=False)
+        self.main_runtime_layout: Layout = field(init=False)
         self.hash_remove_layout: RenderableType = field(init=False)
         self.hash_layout: RenderableType = field(init=False)
         self.sort_layout: RenderableType = field(init=False)
@@ -65,15 +65,12 @@ class ProgressManager:
             Layout(renderable=self.download_stats_progress.get_progress(), name="Download Failures", ratio=1),
         )
 
-        hash_remove_layout = Layout()
-        hash_remove_layout = self.hash_progress.get_removed_progress()
-
-        self.layout = progress_layout
-        self.hash_remove_layout = hash_remove_layout
+        self.main_runtime_layout = progress_layout
+        self.hash_remove_layout = self.hash_progress.get_removed_progress()
         self.hash_layout = self.hash_progress.get_hash_progress()
         self.sort_layout = self.sort_progress.get_renderable()
 
-    def print_stats(self, start_time: timedelta | float) -> None:
+    def print_stats(self, start_time: float) -> None:
         """Prints the stats of the program."""
         end_time = time.perf_counter()
         runtime = timedelta(seconds=int(end_time - start_time))

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -67,7 +67,7 @@ class ProgressManager:
 
         self.main_runtime_layout = progress_layout
         self.hash_remove_layout = self.hash_progress.get_removed_progress()
-        self.hash_layout = self.hash_progress.get_hash_progress()
+        self.hash_layout = self.hash_progress.get_renderable()
         self.sort_layout = self.sort_progress.get_renderable()
 
     def print_stats(self, start_time: float) -> None:

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -19,7 +19,7 @@ def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
 
 
 class DequeProgress(ABC):
-    progress: Progress
+    _progress: Progress
     type_str: str = "Files"
     color = "plum3"
     progress_str = "[{color}]{description}"
@@ -28,19 +28,19 @@ class DequeProgress(ABC):
 
     def __init__(self, title: str, visible_tasks_limit: int) -> None:
         self.title = title
-        self.overflow = Progress("[progress.description]{task.description}")
-        self.queue = Progress("[progress.description]{task.description}")
-        self.progress_group = Group(self.progress, self.overflow, self.queue)
+        self._overflow = Progress("[progress.description]{task.description}")
+        self._queue = Progress("[progress.description]{task.description}")
+        self._progress_group = Group(self._progress, self._overflow, self._queue)
 
-        self.overflow_task_id = self.overflow.add_task(
+        self._overflow_task_id = self._overflow.add_task(
             self.overflow_str.format(color=self.color, number=0, type_str=self.type_str),
             visible=False,
         )
-        self.queue_task_id = self.queue.add_task(
+        self._queue_task_id = self._queue.add_task(
             self.queue_str.format(color=self.color, number=0, type_str=self.type_str, title=self.title),
             visible=False,
         )
-        self.tasks: deque[TaskID] = deque([])
+        self._tasks: deque[TaskID] = deque([])
         self._tasks_visibility_limit = visible_tasks_limit
 
     @abstractmethod
@@ -48,56 +48,56 @@ class DequeProgress(ABC):
 
     @property
     def visible_tasks(self) -> Sequence[TaskID]:
-        if len(self.tasks) > self._tasks_visibility_limit:
-            return [self.tasks[i] for i in range(self._tasks_visibility_limit)]
-        return self.tasks
+        if len(self._tasks) > self._tasks_visibility_limit:
+            return [self._tasks[i] for i in range(self._tasks_visibility_limit)]
+        return self._tasks
 
     @property
     def invisible_tasks(self) -> Sequence[TaskID]:
-        return list(islice(self.tasks, self._tasks_visibility_limit, None))
+        return list(islice(self._tasks, self._tasks_visibility_limit, None))
 
     @property
     def invisible_tasks_len(self) -> int:
         """Faster to compute than `len(self.invisible_tasks)`"""
-        return max(0, len(self.tasks) - self._tasks_visibility_limit)
+        return max(0, len(self._tasks) - self._tasks_visibility_limit)
 
     def has_visible_capacity(self) -> bool:
-        return len(self.tasks) < self._tasks_visibility_limit
+        return len(self._tasks) < self._tasks_visibility_limit
 
-    def get_progress(self) -> Panel:
+    def get_renderable(self) -> Panel:
         """Returns the progress bar."""
-        return Panel(self.progress_group, title=self.title, border_style="green", padding=(1, 1))
+        return Panel(self._progress_group, title=self.title, border_style="green", padding=(1, 1))
 
     def add_task(self, description: str, total: float | None = None) -> TaskID:
         """Adds a new task to the progress bar."""
-        task_id = self.progress.add_task(
+        task_id = self._progress.add_task(
             self.progress_str.format(color=self.color, description=description),
             total=total,
             visible=self.has_visible_capacity(),
         )
-        self.tasks.append(task_id)
+        self._tasks.append(task_id)
         self.redraw()
         return task_id
 
     def remove_task(self, task_id: TaskID) -> None:
         """Removes a task from the progress bar."""
-        if task_id not in self.tasks:
+        if task_id not in self._tasks:
             msg = "Task ID not found"
             raise ValueError(msg)
 
-        self.tasks.remove(task_id)
-        self.progress.remove_task(task_id)
+        self._tasks.remove(task_id)
+        self._progress.remove_task(task_id)
         self.redraw()
 
     def redraw(self) -> None:
         """Redraws the progress bar."""
         for task in self.visible_tasks:
-            self.progress.update(task, visible=True)
+            self._progress.update(task, visible=True)
 
         invisible_tasks_len = self.invisible_tasks_len
 
-        self.overflow.update(
-            self.overflow_task_id,
+        self._overflow.update(
+            self._overflow_task_id,
             description=self.overflow_str.format(
                 color=self.color,
                 number=invisible_tasks_len,
@@ -108,8 +108,8 @@ class DequeProgress(ABC):
 
         queue_length = self.get_queue_length()
 
-        self.queue.update(
-            self.queue_task_id,
+        self._queue.update(
+            self._queue_task_id,
             description=self.queue_str.format(
                 color=self.color, number=queue_length, type_str=self.type_str, title=self.title
             ),

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -31,7 +31,7 @@ class DequeProgress(ABC):
             visible=False,
         )
         self.queue_task_id = self.queue.add_task(
-            self.queue_str.format(color=self.color, number=0, type_str=self.type_str),
+            self.queue_str.format(color=self.color, number=0, type_str=self.type_str, title=self.title),
             visible=False,
         )
         self.tasks: deque[TaskID] = deque([])
@@ -68,7 +68,9 @@ class DequeProgress(ABC):
 
         self.queue.update(
             self.queue_task_id,
-            description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
+            description=self.queue_str.format(
+                color=self.color, number=queue_length, type_str=self.type_str, title=self.title
+            ),
             visible=queue_length > 0,
         )
 

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -53,7 +53,7 @@ class DequeProgress(ABC):
     @abstractmethod
     def get_queue_length(self) -> int: ...
 
-    def redraw(self, passed: bool = False) -> None:
+    def redraw(self) -> None:
         """Redraws the progress bar."""
         for task in self.visible_tasks:
             self.progress.update(task, visible=True)

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -40,11 +40,17 @@ class DequeProgress(ABC):
 
     @property
     def visible_tasks(self) -> list[TaskID]:
-        return list(islice(self.tasks, 0, self._tasks_visibility_limit))
+        if len(self.tasks) > self._tasks_visibility_limit:
+            return [self.tasks[i] for i in range(self._tasks_visibility_limit)]
+        return list(self.tasks)
 
     @property
     def invisible_tasks(self) -> list[TaskID]:
         return list(islice(self.tasks, self._tasks_visibility_limit, None))
+
+    @property
+    def invisible_tasks_len(self) -> int:
+        return max(0, len(self.tasks) - self._tasks_visibility_limit)
 
     def get_progress(self) -> Panel:
         """Returns the progress bar."""
@@ -62,10 +68,10 @@ class DequeProgress(ABC):
             self.overflow_task_id,
             description=self.overflow_str.format(
                 color=self.color,
-                number=len(self.invisible_tasks),
+                number=self.invisible_tasks_len,
                 type_str=self.type_str,
             ),
-            visible=len(self.invisible_tasks) > 0,
+            visible=self.invisible_tasks_len > 0,
         )
 
         queue_length = self.get_queue_length()

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections import deque
+from typing import TYPE_CHECKING
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.progress import Progress, TaskID
+
+if TYPE_CHECKING:
+    from cyberdrop_dl.managers.manager import Manager
+
+
+class DequeProgress(ABC):
+    progress: Progress
+    title: str
+    type_str: str = "Files"
+
+    def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
+        self.manager = manager
+        self.overflow = Progress("[progress.description]{task.description}")
+        self.queue = Progress("[progress.description]{task.description}")
+        self.progress_group = Group(self.progress, self.overflow, self.queue)
+        self.color = "plum3"
+        self.progress_str = "[{color}]{description}"
+        self.overflow_str = "[{color}]... And {number} Other {type_str}"
+        self.queue_str = "[{color}]... And {number} {type_str} In {title} Queue"
+        self.overflow_task_id = self.overflow.add_task(
+            self.overflow_str.format(color=self.color, number=0, type_str=self.type_str),
+            visible=False,
+        )
+        self.queue_task_id = self.queue.add_task(
+            self.queue_str.format(color=self.color, number=0, type_str=self.type_str),
+            visible=False,
+        )
+        self.tasks: deque[TaskID] = deque([])
+        self._tasks_visibility_limit = visible_tasks_limit
+
+    @property
+    def visible_tasks(self) -> list[TaskID]:
+        return self.tasks[: self._tasks_visibility_limit]
+
+    @property
+    def invisible_tasks(self) -> list[TaskID]:
+        return self.tasks[-self._tasks_visibility_limit :]
+
+    def get_progress(self) -> Panel:
+        """Returns the progress bar."""
+        return Panel(self.progress_group, title=self.title, border_style="green", padding=(1, 1))
+
+    @abstractmethod
+    def get_queue_length(self) -> int: ...
+
+    def redraw(self, passed: bool = False) -> None:
+        """Redraws the progress bar."""
+        self.overflow.update(
+            self.overflow_task_id,
+            description=self.overflow_str.format(
+                color=self.color,
+                number=len(self.invisible_tasks),
+                type_str=self.type_str,
+            ),
+            visible=len(self.invisible_tasks) > 0,
+        )
+
+        queue_length = self.get_queue_length()
+
+        self.queue.update(
+            self.queue_task_id,
+            description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
+            visible=queue_length > 0,
+        )
+
+    def add_task(self, description: str, total: float | None = None) -> TaskID:
+        """Adds a new task to the progress bar."""
+        task_id = self.progress.add_task(
+            self.progress_str.format(color=self.color, description=description),
+            total=total,
+            visible=len(self.visible_tasks) >= self._tasks_visibility_limit,
+        )
+        self.tasks.append(task_id)
+        self.redraw()
+        return task_id
+
+    def remove_task(self, task_id: TaskID) -> None:
+        """Removes a task from the progress bar."""
+        old_visible_taks = set(self.visible_tasks)
+        if task_id not in self.tasks:
+            msg = "Task ID not found"
+            raise ValueError(msg)
+
+        self.tasks.remove(task_id)
+        self.progress.remove_task(task_id)
+        new_visible_taks = old_visible_taks - set(self.visible_tasks)
+        for task in new_visible_taks:
+            self.progress.update(task, visible=True)
+        self.redraw()

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -13,6 +13,11 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
+    """Collapse and truncate or pad the given string to fit in the given length."""
+    return f"{s[:length - len(placeholder)]}{placeholder}" if len(s) >= length else s.ljust(length)
+
+
 class DequeProgress(ABC):
     progress: Progress
     type_str: str = "Files"

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -15,14 +15,14 @@ if TYPE_CHECKING:
 
 class DequeProgress(ABC):
     progress: Progress
-    title: str
     type_str: str = "Files"
     color = "plum3"
     progress_str = "[{color}]{description}"
     overflow_str = "[{color}]... And {number} Other {type_str}"
     queue_str = "[{color}]... And {number} {type_str} In {title} Queue"
 
-    def __init__(self, visible_tasks_limit: int) -> None:
+    def __init__(self, title: str, visible_tasks_limit: int) -> None:
+        self.title = title
         self.overflow = Progress("[progress.description]{task.description}")
         self.queue = Progress("[progress.description]{task.description}")
         self.progress_group = Group(self.progress, self.overflow, self.queue)

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -12,16 +12,13 @@ from rich.progress import Progress, TaskID
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from cyberdrop_dl.managers.manager import Manager
-
 
 class DequeProgress(ABC):
     progress: Progress
     title: str
     type_str: str = "Files"
 
-    def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
-        self.manager = manager
+    def __init__(self, visible_tasks_limit: int) -> None:
         self.overflow = Progress("[progress.description]{task.description}")
         self.queue = Progress("[progress.description]{task.description}")
         self.progress_group = Group(self.progress, self.overflow, self.queue)

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from collections import deque
 from typing import TYPE_CHECKING
 
 from pydantic import ByteSize
-from rich.console import Group
 from rich.markup import escape
-from rich.panel import Panel
 from rich.progress import (
     BarColumn,
     DownloadColumn,
@@ -17,6 +14,8 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
+from cyberdrop_dl.ui.progress.deque_progress import DequeProgress
+
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
@@ -26,12 +25,10 @@ def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
     return f"{s[:length - len(placeholder)]}{placeholder}" if len(s) >= length else s.ljust(length)
 
 
-class FileProgress:
+class FileProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
-        self.manager = manager
-
         self.progress = Progress(
             SpinnerColumn(),
             "[progress.description]{task.description}",
@@ -44,39 +41,8 @@ class FileProgress:
             "━",
             TimeRemainingColumn(),
         )
-        self.overflow = Progress("[progress.description]{task.description}")
-        self.queue = Progress("[progress.description]{task.description}")
-        self.progress_group = Group(self.progress, self.overflow, self.queue)
-
-        self.color = "plum3"
-        self.type_str = "Files"
-        self.progress_str = "[{color}]{description}"
-        self.overflow_str = "[{color}]... And {number} Other {type_str}"
-        self.queue_str = "[{color}]... And {number} {type_str} In Download Queue"
-        self.overflow_task_id = self.overflow.add_task(
-            self.overflow_str.format(color=self.color, number=0, type_str=self.type_str),
-            visible=False,
-        )
-        self.queue_task_id = self.queue.add_task(
-            self.queue_str.format(color=self.color, number=0, type_str=self.type_str),
-            visible=False,
-        )
-
-        self.tasks = deque[TaskID] = deque([])
-        self._tasks_visibility_limit = visible_tasks_limit
+        self.title = "Downloads"
         self.downloaded_data = ByteSize(0)
-
-    @property
-    def visible_tasks(self) -> list[TaskID]:
-        return self.tasks[: self._tasks_visibility_limit]
-
-    @property
-    def invisible_tasks(self) -> list[TaskID]:
-        return self.tasks[-self._tasks_visibility_limit :]
-
-    def get_progress(self) -> Panel:
-        """Returns the progress bar."""
-        return Panel(self.progress_group, title="Downloads", border_style="green", padding=(1, 1))
 
     def get_queue_length(self) -> int:
         """Returns the number of tasks in the downloader queue."""
@@ -91,54 +57,12 @@ class FileProgress:
 
         return total
 
-    def redraw(self) -> None:
-        """Redraws the progress bar."""
-        self.overflow.update(
-            self.overflow_task_id,
-            description=self.overflow_str.format(
-                color=self.color,
-                number=len(self.invisible_tasks),
-                type_str=self.type_str,
-            ),
-            visible=len(self.invisible_tasks) > 0,
-        )
-
-        queue_length = self.get_queue_length()
-
-        self.queue.update(
-            self.queue_task_id,
-            description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
-            visible=queue_length > 0,
-        )
-
     def add_task(self, *, domain: str, filename: str, expected_size: int | None = None) -> TaskID:
         """Adds a new task to the progress bar."""
         filename = filename.split("/")[-1].encode("ascii", "ignore").decode().strip()
         filename = escape(adjust_title(filename))
         description = f"({domain.upper()}) {filename}"
-        show_task = len(self.visible_tasks) < self._tasks_visibility_limit
-        task_id = self.progress.add_task(
-            self.progress_str.format(color=self.color, description=description),
-            total=expected_size,
-            visible=show_task,
-        )
-        self.tasks.append(task_id)
-        self.redraw()
-        return task_id
-
-    def remove_task(self, task_id: TaskID) -> None:
-        """Removes the given task from the progress bar."""
-        old_visible_taks = set(self.visible_tasks)
-        if task_id not in self.tasks:
-            msg = "Task ID not found"
-            raise ValueError(msg)
-
-        self.tasks.remove(task_id)
-        self.progress.remove_task(task_id)
-        new_visible_taks = old_visible_taks - set(self.visible_tasks)
-        for task in new_visible_taks:
-            self.progress.update(task, visible=True)
-        self.redraw()
+        return super().add_task(description, expected_size)
 
     def advance_file(self, task_id: TaskID, amount: int) -> None:
         """Advances the progress of the given task by the given amount."""

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -43,6 +43,7 @@ class FileProgress(DequeProgress):
         )
         self.title = "Downloads"
         self.downloaded_data = ByteSize(0)
+        super().__init__(visible_tasks_limit, manager)
 
     def get_queue_length(self) -> int:
         """Returns the number of tasks in the downloader queue."""

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -25,7 +25,7 @@ class FileProgress(DequeProgress):
 
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
         self.manager = manager
-        self.progress = Progress(
+        self._progress = Progress(
             SpinnerColumn(),
             "[progress.description]{task.description}",
             BarColumn(bar_width=None),
@@ -63,4 +63,4 @@ class FileProgress(DequeProgress):
     def advance_file(self, task_id: TaskID, amount: int) -> None:
         """Advances the progress of the given task by the given amount."""
         self.downloaded_data += amount
-        self.progress.advance(task_id, amount)
+        self._progress.advance(task_id, amount)

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -14,15 +14,10 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
-from cyberdrop_dl.ui.progress.deque_progress import DequeProgress
+from cyberdrop_dl.ui.progress.deque_progress import DequeProgress, adjust_title
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
-
-
-def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
-    """Collapse and truncate or pad the given string to fit in the given length."""
-    return f"{s[:length - len(placeholder)]}{placeholder}" if len(s) >= length else s.ljust(length)
 
 
 class FileProgress(DequeProgress):

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -28,6 +28,8 @@ def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
 class FileProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 
+    title = "Downloads"
+
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
         self.manager = manager
         self.progress = Progress(
@@ -42,7 +44,6 @@ class FileProgress(DequeProgress):
             "━",
             TimeRemainingColumn(),
         )
-        self.title = "Downloads"
         self.downloaded_data = ByteSize(0)
         super().__init__(visible_tasks_limit)
 

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -29,6 +29,7 @@ class FileProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
+        self.manager = manager
         self.progress = Progress(
             SpinnerColumn(),
             "[progress.description]{task.description}",
@@ -43,7 +44,7 @@ class FileProgress(DequeProgress):
         )
         self.title = "Downloads"
         self.downloaded_data = ByteSize(0)
-        super().__init__(visible_tasks_limit, manager)
+        super().__init__(visible_tasks_limit)
 
     def get_queue_length(self) -> int:
         """Returns the number of tasks in the downloader queue."""

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import deque
 from typing import TYPE_CHECKING
 
 from pydantic import ByteSize
@@ -61,18 +62,23 @@ class FileProgress:
             visible=False,
         )
 
-        self.visible_tasks: list[TaskID] = []
-        self.invisible_tasks: list[TaskID] = []
-        self.completed_tasks: list[TaskID] = []
-        self.uninitiated_tasks: list[TaskID] = []
-        self.tasks_visibility_limit = visible_tasks_limit
+        self.tasks = deque[TaskID] = deque([])
+        self._tasks_visibility_limit = visible_tasks_limit
         self.downloaded_data = ByteSize(0)
+
+    @property
+    def visible_tasks(self) -> list[TaskID]:
+        return self.tasks[: self._tasks_visibility_limit]
+
+    @property
+    def invisible_tasks(self) -> list[TaskID]:
+        return self.tasks[-self._tasks_visibility_limit :]
 
     def get_progress(self) -> Panel:
         """Returns the progress bar."""
         return Panel(self.progress_group, title="Downloads", border_style="green", padding=(1, 1))
 
-    def get_download_queue_length(self) -> int:
+    def get_queue_length(self) -> int:
         """Returns the number of tasks in the downloader queue."""
         total = 0
         unique_crawler_ids = set()
@@ -85,81 +91,56 @@ class FileProgress:
 
         return total
 
-    def redraw(self, passed: bool = False) -> None:
+    def redraw(self) -> None:
         """Redraws the progress bar."""
-        while len(self.visible_tasks) > self.tasks_visibility_limit:
-            task_id = self.visible_tasks.pop(0)
-            self.invisible_tasks.append(task_id)
-            self.progress.update(task_id, visible=False)
-        while len(self.invisible_tasks) > 0 and len(self.visible_tasks) < self.tasks_visibility_limit:
-            task_id = self.invisible_tasks.pop(0)
-            self.visible_tasks.append(task_id)
-            self.progress.update(task_id, visible=True)
+        self.overflow.update(
+            self.overflow_task_id,
+            description=self.overflow_str.format(
+                color=self.color,
+                number=len(self.invisible_tasks),
+                type_str=self.type_str,
+            ),
+            visible=len(self.invisible_tasks) > 0,
+        )
 
-        if len(self.invisible_tasks) > 0:
-            self.overflow.update(
-                self.overflow_task_id,
-                description=self.overflow_str.format(
-                    color=self.color,
-                    number=len(self.invisible_tasks),
-                    type_str=self.type_str,
-                ),
-                visible=True,
-            )
-        else:
-            self.overflow.update(self.overflow_task_id, visible=False)
+        queue_length = self.get_queue_length()
 
-        queue_length = self.get_download_queue_length()
-        if queue_length > 0:
-            self.queue.update(
-                self.queue_task_id,
-                description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
-                visible=True,
-            )
-        else:
-            self.queue.update(self.queue_task_id, visible=False)
-
-        if not passed:
-            self.manager.progress_manager.scraping_progress.redraw(True)
+        self.queue.update(
+            self.queue_task_id,
+            description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
+            visible=queue_length > 0,
+        )
 
     def add_task(self, *, domain: str, filename: str, expected_size: int | None = None) -> TaskID:
         """Adds a new task to the progress bar."""
         filename = filename.split("/")[-1].encode("ascii", "ignore").decode().strip()
         filename = escape(adjust_title(filename))
         description = f"({domain.upper()}) {filename}"
-        show_task = len(self.visible_tasks) < self.tasks_visibility_limit
+        show_task = len(self.visible_tasks) < self._tasks_visibility_limit
         task_id = self.progress.add_task(
             self.progress_str.format(color=self.color, description=description),
             total=expected_size,
             visible=show_task,
         )
-
-        if show_task:
-            self.visible_tasks.append(task_id)
-        else:
-            self.invisible_tasks.append(task_id)
+        self.tasks.append(task_id)
         self.redraw()
         return task_id
 
-    def remove_file(self, task_id: TaskID) -> None:
+    def remove_task(self, task_id: TaskID) -> None:
         """Removes the given task from the progress bar."""
-        if task_id in self.visible_tasks:
-            self.visible_tasks.remove(task_id)
-            self.progress.update(task_id, visible=False)
-        elif task_id in self.invisible_tasks:
-            self.invisible_tasks.remove(task_id)
-        elif task_id == self.overflow_task_id:
-            self.overflow.update(task_id, visible=False)
-        else:
+        old_visible_taks = set(self.visible_tasks)
+        if task_id not in self.tasks:
             msg = "Task ID not found"
             raise ValueError(msg)
+
+        self.tasks.remove(task_id)
+        self.progress.remove_task(task_id)
+        new_visible_taks = old_visible_taks - set(self.visible_tasks)
+        for task in new_visible_taks:
+            self.progress.update(task, visible=True)
         self.redraw()
 
     def advance_file(self, task_id: TaskID, amount: int) -> None:
         """Advances the progress of the given task by the given amount."""
         self.downloaded_data += amount
-        if task_id in self.uninitiated_tasks:
-            self.uninitiated_tasks.remove(task_id)
-            self.invisible_tasks.append(task_id)
-            self.redraw()
         self.progress.advance(task_id, amount)

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -28,8 +28,6 @@ def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
 class FileProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 
-    title = "Downloads"
-
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
         self.manager = manager
         self.progress = Progress(
@@ -45,7 +43,7 @@ class FileProgress(DequeProgress):
             TimeRemainingColumn(),
         )
         self.downloaded_data = ByteSize(0)
-        super().__init__(visible_tasks_limit)
+        super().__init__("Downloads", visible_tasks_limit)
 
     def get_queue_length(self) -> int:
         """Returns the number of tasks in the downloader queue."""

--- a/cyberdrop_dl/ui/progress/hash_progress.py
+++ b/cyberdrop_dl/ui/progress/hash_progress.py
@@ -18,27 +18,13 @@ class HashProgress:
 
     def __init__(self, manager: Manager) -> None:
         self.manager = manager
-        self.hash_progress = Progress(
-            "[progress.description]{task.description}",
-            BarColumn(bar_width=None),
-            "{task.completed}",
-        )
-        self.remove_progress = Progress(
-            "[progress.description]{task.description}",
-            BarColumn(bar_width=None),
-            "{task.completed}",
-        )
-        self.match_progress = Progress(
-            "[progress.description]{task.description}",
-            BarColumn(bar_width=None),
-            "{task.completed}",
-        )
-
+        self.hash_progress = self.create_generic_progress()
+        self.remove_progress = self.create_generic_progress()
+        self.match_progress = self.create_generic_progress()
         self.current_hashing_text = Progress("{task.description}")
 
         # hashing
-        self.hashed_files = 0
-        self.prev_hashed_files = 0
+        self.hashed_files = self.prev_hashed_files = 0
         self.hash_progress_group = Group(self.current_hashing_text, self.hash_progress)
         self.hashed_files_task_id = self.hash_progress.add_task("[green]Hashed", total=None)
         self.prev_hashed_files_task_id = self.hash_progress.add_task("[green]Previously Hashed", total=None)
@@ -53,7 +39,10 @@ class HashProgress:
             total=None,
         )
 
-    def get_hash_progress(self) -> Panel:
+    def create_generic_progress(self) -> Progress:
+        return Progress("[progress.description]{task.description}", BarColumn(bar_width=None), "{task.completed}")
+
+    def get_renderable(self) -> Panel:
         """Returns the progress bar."""
         return Panel(
             self.hash_progress_group,

--- a/cyberdrop_dl/ui/progress/scraping_progress.py
+++ b/cyberdrop_dl/ui/progress/scraping_progress.py
@@ -16,10 +16,11 @@ class ScrapingProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
+        self.manager = manager
         self.progress = Progress(SpinnerColumn(), "[progress.description]{task.description}")
         self.title = "Scraping"
         self.type_str = "URLs"
-        super().__init__(visible_tasks_limit, manager)
+        super().__init__(visible_tasks_limit)
 
     def get_queue_length(self) -> int:
         """Returns the number of tasks in the scraper queue."""

--- a/cyberdrop_dl/ui/progress/scraping_progress.py
+++ b/cyberdrop_dl/ui/progress/scraping_progress.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from collections import deque
 from typing import TYPE_CHECKING
 
-from rich.console import Group
-from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TaskID
+
+from cyberdrop_dl.ui.progress.deque_progress import DequeProgress
 
 if TYPE_CHECKING:
     from yarl import URL
@@ -19,97 +17,13 @@ def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
     return f"{s[:length - len(placeholder)]}{placeholder}" if len(s) >= length else s.ljust(length)
 
 
-class DequeProgress(ABC):
-    progress: Progress
-
-    def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
-        self.manager = manager
-        self.overflow = Progress("[progress.description]{task.description}")
-        self.queue = Progress("[progress.description]{task.description}")
-        self.progress_group = Group(self.progress, self.overflow, self.queue)
-        self.color = "plum3"
-        self.type_str = "Files"
-        self.progress_str = "[{color}]{description}"
-        self.overflow_str = "[{color}]... And {number} Other {type_str}"
-        self.queue_str = "[{color}]... And {number} {type_str} In {title} Queue"
-        self.overflow_task_id = self.overflow.add_task(
-            self.overflow_str.format(color=self.color, number=0, type_str=self.type_str),
-            visible=False,
-        )
-        self.queue_task_id = self.queue.add_task(
-            self.queue_str.format(color=self.color, number=0, type_str=self.type_str),
-            visible=False,
-        )
-        self.tasks: deque[TaskID] = deque([])
-        self._tasks_visibility_limit = visible_tasks_limit
-
-    @property
-    def visible_tasks(self) -> list[TaskID]:
-        return self.tasks[: self._tasks_visibility_limit]
-
-    @property
-    def invisible_tasks(self) -> list[TaskID]:
-        return self.tasks[-self._tasks_visibility_limit :]
-
-    def get_progress(self) -> Panel:
-        """Returns the progress bar."""
-        return Panel(self.progress_group, title=self.title, border_style="green", padding=(1, 1))
-
-    @abstractmethod
-    def get_queue_length(self) -> int: ...
-
-    def redraw(self, passed: bool = False) -> None:
-        """Redraws the progress bar."""
-        self.overflow.update(
-            self.overflow_task_id,
-            description=self.overflow_str.format(
-                color=self.color,
-                number=len(self.invisible_tasks),
-                type_str=self.type_str,
-            ),
-            visible=len(self.invisible_tasks) > 0,
-        )
-
-        queue_length = self.get_queue_length()
-
-        self.queue.update(
-            self.queue_task_id,
-            description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
-            visible=queue_length > 0,
-        )
-
-    def add_task(self, description: str, total: float | None = None) -> TaskID:
-        """Adds a new task to the progress bar."""
-        task_id = self.progress.add_task(
-            self.progress_str.format(color=self.color, description=description),
-            total=total,
-            visible=len(self.visible_tasks) >= self._tasks_visibility_limit,
-        )
-        self.tasks.append(task_id)
-        self.redraw()
-        return task_id
-
-    def remove_task(self, task_id: TaskID) -> None:
-        """Removes a task from the progress bar."""
-        old_visible_taks = set(self.visible_tasks)
-        if task_id not in self.tasks:
-            msg = "Task ID not found"
-            raise ValueError(msg)
-
-        self.tasks.remove(task_id)
-        self.progress.remove_task(task_id)
-        new_visible_taks = old_visible_taks - set(self.visible_tasks)
-        for task in new_visible_taks:
-            self.progress.update(task, visible=True)
-        self.redraw()
-
-
 class ScrapingProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
         self.progress = Progress(SpinnerColumn(), "[progress.description]{task.description}")
         self.title = "Scraping"
+        self.type_str = "URLs"
         super().__init__(visible_tasks_limit, manager)
 
     def get_queue_length(self) -> int:

--- a/cyberdrop_dl/ui/progress/scraping_progress.py
+++ b/cyberdrop_dl/ui/progress/scraping_progress.py
@@ -37,7 +37,7 @@ class ScrapingProgress(DequeProgress):
     def redraw(self, passed: bool = False) -> None:
         super().redraw()
         if not passed:
-            self.manager.progress_manager.file_progress.redraw(True)
+            self.manager.progress_manager.file_progress.redraw()
 
     def add_task(self, url: URL) -> TaskID:
         """Adds a new task to the progress bar."""

--- a/cyberdrop_dl/ui/progress/scraping_progress.py
+++ b/cyberdrop_dl/ui/progress/scraping_progress.py
@@ -15,11 +15,12 @@ if TYPE_CHECKING:
 class ScrapingProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 
+    title = "Scraping"
+    type_str = "URLs"
+
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
         self.manager = manager
         self.progress = Progress(SpinnerColumn(), "[progress.description]{task.description}")
-        self.title = "Scraping"
-        self.type_str = "URLs"
         super().__init__(visible_tasks_limit)
 
     def get_queue_length(self) -> int:

--- a/cyberdrop_dl/ui/progress/scraping_progress.py
+++ b/cyberdrop_dl/ui/progress/scraping_progress.py
@@ -19,7 +19,7 @@ class ScrapingProgress(DequeProgress):
 
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
         self.manager = manager
-        self.progress = Progress(SpinnerColumn(), "[progress.description]{task.description}")
+        self._progress = Progress(SpinnerColumn(), "[progress.description]{task.description}")
         super().__init__("Scraping", visible_tasks_limit)
 
     def get_queue_length(self) -> int:

--- a/cyberdrop_dl/ui/progress/scraping_progress.py
+++ b/cyberdrop_dl/ui/progress/scraping_progress.py
@@ -15,13 +15,12 @@ if TYPE_CHECKING:
 class ScrapingProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 
-    title = "Scraping"
     type_str = "URLs"
 
     def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
         self.manager = manager
         self.progress = Progress(SpinnerColumn(), "[progress.description]{task.description}")
-        super().__init__(visible_tasks_limit)
+        super().__init__("Scraping", visible_tasks_limit)
 
     def get_queue_length(self) -> int:
         """Returns the number of tasks in the scraper queue."""

--- a/cyberdrop_dl/ui/progress/scraping_progress.py
+++ b/cyberdrop_dl/ui/progress/scraping_progress.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import deque
 from typing import TYPE_CHECKING
 
 from rich.console import Group
@@ -42,9 +43,16 @@ class ScrapingProgress:
             visible=False,
         )
 
-        self.visible_tasks: list[TaskID] = []
-        self.invisible_tasks: list[TaskID] = []
-        self.tasks_visibility_limit = visible_tasks_limit
+        self.tasks: deque[TaskID] = deque([])
+        self._tasks_visibility_limit = visible_tasks_limit
+
+    @property
+    def visible_tasks(self) -> list[TaskID]:
+        return self.tasks[: self._tasks_visibility_limit]
+
+    @property
+    def invisible_tasks(self) -> list[TaskID]:
+        return self.tasks[-self._tasks_visibility_limit :]
 
     def get_progress(self) -> Panel:
         """Returns the progress bar."""
@@ -65,65 +73,47 @@ class ScrapingProgress:
 
     def redraw(self, passed: bool = False) -> None:
         """Redraws the progress bar."""
-        while len(self.visible_tasks) > self.tasks_visibility_limit:
-            task_id = self.visible_tasks.pop(0)
-            self.invisible_tasks.append(task_id)
-            self.progress.update(task_id, visible=False)
-        while len(self.invisible_tasks) > 0 and len(self.visible_tasks) < self.tasks_visibility_limit:
-            task_id = self.invisible_tasks.pop(0)
-            self.visible_tasks.append(task_id)
-            self.progress.update(task_id, visible=True)
-
-        if len(self.invisible_tasks) > 0:
-            self.overflow.update(
-                self.overflow_task_id,
-                description=self.overflow_str.format(
-                    color=self.color,
-                    number=len(self.invisible_tasks),
-                    type_str=self.type_str,
-                ),
-                visible=True,
-            )
-        else:
-            self.overflow.update(self.overflow_task_id, visible=False)
+        self.overflow.update(
+            self.overflow_task_id,
+            description=self.overflow_str.format(
+                color=self.color,
+                number=len(self.invisible_tasks),
+                type_str=self.type_str,
+            ),
+            visible=len(self.invisible_tasks) > 0,
+        )
 
         queue_length = self.get_queue_length()
-        if queue_length > 0:
-            self.queue.update(
-                self.queue_task_id,
-                description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
-                visible=True,
-            )
-        else:
-            self.queue.update(self.queue_task_id, visible=False)
+
+        self.queue.update(
+            self.queue_task_id,
+            description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
+            visible=queue_length > 0,
+        )
 
         if not passed:
             self.manager.progress_manager.file_progress.redraw(True)
 
     def add_task(self, url: URL) -> TaskID:
         """Adds a new task to the progress bar."""
-        if len(self.visible_tasks) >= self.tasks_visibility_limit:
-            task_id = self.progress.add_task(
-                self.progress_str.format(color=self.color, description=str(url)),
-                visible=False,
-            )
-            self.invisible_tasks.append(task_id)
-        else:
-            task_id = self.progress.add_task(self.progress_str.format(color=self.color, description=str(url)))
-            self.visible_tasks.append(task_id)
+        task_id = self.progress.add_task(
+            self.progress_str.format(color=self.color, description=str(url)),
+            visible=len(self.visible_tasks) >= self._tasks_visibility_limit,
+        )
+        self.tasks.append(task_id)
         self.redraw()
         return task_id
 
     def remove_task(self, task_id: TaskID) -> None:
         """Removes a task from the progress bar."""
-        if task_id in self.visible_tasks:
-            self.visible_tasks.remove(task_id)
-            self.progress.update(task_id, visible=False)
-        elif task_id in self.invisible_tasks:
-            self.invisible_tasks.remove(task_id)
-        elif task_id == self.overflow_task_id:
-            self.overflow.update(task_id, visible=False)
-        else:
+        old_visible_taks = set(self.visible_tasks)
+        if task_id not in self.tasks:
             msg = "Task ID not found"
             raise ValueError(msg)
+
+        self.tasks.remove(task_id)
+        self.progress.remove_task(task_id)
+        new_visible_taks = old_visible_taks - set(self.visible_tasks)
+        for task in new_visible_taks:
+            self.progress.update(task, visible=True)
         self.redraw()

--- a/cyberdrop_dl/ui/progress/scraping_progress.py
+++ b/cyberdrop_dl/ui/progress/scraping_progress.py
@@ -12,11 +12,6 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
-def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
-    """Collapse and truncate or pad the given string to fit in the given length."""
-    return f"{s[:length - len(placeholder)]}{placeholder}" if len(s) >= length else s.ljust(length)
-
-
 class ScrapingProgress(DequeProgress):
     """Class that manages the download progress of individual files."""
 

--- a/cyberdrop_dl/ui/progress/sort_progress.py
+++ b/cyberdrop_dl/ui/progress/sort_progress.py
@@ -22,7 +22,7 @@ class SortProgress(DequeProgress):
 
         Should work similar to the file_progress but for folders, with a percentage and progress bar for the files within the folders"""
         self.manager = manager
-        self.progress = Progress(
+        self._progress = Progress(
             SpinnerColumn(),
             "[progress.description]{task.description}",
             BarColumn(bar_width=None),
@@ -38,10 +38,10 @@ class SortProgress(DequeProgress):
     def get_queue_length(self) -> int:
         return self.queue_length
 
-    def get_progress(self) -> Panel:
+    def get_renderable(self) -> Panel:
         """Returns the progress bar."""
         return Panel(
-            self.progress_group,
+            self._progress_group,
             title=f"Sorting Downloads ━ Config: {self.manager.config_manager.loaded_config}",
             border_style="green",
             padding=(1, 1),
@@ -59,7 +59,7 @@ class SortProgress(DequeProgress):
 
     def advance_folder(self, task_id: TaskID, amount: int = 1) -> None:
         """Advances the progress of the given task by the given amount."""
-        self.progress.advance(task_id, amount)
+        self._progress.advance(task_id, amount)
 
     def increment_audio(self) -> None:
         self.audio_count += 1

--- a/cyberdrop_dl/ui/progress/sort_progress.py
+++ b/cyberdrop_dl/ui/progress/sort_progress.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from rich.console import Group
+from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskID
+
+from cyberdrop_dl.ui.progress.deque_progress import DequeProgress
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -15,12 +17,16 @@ def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
     return f"{s[:length - len(placeholder)]}{placeholder}" if len(s) >= length else s.ljust(length)
 
 
-class SortProgress:
+class SortProgress(DequeProgress):
     """Class that keeps track of sorted files."""
 
-    def __init__(self, visible_task_limit: int, manager: Manager) -> None:
+    type_str = "Folders"
+
+    def __init__(self, visible_tasks_limit: int, manager: Manager) -> None:
+        """Sorter to track the progress of folders being sorted.
+
+        Should work similar to the file_progress but for folders, with a percentage and progress bar for the files within the folders"""
         self.manager = manager
-        # Sorter to track the progress of folders being sorted, should work similar to the file_progress but for folders, with a percentage and progress bar for the files within the folders
         self.progress = Progress(
             SpinnerColumn(),
             "[progress.description]{task.description}",
@@ -29,127 +35,35 @@ class SortProgress:
             "━",
             "{task.completed}/{task.total} files",
         )
-        self.overflow = Progress("[progress.description]{task.description}")
-        self.queue = Progress("[progress.description]{task.description}")
-        self.progress_group = Group(self.progress, self.overflow, self.queue)
+        super().__init__("Sort", visible_tasks_limit)
 
-        self.color = "plum3"
-        self.type_str = "Folders"
-        self.progress_str = "[{color}]{description}"
-        self.overflow_str = "[{color}]... And {number} Other Folders"
-        self.queue_length = 0
-        self.queue_str = "[{color}]... And {number} Folders In Sort Queue"
-        self.overflow_task_id = self.overflow.add_task(
-            self.overflow_str.format(color=self.color, number=0, type_str=self.type_str),
-            visible=False,
-        )
-        self.queue_task_id = self.queue.add_task(
-            self.queue_str.format(color=self.color, number=0, type_str=self.type_str),
-            visible=False,
-        )
+        # counts
+        self.queue_length = self.audio_count = self.video_count = self.image_count = self.other_count = 0
 
-        self.visible_tasks: list[TaskID] = []
-        self.invisible_tasks: list[TaskID] = []
-        self.completed_tasks: list[TaskID] = []
-        self.uninitiated_tasks: list[TaskID] = []
-        self.tasks_visibility_limit = visible_task_limit
-        self.panel = Panel(
+    def get_queue_length(self) -> int:
+        return self.queue_length
+
+    def get_progress(self) -> Panel:
+        """Returns the progress bar."""
+        return Panel(
             self.progress_group,
             title=f"Sorting Downloads ━ Config: {self.manager.config_manager.loaded_config}",
             border_style="green",
             padding=(1, 1),
         )
 
-        # counts
-        self.audio_count = 0
-        self.video_count = 0
-        self.image_count = 0
-        self.other_count = 0
-
-    def get_progress(self) -> Panel:
-        """Returns the progress bar."""
-        return self.panel
-
     def set_queue_length(self, length: int) -> None:
         self.queue_length = length
-
-    def redraw(self) -> None:
-        """Redraws the progress bar."""
-        while len(self.visible_tasks) > self.tasks_visibility_limit:
-            task_id = self.visible_tasks.pop(0)
-            self.invisible_tasks.append(task_id)
-            self.progress.update(task_id, visible=False)
-        while len(self.invisible_tasks) > 0 and len(self.visible_tasks) < self.tasks_visibility_limit:
-            task_id = self.invisible_tasks.pop(0)
-            self.visible_tasks.append(task_id)
-            self.progress.update(task_id, visible=True)
-
-        if len(self.invisible_tasks) > 0:
-            self.overflow.update(
-                self.overflow_task_id,
-                description=self.overflow_str.format(
-                    color=self.color,
-                    number=len(self.invisible_tasks),
-                    type_str=self.type_str,
-                ),
-                visible=True,
-            )
-        else:
-            self.overflow.update(self.overflow_task_id, visible=False)
-
-        queue_length = self.queue_length
-        if queue_length > 0:
-            self.queue.update(
-                self.queue_task_id,
-                description=self.queue_str.format(color=self.color, number=queue_length, type_str=self.type_str),
-                visible=True,
-            )
-        else:
-            self.queue.update(self.queue_task_id, visible=False)
 
     def add_task(self, folder: str, expected_size: int | None) -> TaskID:
         """Adds a new task to the progress bar."""
         # description = f'Sorting {folder}'
-        description = folder
-        description = description.encode("ascii", "ignore").decode().strip()
-        description = adjust_title(description)
-
-        if len(self.visible_tasks) >= self.tasks_visibility_limit:
-            task_id = self.progress.add_task(
-                self.progress_str.format(color=self.color, description=description),
-                total=expected_size,
-                visible=False,
-            )
-            self.invisible_tasks.append(task_id)
-        else:
-            task_id = self.progress.add_task(
-                self.progress_str.format(color=self.color, description=description),
-                total=expected_size,
-            )
-            self.visible_tasks.append(task_id)
-        self.redraw()
-        return task_id
-
-    def remove_folder(self, task_id: TaskID) -> None:
-        """Removes the given task from the progress bar."""
-        if task_id in self.visible_tasks:
-            self.visible_tasks.remove(task_id)
-            self.progress.update(task_id, visible=False)
-        elif task_id in self.invisible_tasks:
-            self.invisible_tasks.remove(task_id)
-        elif task_id == self.overflow_task_id:
-            self.overflow.update(task_id, visible=False)
-        else:
-            msg = "Task ID not found"
-            raise ValueError(msg)
-        self.redraw()
+        description = folder.encode("ascii", "ignore").decode().strip()
+        description = escape(adjust_title(description))
+        return super().add_task(description, expected_size)
 
     def advance_folder(self, task_id: TaskID, amount: int = 1) -> None:
         """Advances the progress of the given task by the given amount."""
-        if task_id in self.uninitiated_tasks:
-            self.uninitiated_tasks.remove(task_id)
-            self.invisible_tasks.append(task_id)
-            self.redraw()
         self.progress.advance(task_id, amount)
 
     def increment_audio(self) -> None:

--- a/cyberdrop_dl/ui/progress/sort_progress.py
+++ b/cyberdrop_dl/ui/progress/sort_progress.py
@@ -6,15 +6,10 @@ from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskID
 
-from cyberdrop_dl.ui.progress.deque_progress import DequeProgress
+from cyberdrop_dl.ui.progress.deque_progress import DequeProgress, adjust_title
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
-
-
-def adjust_title(s: str, length: int = 40, placeholder: str = "...") -> str:
-    """Collapse and truncate or pad the given string to fit in the given length."""
-    return f"{s[:length - len(placeholder)]}{placeholder}" if len(s) >= length else s.ljust(length)
 
 
 class SortProgress(DequeProgress):

--- a/cyberdrop_dl/ui/progress/sort_progress.py
+++ b/cyberdrop_dl/ui/progress/sort_progress.py
@@ -73,7 +73,7 @@ class SortProgress:
     def set_queue_length(self, length: int) -> None:
         self.queue_length = length
 
-    def redraw(self, passed: bool = False) -> None:
+    def redraw(self) -> None:
         """Redraws the progress bar."""
         while len(self.visible_tasks) > self.tasks_visibility_limit:
             task_id = self.visible_tasks.pop(0)
@@ -106,9 +106,6 @@ class SortProgress:
             )
         else:
             self.queue.update(self.queue_task_id, visible=False)
-
-        if not passed:
-            self.manager.progress_manager.scraping_progress.redraw(True)
 
     def add_task(self, folder: str, expected_size: int | None) -> TaskID:
         """Adds a new task to the progress bar."""

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -106,7 +106,7 @@ class Sorter:
                     self.sort_other(file, folder_name)
 
                 self.manager.progress_manager.sort_progress.advance_folder(task_id)
-            self.manager.progress_manager.sort_progress.remove_folder(task_id)
+            self.manager.progress_manager.sort_progress.remove_task(task_id)
             queue_length -= 1
             self.manager.progress_manager.sort_progress.set_queue_length(queue_length)
             await asyncio.sleep(1)  # required to update the UI

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -36,10 +36,10 @@ class Sorter:
         self.incrementer_format: str = manager.config_manager.settings_data.sorting.sort_incrementer_format
         self.db_manager = manager.db_manager
 
-        self.audio_format: str = manager.config_manager.settings_data.sorting.sorted_audio
-        self.image_format: str = manager.config_manager.settings_data.sorting.sorted_image
-        self.video_format: str = manager.config_manager.settings_data.sorting.sorted_video
-        self.other_format: str = manager.config_manager.settings_data.sorting.sorted_other
+        self.audio_format: str | None = manager.config_manager.settings_data.sorting.sorted_audio
+        self.image_format: str | None = manager.config_manager.settings_data.sorting.sorted_image
+        self.video_format: str | None = manager.config_manager.settings_data.sorting.sorted_video
+        self.other_format: str | None = manager.config_manager.settings_data.sorting.sorted_other
 
     def _get_files(self, directory: Path) -> list[Path]:
         """Finds all files in a directory and returns them in a list."""
@@ -139,7 +139,7 @@ class Sorter:
             return
         height = resolution = width = None
         with (
-            contextlib.suppress(PIL.UnidentifiedImageError, PIL.Image.DecompressionBombError),
+            contextlib.suppress(PIL.UnidentifiedImageError, PIL.Image.DecompressionBombError),  # type: ignore
             Image.open(file) as image,
         ):  # type: ignore
             width, height = image.size
@@ -194,7 +194,7 @@ class Sorter:
         if self._process_file_move(file, base_name, self.other_format):
             self.manager.progress_manager.sort_progress.increment_other()
 
-    def _process_file_move(self, file: Path, base_name: str, format_str: str, **kwargs) -> None:
+    def _process_file_move(self, file: Path, base_name: str, format_str: str, **kwargs) -> bool:
         file_date = get_modified_date(file)
         file_date_us = file_date.strftime("%Y-%d-%m")
         file_date_iso = file_date.strftime("%Y-%m-%d")


### PR DESCRIPTION
- Use deque to speed up the time it takes to redraw the entire UI. Helps reduce flickering on some terminals

- Use a base class for file, scrape and sort progress, to reduce code duplication

# TODO

- [ ] ~~Apply to hashing progress~~ Progress is too different
- [x] Apply to sort progress