### PR TITLE
Update start scripts

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -34,7 +34,7 @@ There are two ways to install Cyberdrop-DL. The first is the easy method, where 
 
 ## What now?</a>
 
-If you downloaded the start scripts, just open the start script with the name of the OS your are using. For a manual install, execute the program with this command:
+If you downloaded the start scripts, just open the start script with the name of the OS you are using. For a manual install, execute the program with this command:
 
 ```shell
 cyberdrop-dl

--- a/docs/getting-started/cyberdrop-dl-install.md
+++ b/docs/getting-started/cyberdrop-dl-install.md
@@ -18,7 +18,7 @@ Extract the contents of the zip file to any location where you'd like the progra
 If you're using Windows or Linux, simply open the start file, and it will handle the rest for you
 
 {% hint style="info" %}
-If your are using Windows, **DO NOT** run the script as admin
+If you are using Windows, **DO NOT** run the script as admin
 {% endhint %}
 
 On macOS, you should be able to open the start file and have everything set up automatically. However, in some rare cases, macOS users may need to run the following command first::

--- a/scripts/release/start_linux.sh
+++ b/scripts/release/start_linux.sh
@@ -5,6 +5,45 @@
 PYTHON=""
 VENV_DIR=""
 COMMANDLINE_ARGS=""
+AUTO_UPDATE=true
+AUTO_UPDATE_PIP=true
+
+# Parse arguments
+HELP=false
+SKIP_UPDATE=false
+for arg in "$@"
+do
+    case "$arg" in
+        --no-update)
+            SKIP_UPDATE=true
+            ;;
+        -h|--help)
+            HELP=true
+            ;;
+    esac
+done
+
+# Define help message
+HELP_TEXT=$(cat << EOF
+
+Usage:
+  $0 [OPTIONS]
+
+Options:
+  --no-update       Skip updating Cyberdrop-DL.
+  -h, --help        Show this help message and exit.
+
+Description:
+  This script sets up a virtual environment and runs Cyberdrop-DL.
+  By default, it ensures that Cyberdrop-DL is installed and up to date.
+
+EOF
+)
+# Display help message
+if [ "$HELP" = true ]; then
+    echo "$HELP_TEXT"
+    exit 0
+fi
 
 # Check the installed Python version
 MIN_PYTHON_VER="3.11"
@@ -12,7 +51,7 @@ MAX_PYTHON_VER="3.14"
 
 if [ -z "$PYTHON" ]
 then
-      PYTHON=python3
+    PYTHON=python3
 fi
 
 "$PYTHON" -c "
@@ -36,14 +75,14 @@ fi
 
 if [ -z "$VENV_DIR" ]
 then
-      VENV_DIR="${0%/*}/venv"
+    VENV_DIR="${0%/*}/venv"
 fi
 
 if [ ! -f "${VENV_DIR}/bin/activate" ]
 then
-      echo Creating virtual environment
-      "$PYTHON" -m venv "${VENV_DIR}"
-      echo
+    echo Creating virtual environment
+    "$PYTHON" -m venv "${VENV_DIR}"
+    echo
 fi
 
 
@@ -51,11 +90,33 @@ echo Attempting to start venv
 . "${VENV_DIR}/bin/activate"
 echo
 
-echo Updating PIP
-"$PYTHON" -m pip install --upgrade pip
-echo
+if [ "$AUTO_UPDATE_PIP" = true ]; then
+    echo Updating PIP
+    "$PYTHON" -m pip install --upgrade pip
+    echo
+fi
 
-echo Installing / Updating Cyberdrop-DL
 pip uninstall -y -qq cyberdrop-dl
-pip install --upgrade "cyberdrop-dl-patched>=6.0,<7.0" && clear && cyberdrop-dl $COMMANDLINE_ARGS
-echo
+# Ensure Cyberdrop-DL is installed
+if ! command -v cyberdrop-dl >/dev/null 2>&1; then
+    echo Cyberdrop-DL is not installed, installing...
+    pip install "cyberdrop-dl-patched>=6.0,<7.0"
+    echo
+    if [ $? -ne 0 ]; then
+        echo "Failed to install Cyberdrop-DL."
+        exit 1
+    fi
+    if ! command -v cyberdrop-dl >/dev/null 2>&1; then
+        echo Cyberdrop-DL was successfully installed, but could not be found in the virtual environment.
+        exit 1
+    fi
+else
+    if [ "$AUTO_UPDATE" = true ] && [ "$SKIP_UPDATE" = false ]; then
+        echo Updating Cyberdrop-DL...
+        pip install --upgrade "cyberdrop-dl-patched>=6.0,<7.0"
+        echo
+    fi
+fi
+
+
+clear && cyberdrop-dl $COMMANDLINE_ARGS

--- a/scripts/release/start_macOS.command
+++ b/scripts/release/start_macOS.command
@@ -5,6 +5,45 @@
 PYTHON=""
 VENV_DIR=""
 COMMANDLINE_ARGS=""
+AUTO_UPDATE=true
+AUTO_UPDATE_PIP=true
+
+# Parse arguments
+HELP=false
+SKIP_UPDATE=false
+for arg in "$@"
+do
+    case "$arg" in
+        --no-update)
+            SKIP_UPDATE=true
+            ;;
+        -h|--help)
+            HELP=true
+            ;;
+    esac
+done
+
+# Define help message
+HELP_TEXT=$(cat << EOF
+
+Usage:
+  $0 [OPTIONS]
+
+Options:
+  --no-update       Skip updating Cyberdrop-DL.
+  -h, --help        Show this help message and exit.
+
+Description:
+  This script sets up a virtual environment and runs Cyberdrop-DL.
+  By default, it ensures that Cyberdrop-DL is installed and up to date.
+
+EOF
+)
+# Display help message
+if [ "$HELP" = true ]; then
+    echo "$HELP_TEXT"
+    exit 0
+fi
 
 # Check the installed Python version
 MIN_PYTHON_VER="3.11"
@@ -12,7 +51,7 @@ MAX_PYTHON_VER="3.14"
 
 if [ -z "$PYTHON" ]
 then
-      PYTHON=python3
+    PYTHON=python3
 fi
 
 "$PYTHON" -c "
@@ -36,14 +75,14 @@ fi
 
 if [ -z "$VENV_DIR" ]
 then
-      VENV_DIR="${0%/*}/venv"
+    VENV_DIR="${0%/*}/venv"
 fi
 
 if [ ! -f "${VENV_DIR}/bin/activate" ]
 then
-      echo Creating virtual environment
-      "$PYTHON" -m venv "${VENV_DIR}"
-      echo
+    echo Creating virtual environment
+    "$PYTHON" -m venv "${VENV_DIR}"
+    echo
 fi
 
 
@@ -51,11 +90,33 @@ echo Attempting to start venv
 . "${VENV_DIR}/bin/activate"
 echo
 
-echo Updating PIP
-"$PYTHON" -m pip install --upgrade pip
-echo
+if [ "$AUTO_UPDATE_PIP" = true ]; then
+    echo Updating PIP
+    "$PYTHON" -m pip install --upgrade pip
+    echo
+fi
 
-echo Installing / Updating Cyberdrop-DL
 pip uninstall -y -qq cyberdrop-dl
-pip install --upgrade "cyberdrop-dl-patched>=6.0,<7.0" && clear && cyberdrop-dl $COMMANDLINE_ARGS
-echo
+# Ensure Cyberdrop-DL is installed
+if ! command -v cyberdrop-dl >/dev/null 2>&1; then
+    echo Cyberdrop-DL is not installed, installing...
+    pip install "cyberdrop-dl-patched>=6.0,<7.0"
+    echo
+    if [ $? -ne 0 ]; then
+        echo "Failed to install Cyberdrop-DL."
+        exit 1
+    fi
+    if ! command -v cyberdrop-dl >/dev/null 2>&1; then
+        echo Cyberdrop-DL was successfully installed, but could not be found in the virtual environment.
+        exit 1
+    fi
+else
+    if [ "$AUTO_UPDATE" = true ] && [ "$SKIP_UPDATE" = false ]; then
+        echo Updating Cyberdrop-DL...
+        pip install --upgrade "cyberdrop-dl-patched>=6.0,<7.0"
+        echo
+    fi
+fi
+
+
+clear && cyberdrop-dl $COMMANDLINE_ARGS

--- a/scripts/release/start_windows.bat
+++ b/scripts/release/start_windows.bat
@@ -9,13 +9,20 @@ set "COMMANDLINE_ARGS="
 set "AUTO_UPDATE=true"
 set "AUTO_UPDATE_PIP=true"
 
-rem Check if the user wants to skip auto-updating
+rem Parse arguments
+set "HELP=false"
 set "SKIP_UPDATE=false"
 for %%a in (%*) do (
     if "%%a"=="--no-update" (
         set "SKIP_UPDATE=true"
+    ) else if "%%a"=="-h" (
+        set "HELP=true"
+    ) else if "%%a"=="--help" (
+        set "HELP=true"
     )
 )
+
+if "%HELP%"=="true" goto :HELP
 
 rem Check the installed Python version
 chcp 65001 > nul
@@ -53,8 +60,9 @@ if [ "$AUTO_UPDATE_PIP" = true ]; then
     python -m pip install --upgrade pip
 fi
 
+pip uninstall -y -qq cyberdrop-dl
 rem Ensure Cyberdrop-DL is installed
-pip show cyberdrop-dl-patched >nul 2>&1
+where cyberdrop-dl >nul 2>&1
 if %ERRORLEVEL% neq 0 (
     echo Cyberdrop-DL is not installed, installing...
     pip install "cyberdrop-dl-patched>=6.0,<7.0"
@@ -63,13 +71,16 @@ if %ERRORLEVEL% neq 0 (
         pause
         exit /b 1
     )
+    where cyberdrop-dl >nul 2>&1
+    if %ERRORLEVEL% neq 0 (
+        echo Cyberdrop-DL was successfully installed, but could not be found in the virtual environment.
+        pause
+        exit /b 1
+    )
 ) else (
     if "%AUTO_UPDATE%"=="true" if "%SKIP_UPDATE%"=="false" (
         echo Updating Cyberdrop-DL...
-        pip uninstall -y -qq cyberdrop-dl
         pip install --upgrade "cyberdrop-dl-patched>=6.0,<7.0"
-    ) else (
-        echo Skipping update of Cyberdrop-DL as per user or script settings.
     )
 )
 
@@ -77,3 +88,18 @@ if %ERRORLEVEL% neq 0 (
 cls
 cyberdrop-dl %COMMANDLINE_ARGS%
 pause
+
+:HELP
+echo.
+echo Usage:
+echo   %~nx0 [OPTIONS]
+echo.
+echo Options:
+echo   --no-update       Skip updating Cyberdrop-DL.
+echo   -h, --help        Show this help message and exit.
+echo.
+echo Description:
+echo   This script sets up a virtual environment and runs Cyberdrop-DL.
+echo   By default, it ensures that Cyberdrop-DL is installed and up to date.
+echo.
+exit /b 0

--- a/scripts/release/start_windows.bat
+++ b/scripts/release/start_windows.bat
@@ -6,24 +6,33 @@ rem User defined variables
 set "PYTHON="
 set "VENV_DIR="
 set "COMMANDLINE_ARGS="
+set "AUTO_UPDATE=true"
+set "AUTO_UPDATE_PIP=true"
+
+rem Check if the user wants to skip auto-updating
+set "SKIP_UPDATE=false"
+for %%a in (%*) do (
+    if "%%a"=="--no-update" (
+        set "SKIP_UPDATE=true"
+    )
+)
 
 rem Check the installed Python version
-chcp 65001
+chcp 65001 > nul
 set MIN_PYTHON_VER=3.11
 set MAX_PYTHON_VER=3.14
 if not defined PYTHON (set PYTHON=python)
 "%PYTHON%" -c "import sys; MIN_PYTHON_VER = tuple(map(int, '%MIN_PYTHON_VER%'.split('.'))); MAX_PYTHON_VER = tuple(map(int, '%MAX_PYTHON_VER%'.split('.'))); current_version = sys.version_info; exit(0 if (current_version >= MIN_PYTHON_VER and current_version < MAX_PYTHON_VER) else 1)"
 
 if %ERRORLEVEL% equ 1 (
-	"%PYTHON%" -V
-    echo Unsupported python version installed. Needs version ^>=%MIN_PYTHON_VER% and ^<%MAX_PYTHON_VER%
-	pause
+    "%PYTHON%" -V
+    echo Unsupported Python version installed. Needs version ^>=%MIN_PYTHON_VER% and ^<%MAX_PYTHON_VER%
+    pause
     exit /b 1
 )
 
-
 rem Create and activate venv
-if not defined VENV_DIR (set "VENV_DIR=%~dp0%venv")
+if not defined VENV_DIR (set "VENV_DIR=%~dp0venv")
 
 if not exist "%VENV_DIR%" (
     mkdir "%VENV_DIR%"
@@ -39,12 +48,32 @@ echo Attempting to start venv
 call "%VENV_DIR%\Scripts\activate.bat"
 echo:
 
-rem Program startup
-echo Updating PIP
-python -m pip install --upgrade pip
-echo:
+if [ "$AUTO_UPDATE_PIP" = true ]; then
+    echo Updating pip...
+    python -m pip install --upgrade pip
+fi
 
-echo Installing / Updating Cyberdrop-DL
-pip uninstall -y -qq cyberdrop-dl
-pip install --upgrade "cyberdrop-dl-patched>=6.0,<7.0" && cls && cyberdrop-dl %COMMANDLINE_ARGS%
+rem Ensure Cyberdrop-DL is installed
+pip show cyberdrop-dl-patched >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo Cyberdrop-DL is not installed, installing...
+    pip install "cyberdrop-dl-patched>=6.0,<7.0"
+    if %ERRORLEVEL% neq 0 (
+        echo Failed to install Cyberdrop-DL.
+        pause
+        exit /b 1
+    )
+) else (
+    if "%AUTO_UPDATE%"=="true" if "%SKIP_UPDATE%"=="false" (
+        echo Updating Cyberdrop-DL...
+        pip uninstall -y -qq cyberdrop-dl
+        pip install --upgrade "cyberdrop-dl-patched>=6.0,<7.0"
+    ) else (
+        echo Skipping update of Cyberdrop-DL as per user or script settings.
+    )
+)
+
+
+cls
+cyberdrop-dl %COMMANDLINE_ARGS%
 pause


### PR DESCRIPTION
Update all start scripts to add a `--help` / `-h` option, `--no-update`, to skip auto-updating Cyberdrop-DL, and config options to enable/disable auto-updating Cyberdrop-DL and pip. These new config options are enabled by default.

Also added a check to determine whether or not Cyberdrop-DL is already installed.