### PR TITLE
refactor: add `MediaItem` inmediatly to db 

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -145,7 +145,6 @@ class DownloadClient:
             media_item.filesize = int(resp.headers.get("Content-Length", "0"))
             if not media_item.complete_file:
                 proceed, skip = await self.get_final_file_info(media_item, domain)
-                await self.mark_incomplete(media_item, domain)
                 self.client_manager.check_bunkr_maint(resp.headers)
                 if skip:
                     self.manager.progress_manager.download_progress.add_skipped()
@@ -211,7 +210,6 @@ class DownloadClient:
             log(f"Download Skip {media_item.url} due to mark completed option", 10)
             self.manager.progress_manager.download_progress.add_skipped()
             # set completed path
-            await self.mark_incomplete(media_item, domain)
             await self.process_completed(media_item, domain)
             return False
 

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -90,6 +90,7 @@ class Downloader:
 
         self.waiting_items += 1
         media_item.current_attempt = 0
+        await self.client.mark_incomplete(media_item, self.domain)
         async with self._semaphore:
             self.waiting_items -= 1
             self.processed_items.add(media_item.url.path)


### PR DESCRIPTION
Allows retrying them with `--retry-failed`, for any error (Insufficient space error, skipped by config or just not processed)

Only downside if that they will be added with `null` as `filesize` cause the initial request to get the file info has not been made yet. I'm not sure if something will break without it. Could not find a function that needs it except for the UI

## TODO

- [ ] ~~Test edge cases~~
- [ ] ~~Add `--retry-skipped`~~
- [ ] ~~Add `--retry-queue`~~