### PR TITLE
feat: add support indirect links (routed via api) (saint)

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -9,6 +9,7 @@ from yarl import URL
 
 from cyberdrop_dl.clients.errors import ScrapeError
 from cyberdrop_dl.scraper.crawler import Crawler, create_task_id
+from cyberdrop_dl.utils.data_enums_classes.url_objects import FILE_HOST_ALBUM, ScrapeItem
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
 
 if TYPE_CHECKING:
@@ -17,7 +18,6 @@ if TYPE_CHECKING:
     from bs4 import BeautifulSoup
 
     from cyberdrop_dl.managers.manager import Manager
-    from cyberdrop_dl.utils.data_enums_classes.url_objects import ScrapeItem
 
 
 class SaintCrawler(Crawler):
@@ -48,6 +48,7 @@ class SaintCrawler(Crawler):
         results = await self.get_album_results(album_id)
         scrape_item.album_id = album_id
         scrape_item.part_of_album = True
+        scrape_item.set_type(FILE_HOST_ALBUM, self.manager)
 
         async with self.request_limiter:
             soup: BeautifulSoup = await self.client.get_soup(self.domain, scrape_item.url, origin=scrape_item)
@@ -66,6 +67,7 @@ class SaintCrawler(Crawler):
             filename, ext = get_filename_and_ext(link.name)
             if not self.check_album_results(link, results):
                 await self.handle_file(link, scrape_item, filename, ext)
+            scrape_item.add_children()
 
     @error_handling_wrapper
     async def embed(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -71,7 +71,7 @@ class SaintCrawler(Crawler):
 
     @error_handling_wrapper
     async def embed(self, scrape_item: ScrapeItem) -> None:
-        """Scrapes a embeded video page."""
+        """Scrapes an embeded video page."""
         if await self.check_complete_from_referer(scrape_item):
             return
 

--- a/cyberdrop_dl/scraper/crawlers/saint_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/saint_crawler.py
@@ -8,7 +8,7 @@ from aiolimiter import AsyncLimiter
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import ScrapeError
-from cyberdrop_dl.scraper.crawler import Crawler
+from cyberdrop_dl.scraper.crawler import Crawler, create_task_id
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
 
 if TYPE_CHECKING:
@@ -29,9 +29,9 @@ class SaintCrawler(Crawler):
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
+    @create_task_id
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         """Determines where to send the scrape item based on the url."""
-        task_id = self.scraping_progress.add_task(scrape_item.url)
         scrape_item.url = self.primary_base_domain.with_path(scrape_item.url.path)
 
         if "a" in scrape_item.url.parts:
@@ -40,8 +40,6 @@ class SaintCrawler(Crawler):
             await self.embed(scrape_item)
         else:
             await self.video(scrape_item)
-
-        self.scraping_progress.remove_task(task_id)
 
     @error_handling_wrapper
     async def album(self, scrape_item: ScrapeItem) -> None:


### PR DESCRIPTION
- As far as i can tell, these URLs always require cookies cause they trigger a DDoS Guard challenge
- Resolves #458 

There's a regression from a few PRs back. CDL no longer triggers `DDoS-Guard` errors, only `403 forbidden`. I will fix it on another PR