### PR TITLE
feat: skip urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 *.log
 *.profiling
 .coverage
+#configs
+config.yaml
+*.yaml
+*.yml
 
 # Python cache
 __pycache__

--- a/cyberdrop_dl/config_definitions/config_settings.py
+++ b/cyberdrop_dl/config_definitions/config_settings.py
@@ -110,8 +110,9 @@ class IgnoreOptions(BaseModel):
     ignore_coomer_ads: bool = False
     skip_hosts: list[NonEmptyStr] = []
     only_hosts: list[NonEmptyStr] = []
+    skip_urls: list[NonEmptyStr] = []
 
-    @field_validator("skip_hosts", "only_hosts", mode="before")
+    @field_validator("skip_hosts", "only_hosts", "skip_urls", mode="before")
     @classmethod
     def handle_falsy(cls, value: list) -> list:
         if not value:

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -149,9 +149,13 @@ class Crawler(ABC):
         if not skip and self.manager.config_manager.settings_data.ignore_options.skip_hosts:
             skip_hosts = self.manager.config_manager.settings_data.ignore_options.skip_hosts
             if any(host in media_item.url.host for host in skip_hosts):
-                log(f"Download skip {media_item.url} due to skip_hosts config", 10)
+                log(f"Download skip {media_item.url} due to skip_urls config", 10)
                 skip = True
-
+        if not skip and self.manager.config_manager.settings_data.ignore_options.skip_urls:
+            skip_urls = self.manager.config_manager.settings_data.ignore_options.skip_urls
+            if any(url in str(media_item.url) for url in skip_urls):
+                log(f"Download skip {media_item.url} due to skip_urls config", 10)
+                skip = True
         if not skip and self.manager.config_manager.settings_data.ignore_options.only_hosts:
             only_hosts = self.manager.config_manager.settings_data.ignore_options.only_hosts
             if not any(host in media_item.url.host for host in only_hosts):

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -48,8 +48,12 @@ def is_outside_date_range(scrape_item: ScrapeItem, before: arrow, after: arrow) 
     return skip
 
 
-def is_in_domain_list(scrape_item: ScrapeItem, domain_list: list[str]) -> bool:
+def host_is_in_domain_list(scrape_item: ScrapeItem, domain_list: list[str]) -> bool:
     return any(domain in scrape_item.url.host for domain in domain_list)
+
+
+def url_is_in_domain_list(scrape_item: ScrapeItem, domain_list: list[str]) -> bool:
+    return any(domain in str(scrape_item.url) for domain in domain_list)
 
 
 def remove_trailing_slash(url: URL) -> URL:

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -15,10 +15,11 @@ from cyberdrop_dl.downloader.downloader import Downloader
 from cyberdrop_dl.scraper import CRAWLERS
 from cyberdrop_dl.scraper.filters import (
     has_valid_extension,
-    is_in_domain_list,
+    host_is_in_domain_list,
     is_outside_date_range,
     is_valid_url,
     remove_trailing_slash,
+    url_is_in_domain_list,
 )
 from cyberdrop_dl.scraper.jdownloader import JDownloader
 from cyberdrop_dl.utils.constants import BLOCKED_DOMAINS, REGEX_LINKS
@@ -304,7 +305,7 @@ class ScrapeMapper:
         if not is_valid_url(scrape_item):
             return False
 
-        if is_in_domain_list(scrape_item, BLOCKED_DOMAINS):
+        if host_is_in_domain_list(scrape_item, BLOCKED_DOMAINS):
             log(f"Skipping {scrape_item.url} as it is a blocked domain", 10)
             return False
 
@@ -315,12 +316,17 @@ class ScrapeMapper:
             return False
 
         skip_hosts = self.manager.config_manager.settings_data.ignore_options.skip_hosts
-        if skip_hosts and is_in_domain_list(scrape_item, skip_hosts):
+        skip_urls = self.manager.config_manager.settings_data.ignore_options.skip_urls
+
+        if skip_hosts and host_is_in_domain_list(scrape_item, skip_hosts):
             log(f"Skipping URL by skip_hosts config: {scrape_item.url}", 10)
+            return False
+        if skip_urls and url_is_in_domain_list(scrape_item, skip_urls):
+            log(f"Skipping URL by skip_urls config: {scrape_item.url}", 10)
             return False
 
         only_hosts = self.manager.config_manager.settings_data.ignore_options.only_hosts
-        if only_hosts and not is_in_domain_list(scrape_item, only_hosts):
+        if only_hosts and not host_is_in_domain_list(scrape_item, only_hosts):
             log(f"Skipping URL by only_hosts config: {scrape_item.url}", 10)
             return False
 


### PR DESCRIPTION
Currently the only option is to skip an entire hosts, however in some cases it is desirable to be able to add a specific url to skip

For example on forums at least 3 times, I've notice that the scraper will start to download content for a model that is not related to the current thread