### PR TITLE
New debug var

### DIFF
--- a/cyberdrop_dl/scraper/__init__.py
+++ b/cyberdrop_dl/scraper/__init__.py
@@ -56,8 +56,8 @@ DEBUG_CRAWLERS = {SimpCityCrawler}
 CRAWLERS = ALL_CRAWLERS - DEBUG_CRAWLERS
 
 constants.RUNNING_PRERELEASE = next((tag for tag in constants.PRERELEASE_TAGS if tag in current_version), False)
-RUNNING_IN_IDE = os.getenv("PYCHARM_HOSTED") or os.getenv("ENABLESIMPCITY") or os.getenv("TERM_PROGRAM") == "vscode"
-if constants.RUNNING_PRERELEASE or RUNNING_IN_IDE:
+RUNNING_IN_IDE = os.getenv("PYCHARM_HOSTED") or os.getenv("TERM_PROGRAM") == "vscode"
+if constants.RUNNING_PRERELEASE or RUNNING_IN_IDE or os.getenv("ENABLESIMPCITY"):
     CRAWLERS = ALL_CRAWLERS
 
 if RUNNING_IN_IDE:

--- a/cyberdrop_dl/scraper/__init__.py
+++ b/cyberdrop_dl/scraper/__init__.py
@@ -56,7 +56,7 @@ DEBUG_CRAWLERS = {SimpCityCrawler}
 CRAWLERS = ALL_CRAWLERS - DEBUG_CRAWLERS
 
 constants.RUNNING_PRERELEASE = next((tag for tag in constants.PRERELEASE_TAGS if tag in current_version), False)
-RUNNING_IN_IDE = os.getenv("PYCHARM_HOSTED") or os.getenv("TERM_PROGRAM") == "vscode"
+RUNNING_IN_IDE = os.getenv("PYCHARM_HOSTED") or os.getenv("ENABLESIMPCITY") or os.getenv("TERM_PROGRAM") == "vscode"
 if constants.RUNNING_PRERELEASE or RUNNING_IN_IDE:
     CRAWLERS = ALL_CRAWLERS
 

--- a/cyberdrop_dl/utils/transfer/transfer_hash_db.py
+++ b/cyberdrop_dl/utils/transfer/transfer_hash_db.py
@@ -11,6 +11,7 @@ from cyberdrop_dl.utils.transfer.wrapper import db_transfer_context
 
 console = Console()
 
+
 def transfer_from_old_hash_table(db_path):
     """Transfers data from the old 'hash' table to new 'files' and 'temp_hash' tables, handling potential schema differences and errors.
 


### PR DESCRIPTION
Add a new debug var for SimpCity support. Allowing us to enable SimpCity support without running in IDE or on a development build.