### PR TITLE
fix: update jpg5 rate limit

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/chevereto_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/chevereto_crawler.py
@@ -36,7 +36,7 @@ class UrlType(enum.StrEnum):
 
 
 class CheveretoCrawler(Crawler):
-    JPG5_DOMAINS: ClassVar[tuple[str, ...]] = [
+    JPG5_DOMAINS: ClassVar[list[str]] = [
         "jpg5.su",
         "jpg.homes",
         "jpg.church",
@@ -72,7 +72,7 @@ class CheveretoCrawler(Crawler):
     def __init__(self, manager: Manager, site: str) -> None:
         super().__init__(manager, site, self.FOLDER_DOMAINS.get(site, "Chevereto"))
         self.primary_base_domain = self.PRIMARY_BASE_DOMAINS.get(site, URL(f"https://{site}"))
-        self.request_limiter = AsyncLimiter(10, 1)
+        self.request_limiter = AsyncLimiter(2, 1)
         self.next_page_selector = "a[data-pagination=next]"
         self.album_title_selector = "a[data-text=album-name]"
         self.album_img_selector = "a[class='image-container --media'] img"


### PR DESCRIPTION
fixes 503s while scraping

I will make a different PR with some refactors to automatically use the `rate_limit` of the crawler without having to manually use a context manager

The change is small but it needs to be added to every crawler