### PR TITLE
Add last version run with to the cache

### DIFF
--- a/cyberdrop_dl/managers/cache_manager.py
+++ b/cyberdrop_dl/managers/cache_manager.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from aiohttp_client_cache import SQLiteBackend
 
+from cyberdrop_dl import __version__ as current_version
 from cyberdrop_dl.scraper.filters import filter_fn
 from cyberdrop_dl.utils import yaml
 from cyberdrop_dl.utils.data_enums_classes.supported_domains import SUPPORTED_FORUMS, SUPPORTED_WEBSITES
@@ -82,3 +83,6 @@ class CacheManager:
 
     async def close(self):
         await self.request_cache.close()
+
+    def close_sync(self):
+        self.save("version", current_version)

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -221,6 +221,7 @@ class Manager:
         if not isinstance(self.client_manager, Field):
             await self.client_manager.close()
         await self.cache_manager.close()
+        self.cache_manager.close_sync()
         self.db_manager: DBManager = field(init=False)
         self.cache_manager: CacheManager = field(init=False)
         self.hash_manager: HashManager = field(init=False)

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -261,6 +261,7 @@ class ProgramUI:
     def _process_answer(self, answer: Any, options_map=dict) -> Choice | None:
         """Checks prompt answer and executes corresponding function."""
         if answer == EXIT_CHOICE.value:
+            self.manager.cache_manager.close_sync()
             asyncio.run(self.manager.cache_manager.close())
             sys.exit(0)
         if answer == DONE_CHOICE.value:


### PR DESCRIPTION
Add the last version that CDL was run on to the cache. This would aid in detecting when a transition is necessary or when to tell a user that they must downgrade in order to transition.