### PR TITLE
fix: regression - additive config options

### DIFF
--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -140,17 +140,17 @@ class Manager:
         cli_ignore_options = self.parsed_args.config_settings.ignore_options
         config_skip_hosts = self.config_manager.settings_data.ignore_options.skip_hosts
         config_only_hosts = self.config_manager.settings_data.ignore_options.only_hosts
-        exclude = set("+", "-")
+        exclude = {"+", "-"}
 
-        def add(config_list: list, cli_list: list) -> list:
+        def add(config_list: list[str], cli_list: list[str]) -> list[str]:
             new_list_as_set = set(config_list + cli_list)
             return sorted(new_list_as_set - exclude)
 
-        def remove(config_list: list, cli_list: list) -> list:
+        def remove(config_list: list[str], cli_list: list[str]) -> list[str]:
             new_list_as_set = set(config_list) - set(cli_list)
             return sorted(new_list_as_set - exclude)
 
-        def add_or_remove(config_list: list, cli_list: list) -> list[str]:
+        def add_or_remove(config_list: list[str], cli_list: list[str]) -> list[str]:
             if cli_list:
                 if cli_list[0] == "+":
                     return add(config_list, cli_list)

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -136,8 +136,15 @@ class Manager:
         self.progress_manager = ProgressManager(self)
         self.progress_manager.startup()
 
+    def process_additive_args(self) -> None:
+        cli_config_settings = self.parsed_args.config_settings
+        current_config_settings = self.config_manager.settings_data
+        cli_config_settings.ignore_options.skip_hosts += current_config_settings.ignore_options.skip_hosts
+        cli_config_settings.ignore_options.only_hosts += current_config_settings.ignore_options.only_hosts
+
     def args_consolidation(self) -> None:
         """Consolidates runtime arguments with config values."""
+        self.process_additive_args()
         cli_config_settings = self.parsed_args.config_settings.model_dump(exclude_unset=True)
         cli_global_settings = self.parsed_args.global_settings.model_dump(exclude_unset=True)
 

--- a/docs/reference/configuration-options/settings/ignore_options.md
+++ b/docs/reference/configuration-options/settings/ignore_options.md
@@ -46,7 +46,7 @@ When this is set to `true`, the program will skip post marked as ads by models i
 |----------------|----------|
 | `list[NonEmptyStr]` | `[]` |
 
-You can supply hosts that you'd like the program to skip, to not scrape/download from them. This setting accepts any domain, even if they are no supported
+You can supply hosts that you'd like the program to skip, to not scrape/download from them. This setting accepts any domain, even if they are no supported. When passing hosts as CLI arguments, if the first host is `+`, any hosts after it will be added to the lists of hosts specified in the config file instead of overriding it. Similarly, if the first hosts is `-`, any hosts after it will be removed from the lists of hosts specified in the config
 
 ## `only_hosts`
 
@@ -54,7 +54,7 @@ You can supply hosts that you'd like the program to skip, to not scrape/download
 |----------------|----------|
 | `list[NonEmptyStr]` | `[]` |
 
-You can supply hosts that you'd like the program to exclusively scrape/download from. This setting accepts any domain, even if they are no supported
+You can supply hosts that you'd like the program to exclusively scrape/download from. This setting accepts any domain, even if they are no supported. When passing hosts as CLI arguments, if the first host is `+`, any hosts after it will be added to the lists of hosts specified in the config file instead of overriding it. Similarly, if the first hosts is `-`, any hosts after it will be removed from the lists of hosts specified in the config
 
 ## `filename_regex_filter`
 


### PR DESCRIPTION
Fix regression introduced from pydantic config validation. `skip-hosts` and `only-hosts` values passed from CLI should be added to the config values, not overridden