### PR TITLE
fix: xenforo crawlers

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -81,12 +81,13 @@ class DownloadClient:
     def add_request_log_hooks(self) -> None:
         async def on_request_start(*args):
             params: aiohttp.TraceRequestStartParams = args[2]
-            log(f"Starting download {params.method} request to {params.url}", 20)
+            log(f"Starting download {params.method} request to {params.url}", 10)
 
         async def on_request_end(*args):
             params: aiohttp.TraceRequestEndParams = args[2]
-            log(f"Finishing download {params.method} request to {params.url}", 20)
-            log(f"Response status for {params.url}: {params.response.status}", 20)
+            msg = f"Finishing download {params.method} request to {params.url}"
+            msg += f"-> response status: {params.response.status}"
+            log(msg, 10)
 
         trace_config = aiohttp.TraceConfig()
         trace_config.on_request_start.append(on_request_start)

--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -73,12 +73,13 @@ class ScraperClient:
     def add_request_log_hooks(self) -> None:
         async def on_request_start(*args):
             params: aiohttp.TraceRequestStartParams = args[2]
-            log(f"Starting download {params.method} request to {params.url}", 20)
+            log(f"Starting scrape {params.method} request to {params.url}", 10)
 
         async def on_request_end(*args):
             params: aiohttp.TraceRequestEndParams = args[2]
-            log(f"Finishing download {params.method} request to {params.url}", 20)
-            log(f"Response status for {params.url}: {params.response.status}", 20)
+            msg = f"Finishing scrape {params.method} request to {params.url}"
+            msg += f"-> response status: {params.response.status}"
+            log(msg, 10)
 
         trace_config = aiohttp.TraceConfig()
         trace_config.on_request_start.append(on_request_start)

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -347,6 +347,8 @@ def create_task_id(func: Callable) -> Callable:
         task_id = self.scraping_progress.add_task(scrape_item.url)
         try:
             return await func(self, *args, **kwargs)
+        except ValueError:
+            log(f"Scrape Failed: Unknown URL path: {scrape_item.url}", 40)
         finally:
             self.scraping_progress.remove_task(task_id)
 

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -280,7 +280,12 @@ class Crawler(ABC):
             new_url = new_url.with_scheme(base.scheme or "https")
         return new_url
 
-    def update_cookies(self, cookies: dict, response_url: URL) -> None:
+    def update_cookies(self, cookies: dict, url: URL | None = None) -> None:
+        """Update cookies for the provided URL
+
+        If `url` is `None`, defaults to `self.primary_base_domain`
+        """
+        response_url = url or self.primary_base_domain
         self.client.client_manager.cookies.update_cookies(cookies, response_url)
 
 

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -290,7 +290,7 @@ class Crawler(ABC):
         scrape_item.album_id = album_id or scrape_item.album_id
         return scrape_item
 
-    def create_title(self, title: str, album_id: str | None = None, thread_id: str | None = None) -> str:
+    def create_title(self, title: str, album_id: str | None = None, thread_id: int | None = None) -> str:
         """Creates the title for the scrape item."""
         download_options = self.manager.config_manager.settings_data.download_options
         if not title:

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -279,6 +279,9 @@ class Crawler(ABC):
             new_url = new_url.with_scheme(base.scheme or "https")
         return new_url
 
+    def update_cookies(self, cookies: dict, response_url: URL) -> None:
+        self.client.client_manager.cookies.update_cookies(cookies, response_url)
+
 
 def create_task_id(func: Callable) -> Callable:
     """Wrapper handles task_id creation and removal for ScrapeItems"""

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -164,24 +164,6 @@ class Crawler(ABC):
 
         return False
 
-    def check_post_number(self, post_number: int, current_post_number: int) -> tuple[bool, bool]:
-        """Checks if the program should scrape the current post."""
-        """Returns (scrape_post, continue_scraping)"""
-        scrape_single_forum_post = self.manager.config_manager.settings_data.download_options.scrape_single_forum_post
-
-        scrape_post = continue_scraping = True
-
-        if scrape_single_forum_post:
-            if not post_number or post_number == current_post_number:
-                continue_scraping = False
-            else:
-                scrape_post = False
-
-        elif post_number and post_number > current_post_number:
-            scrape_post = False
-
-        return scrape_post, continue_scraping
-
     def handle_external_links(self, scrape_item: ScrapeItem) -> None:
         """Maps external links to the scraper class."""
         self.manager.task_group.create_task(self.manager.scrape_mapper.filter_and_send_to_crawler(scrape_item))

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -164,8 +164,10 @@ class Crawler(ABC):
 
         return False
 
-    def handle_external_links(self, scrape_item: ScrapeItem) -> None:
+    def handle_external_links(self, scrape_item: ScrapeItem, reset: bool = False) -> None:
         """Maps external links to the scraper class."""
+        if reset:
+            scrape_item.reset()
         self.manager.task_group.create_task(self.manager.scrape_mapper.filter_and_send_to_crawler(scrape_item))
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -34,8 +34,8 @@ class Post(Protocol):
 
 class Crawler(ABC):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {}
-    domain = None
-    primary_base_domain: URL = None
+    domain: str = None  # type: ignore
+    primary_base_domain: URL = None  # type: ignore
     DEFAULT_POST_TITLE_FORMAT = "{date} - {number} - {title}"
 
     def __init__(self, manager: Manager, domain: str, folder_domain: str | None = None) -> None:
@@ -144,6 +144,7 @@ class Crawler(ABC):
             log(f"Download skip {media_item.url} as referer has been seen before", 10)
             return True
 
+        assert media_item.url.host
         skip_hosts = settings.ignore_options.skip_hosts
         if skip_hosts and any(host in media_item.url.host for host in skip_hosts):
             log(f"Download skip {media_item.url} due to skip_hosts config", 10)
@@ -157,7 +158,7 @@ class Crawler(ABC):
         valid_regex_filter = self.manager.config_manager.valid_filename_filter_regex
         regex_filter = self.manager.config_manager.settings_data.ignore_options.filename_regex_filter
 
-        if valid_regex_filter and re.search(regex_filter, media_item.filename):
+        if valid_regex_filter and regex_filter and re.search(regex_filter, media_item.filename):
             log(f"Download skip {media_item.url} due to filename regex filter config", 10)
             return True
 
@@ -258,7 +259,7 @@ class Crawler(ABC):
             title_format = self.DEFAULT_POST_TITLE_FORMAT
         date = post.date
         if isinstance(post.date, int):
-            date = datetime.fromtimestamp(date)
+            date = datetime.fromtimestamp(date)  # type: ignore
         if isinstance(date, datetime):
             date = date.isoformat()
         id = "Unknown" if post.id is None else post.id

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -29,7 +29,7 @@ class Post(Protocol):
     number: int
     id: str
     title: str
-    date: datetime | int
+    date: datetime | int | None
 
 
 class Crawler(ABC):

--- a/cyberdrop_dl/scraper/crawlers/allporncomix_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/allporncomix_crawler.py
@@ -15,7 +15,7 @@ class AllPornComixCrawler(XenforoCrawler):
     domain = "allporncomix"
     login_required = False
     post_selectors = PostSelectors(
-        content=Selector("div[class=bbWrapper]", None),
+        content=Selector("div[class=bbWrapper]"),
         images=Selector("img[class*=bbImage]", "data-src"),
         date=Selector("time", "datetime"),
         attachments=Selector("section[class=message-attachments] .attachmentList .file .file-preview", "href"),

--- a/cyberdrop_dl/scraper/crawlers/bellazon_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bellazon_crawler.py
@@ -17,7 +17,7 @@ class BellazonCrawler(XenforoCrawler):
     login_required = False
     post_selectors = PostSelectors(
         element="div[class*=ipsComment_content]",
-        content=Selector("div[class=cPost_contentWrap]", None),
+        content=Selector("div[class=cPost_contentWrap]"),
         attachments=Selector("a[class*=ipsAttachLink]", "href"),
         images=Selector("a[class*=ipsAttachLink_image]", "href"),
         videos=Selector("video[class=ipsEmbeddedVideo] source", "src"),
@@ -26,7 +26,7 @@ class BellazonCrawler(XenforoCrawler):
     )
     selectors = XenforoSelectors(
         posts=post_selectors,
-        title=Selector("span.ipsType_break.ipsContained span", None),
+        title=Selector("span.ipsType_break.ipsContained span"),
         next_page=Selector("li[class=ipsPagination_next] a", "href"),
         post_name="comment-",
     )

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -115,15 +115,16 @@ class CoomerCrawler(Crawler):
             msg = "No session cookie found in the config file, cannot scrape favorites"
             raise ScrapeError(401, msg, origin=scrape_item)
 
-        self.client.client_manager.cookies.update_cookies(
-            {"session": self.manager.config_manager.authentication_data.coomer.session},
-            response_url=self.primary_base_domain,
-        )
+        cookies = {"session": self.manager.config_manager.authentication_data.coomer.session}
+        self.update_cookies(cookies, self.primary_base_domain)
+
         async with self.request_limiter:
             favourites_api_url = (self.api_url / "account/favorites").with_query({"type": "artist"})
             JSON_Resp = await self.client.get_json(self.domain, favourites_api_url, origin=scrape_item)
 
-        self.client.client_manager.cookies.update_cookies({"session": ""}, response_url=self.primary_base_domain)
+        cookies = {"session": ""}
+        self.update_cookies(cookies, self.primary_base_domain)
+
         for user in JSON_Resp:
             id = user["id"]
             service = user["service"]

--- a/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/coomer_crawler.py
@@ -116,14 +116,14 @@ class CoomerCrawler(Crawler):
             raise ScrapeError(401, msg, origin=scrape_item)
 
         cookies = {"session": self.manager.config_manager.authentication_data.coomer.session}
-        self.update_cookies(cookies, self.primary_base_domain)
+        self.update_cookies(cookies)
 
         async with self.request_limiter:
             favourites_api_url = (self.api_url / "account/favorites").with_query({"type": "artist"})
             JSON_Resp = await self.client.get_json(self.domain, favourites_api_url, origin=scrape_item)
 
         cookies = {"session": ""}
-        self.update_cookies(cookies, self.primary_base_domain)
+        self.update_cookies(cookies)
 
         for user in JSON_Resp:
             id = user["id"]

--- a/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/f95zone_crawler.py
@@ -39,7 +39,7 @@ class F95ZoneCrawler(XenforoCrawler):
             return self.parse_url(JSON_Resp["msg"])
         return None
 
-    async def filter_link(self, link: URL) -> URL:
+    def filter_link(self, link: URL) -> URL:
         if "thumb" in link.parts:
             parts = [x for x in link.parts if x not in ("thumb", "/")]
             new_path = "/".join(parts)

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -132,7 +132,8 @@ class GoFileCrawler(Crawler):
         """Gets the token for the API."""
         self.api_key = self.api_key or await self._get_new_api_key()
         self.headers["Authorization"] = f"Bearer {self.api_key}"
-        self.client.client_manager.cookies.update_cookies({"accountToken": self.api_key}, self.primary_base_domain)
+        cookies = {"accountToken": self.api_key}
+        self.update_cookies(cookies, self.primary_base_domain)
 
     async def _get_new_api_key(self) -> str:
         create_account_address = self.api / "accounts"

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -133,7 +133,7 @@ class GoFileCrawler(Crawler):
         self.api_key = self.api_key or await self._get_new_api_key()
         self.headers["Authorization"] = f"Bearer {self.api_key}"
         cookies = {"accountToken": self.api_key}
-        self.update_cookies(cookies, self.primary_base_domain)
+        self.update_cookies(cookies)
 
     async def _get_new_api_key(self) -> str:
         create_account_address = self.api / "accounts"

--- a/cyberdrop_dl/scraper/crawlers/imagebam_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imagebam_crawler.py
@@ -117,4 +117,4 @@ class ImageBamCrawler(Crawler):
     def set_cookies(self) -> None:
         """Set cookies to bypass confirmation."""
         cookies = {"nsfw_inter": "1"}
-        self.update_cookies(cookies, self.primary_base_domain)
+        self.update_cookies(cookies)

--- a/cyberdrop_dl/scraper/crawlers/imagebam_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imagebam_crawler.py
@@ -116,4 +116,5 @@ class ImageBamCrawler(Crawler):
 
     def set_cookies(self) -> None:
         """Set cookies to bypass confirmation."""
-        self.client.client_manager.cookies.update_cookies({"nsfw_inter": "1"}, self.primary_base_domain)
+        cookies = {"nsfw_inter": "1"}
+        self.update_cookies(cookies, self.primary_base_domain)

--- a/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/imgur_crawler.py
@@ -105,9 +105,9 @@ class ImgurCrawler(Crawler):
         filename, ext = get_filename_and_ext(scrape_item.url.name)
         if ext.lower() in (".gifv", ".mp4"):
             filename = filename.replace(ext, ".mp4")
-            link_str = "/" + filename.rsplit(".", 1)[0]
+            file_id = filename.rsplit(".", 1)[0]
             ext = ".mp4"
-            link = self.parse_url(link_str, URL("https://imgur.com/download"))
+            link = URL("https://imgur.com/download") / file_id
             new_scrape_item = self.create_scrape_item(scrape_item, link)
             return await self.handle_file(link, new_scrape_item, filename, ext)
         await self.handle_file(scrape_item.url, scrape_item, filename, ext)

--- a/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/nudostar_crawler.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class NudoStarCrawler(XenforoCrawler):
-    primary_base_domain = URL("https://nudostar.com")
+    primary_base_domain = URL("https://nudostar.com/forum/")
     post_selectors = PostSelectors(
         date=Selector("time", "data-time"),
         number=Selector("a[class=u-concealed]", "href"),

--- a/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
@@ -81,6 +81,5 @@ class RealBooruCrawler(Crawler):
 
     def set_cookies(self) -> None:
         """Sets the cookies for the client."""
-        self.client.client_manager.cookies.update_cookies(
-            {"resize-original": "1"}, response_url=self.primary_base_domain
-        )
+        cookies = {"resize-original": "1"}
+        self.update_cookies(cookies, self.primary_base_domain)

--- a/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realbooru_crawler.py
@@ -82,4 +82,4 @@ class RealBooruCrawler(Crawler):
     def set_cookies(self) -> None:
         """Sets the cookies for the client."""
         cookies = {"resize-original": "1"}
-        self.update_cookies(cookies, self.primary_base_domain)
+        self.update_cookies(cookies)

--- a/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
@@ -84,4 +84,4 @@ class Rule34XXXCrawler(Crawler):
     async def set_cookies(self) -> None:
         """Sets the cookies for the client."""
         cookies = {"resize-original": "1"}
-        self.update_cookies(cookies, self.primary_base_domain)
+        self.update_cookies(cookies)

--- a/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/rule34xxx_crawler.py
@@ -83,6 +83,5 @@ class Rule34XXXCrawler(Crawler):
 
     async def set_cookies(self) -> None:
         """Sets the cookies for the client."""
-        self.client.client_manager.cookies.update_cookies(
-            {"resize-original": "1"}, response_url=self.primary_base_domain
-        )
+        cookies = {"resize-original": "1"}
+        self.update_cookies(cookies, self.primary_base_domain)

--- a/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/socialmediagirls_crawler.py
@@ -14,7 +14,7 @@ class SocialMediaGirlsCrawler(XenforoCrawler):
     primary_base_domain = URL("https://forums.socialmediagirls.com")
     domain = "socialmediagirls"
     post_selectors = PostSelectors(
-        content=Selector("div[class=bbWrapper]", None),
+        content=Selector("div[class=bbWrapper]"),
         images=Selector("img[class*=bbImage]", "data-src"),
         date=Selector("time", "data-time"),
     )

--- a/cyberdrop_dl/scraper/crawlers/titsintops_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/titsintops_crawler.py
@@ -19,7 +19,6 @@ class TitsInTopsCrawler(XenforoCrawler):
         images=Selector("a[class*=file-preview]", "href"),
     )
     selectors = XenforoSelectors(posts=post_selectors)
-    login_required = True
 
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, self.domain, "TitsInTops")
@@ -41,7 +40,8 @@ class TitsInTopsCrawler(XenforoCrawler):
         text = link_obj.text
         if text and "view attachment" in text.lower():
             return False
-        if link_obj.get("title") and "permanent link" in link_obj.get("title").lower():
+        title: str = link_obj.get("title")  # type: ignore
+        if title and "permanent link" in title.lower():
             return False
-        link_str: str = link_obj.get(self.selectors.posts.links.element)
+        link_str: str = link_obj.get(self.selectors.posts.links.element)  # type: ignore
         return not (is_image and self.is_attachment(link_str))

--- a/cyberdrop_dl/scraper/crawlers/titsintops_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/titsintops_crawler.py
@@ -25,7 +25,7 @@ class TitsInTopsCrawler(XenforoCrawler):
         super().__init__(manager, self.domain, "TitsInTops")
         self.attachment_url_part = ["attachments", "data"]
 
-    async def filter_link(self, link: URL):
+    def filter_link(self, link: URL):
         return URL(
             str(link)
             .replace("index.php%3F", "index.php/")
@@ -33,7 +33,7 @@ class TitsInTopsCrawler(XenforoCrawler):
             .replace("index.php/goto", "index.php?goto")
         )
 
-    async def pre_filter_link(self, link):
+    def pre_filter_link(self, link):
         return URL(str(link).replace("index.php?", "index.php/").replace("index.php%3F", "index.php/"))
 
     def is_valid_post_link(self, link_obj: Tag) -> bool:

--- a/cyberdrop_dl/scraper/crawlers/tokyomotion_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/tokyomotion_crawler.py
@@ -161,8 +161,8 @@ class TokioMotionCrawler(Crawler):
                 link_tag = image.select_one(self.image_thumb_selector)
                 if not link_tag:
                     continue
-                link_str: str = link_tag.get("src")
-                link = self.parse_url(link_str.replace("/tmb/", "/"))
+                link_str: str = link_tag.get("src").replace("/tmb/", "/")
+                link = self.parse_url(link_str)
                 filename, ext = get_filename_and_ext(link.name)
                 await self.handle_file(link, scrape_item, filename, ext)
 

--- a/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xbunker_crawler.py
@@ -14,7 +14,7 @@ class XBunkerCrawler(XenforoCrawler):
     primary_base_domain = URL("https://xbunker.nu/")
     domain = "xbunker"
     post_selectors = PostSelectors(
-        content=Selector("div[class=bbWrapper]", None),
+        content=Selector("div[class=bbWrapper]"),
         images=Selector("img[class*=bbImage], a[class*=js-lbImage]", "data-src"),
         date=Selector("time", "data-time"),
     )

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -107,7 +107,6 @@ class ThreadInfo(NamedTuple):
 
 class XenforoCrawler(Crawler):
     login_required = True
-    primary_base_domain = None
     selectors = XenforoSelectors()
     POST_NAME = "post-"
     PAGE_NAME = "page-"
@@ -115,7 +114,7 @@ class XenforoCrawler(Crawler):
 
     def __init__(self, manager: Manager, site: str, folder_domain: str | None = None) -> None:
         super().__init__(manager, site, folder_domain)
-        self.primary_base_domain = self.primary_base_domain or URL(f"https://{site}")
+        assert self.primary_base_domain, "Subclasses must override primary_base_domain"
         self.attachment_url_parts = ["attachments", "data"]
         self.attachment_url_hosts = ["smgmedia", "attachments.f95zone"]
         self.logged_in = False

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -174,13 +174,16 @@ class XenforoCrawler(Crawler):
         scrape_item.set_type(FORUM, self.manager)
         thread = self.get_thread_info(scrape_item.url)
         last_scraped_post_number = None
+        title = None
         async for soup in self.thread_pager(scrape_item):
-            title_block = soup.select_one(self.selectors.title.element)
-            trash: list[Tag] = title_block.find_all(self.selectors.title_trash.element)
-            for element in trash:
-                element.decompose()
+            if not title:
+                title_block = soup.select_one(self.selectors.title.element)
+                trash: list[Tag] = title_block.find_all(self.selectors.title_trash.element)
+                for element in trash:
+                    element.decompose()
 
-            title = self.create_title(title_block.text.replace("\n", ""), thread_id=thread.id_)
+                title = self.create_title(title_block.text.replace("\n", ""), thread_id=thread.id_)
+
             scrape_item.add_to_parent_title(title)
             posts = soup.select(self.selectors.posts.element)
             continue_scraping = False

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -97,7 +97,7 @@ class ForumPost:
 
 
 @dataclass(frozen=True, slots=True)
-class ThreadInfo:
+class ForumThread:
     name: str
     id_: int
     page: int
@@ -171,7 +171,9 @@ class XenforoCrawler(Crawler):
 
         await self.write_last_forum_post(thread.url, last_post_url)
 
-    def process_thread_page(self, scrape_item: ScrapeItem, thread: ThreadInfo, soup: BeautifulSoup) -> tuple[bool, URL]:
+    def process_thread_page(
+        self, scrape_item: ScrapeItem, thread: ForumThread, soup: BeautifulSoup
+    ) -> tuple[bool, URL]:
         posts = soup.select(self.selectors.posts.element)
         continue_scraping = False
         create = partial(self.create_scrape_item, scrape_item)
@@ -450,12 +452,12 @@ class XenforoCrawler(Crawler):
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
-    def get_thread_info(self, url: URL) -> ThreadInfo:
+    def get_thread_info(self, url: URL) -> ForumThread:
         name_index = url.parts.index(self.thread_url_part) + 1
         name, id_ = get_thread_name_and_id(url, name_index)
         thread_url = get_thread_canonical_url(url, name_index)
         page, post = get_thread_page_and_post(url, name_index, self.PAGE_NAME, self.POST_NAME)
-        return ThreadInfo(name, id_, page, post, thread_url, url)
+        return ForumThread(name, id_, page, post, thread_url, url)
 
 
 def get_thread_name_and_id(url: URL, thread_name_index: int) -> tuple[str, int]:

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -194,10 +194,6 @@ class XenforoCrawler(Crawler):
                     post_string = f"{self.POST_NAME}{current_post.number}"
                     parent_url = thread.url / post_string
                     new_scrape_item = create(thread.url, possible_datetime=date, add_parent=parent_url)
-                    trash: list[Tag] = title_block.find_all(self.selectors.quotes.element)
-                    for element in trash:
-                        element.decompose()
-
                     await self.post(new_scrape_item, current_post)
                     scrape_item.add_children()
 

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -94,6 +94,15 @@ class ForumPost:
         return self.number
 
 
+class ThreadInfo(NamedTuple):
+    name: str
+    id_: int
+    page: int
+    post: int
+    url: URL
+    complete_url: URL
+
+
 class XenforoCrawler(Crawler):
     login_required = True
     primary_base_domain = None
@@ -393,10 +402,10 @@ class XenforoCrawler(Crawler):
             data: dict = {elem["name"]: elem["value"] for elem in inputs if elem.get("name") and elem.get("value")}
             return data | credentials
 
+        assert login_url.host
         while attempt < retries:
             try:
                 attempt += 1
-                assert login_url.host
                 await set_return_value(str(login_url), False, pop=False)
                 await set_return_value(str(login_url / "login"), False, pop=False)
                 await asyncio.sleep(wait_time)
@@ -427,15 +436,6 @@ class XenforoCrawler(Crawler):
         page, post = get_thread_page_and_post(url, name_index, self.PAGE_NAME, self.POST_NAME)
 
         return ThreadInfo(name, id_, page, post, thread_url, url)
-
-
-class ThreadInfo(NamedTuple):
-    name: str
-    id_: int
-    page: int
-    post: int
-    url: URL
-    complete_url: URL
 
 
 def get_thread_name_and_id(url: URL, thread_name_index: int) -> tuple[str, int]:

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -194,7 +194,7 @@ class XenforoCrawler(Crawler):
                     post_string = f"{self.POST_NAME}{current_post.number}"
                     parent_url = thread.url / post_string
                     new_scrape_item = create(thread.url, possible_datetime=date, add_parent=parent_url)
-                    await self.post(new_scrape_item, current_post)
+                    self.manager.task_group.create_task(self.post(new_scrape_item, current_post))
                     scrape_item.add_children()
 
                 if not continue_scraping:

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -177,7 +177,7 @@ class XenforoCrawler(Crawler):
         post_url = thread.url
         for post in posts:
             current_post = ForumPost(post, selectors=self.selectors.posts, post_name=self.POST_NAME)
-            scrape_post, continue_scraping = self.check_post_number(thread.post, current_post.number)
+            continue_scraping, scrape_post = self.check_post_number(thread.post, current_post.number)
             date = current_post.date
             post_string = f"{self.POST_NAME}{current_post.number}"
             post_url = thread.url / post_string
@@ -331,6 +331,23 @@ class XenforoCrawler(Crawler):
             return
         link_str: str = confirm_button.get("href")
         return self.parse_url(link_str)
+
+    def check_post_number(self, post_number: int, current_post_number: int) -> tuple[bool, bool]:
+        """Checks if the program should scrape the current post."""
+        """Returns (scrape_post, continue_scraping)"""
+        scrape_single_forum_post = self.manager.config_manager.settings_data.download_options.scrape_single_forum_post
+        scrape_post = continue_scraping = True
+
+        if scrape_single_forum_post:
+            if not post_number or post_number == current_post_number:
+                continue_scraping = False
+            else:
+                scrape_post = False
+
+        elif post_number and post_number > current_post_number:
+            scrape_post = False
+
+        return continue_scraping, scrape_post
 
     async def write_last_forum_post(self, thread_url: URL, last_post_url: URL | None) -> None:
         if not last_post_url or last_post_url == thread_url:

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -370,8 +370,8 @@ class XenforoCrawler(Crawler):
         wait_time: int = 5
 
         if not ((username and password) or session_cookie) and self.login_required:
-            log(f"Login wasn't provided for {login_url.host}", 40)
-            raise LoginError(message="Login wasn't provided")
+            msg = f"Login wasn't provided for {login_url.host}"
+            raise LoginError(message=msg)
 
         if session_cookie:
             self.client.client_manager.cookies.update_cookies(
@@ -411,7 +411,8 @@ class XenforoCrawler(Crawler):
                 continue
 
         if self.login_required:
-            raise LoginError(message="Failed to login after 5 attempts")
+            msg = "Failed to login after 5 attempts"
+            raise LoginError(message=msg)
 
         log(f"Scraping {self.domain} without an account", 30)
 

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -367,7 +367,7 @@ class XenforoCrawler(Crawler):
 
     @error_handling_wrapper
     async def forum_login(self, login_url: URL, session_cookie: str, username: str, password: str) -> None:
-        """Logs into a forum."""
+        """Logs in to a forum."""
 
         attempt = 0
         retries = wait_time = 5
@@ -376,11 +376,9 @@ class XenforoCrawler(Crawler):
             msg = f"Login wasn't provided for {login_url.host}"
             raise LoginError(message=msg)
 
+        cookies = {"xf_user": session_cookie}
         if session_cookie:
-            self.client.client_manager.cookies.update_cookies(
-                {"xf_user": session_cookie},
-                response_url=self.primary_base_domain,
-            )
+            self.update_cookies(cookies, self.primary_base_domain)
 
         text, logged_in = await self.check_login_with_request(login_url)
         if logged_in:

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -319,6 +319,7 @@ class XenforoCrawler(Crawler):
             if self.is_attachment(link):
                 return await self.handle_internal_link(link, scrape_item)
             new_scrape_item = self.create_scrape_item(scrape_item, link)
+            new_scrape_item.set_type(None, self.manager)
             self.handle_external_links(new_scrape_item)
         except TypeError:
             log(f"Scrape Failed: encountered while handling {link}", 40)

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -316,14 +316,10 @@ class XenforoCrawler(Crawler):
             return
         try:
             assert self.domain and link.host
-            if self.domain not in link.host:
-                new_scrape_item = self.create_scrape_item(scrape_item, link)
-                new_scrape_item.reset_childen()
-                self.handle_external_links(new_scrape_item)
-            elif self.is_attachment(link):
-                await self.handle_internal_link(link, scrape_item)
-            else:
-                log(f"Unknown link type: {link}", 30)
+            if self.is_attachment(link):
+                return await self.handle_internal_link(link, scrape_item)
+            new_scrape_item = self.create_scrape_item(scrape_item, link)
+            self.handle_external_links(new_scrape_item)
         except TypeError:
             log(f"Scrape Failed: encountered while handling {link}", 40)
 

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -312,7 +312,7 @@ class XenforoCrawler(Crawler):
         return await self.get_absolute_link(parsed_link)
 
     async def handle_link(self, scrape_item: ScrapeItem, link: URL) -> None:
-        if not link:
+        if not link or link == self.primary_base_domain:
             return
         try:
             assert self.domain and link.host

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -188,8 +188,8 @@ class XenforoCrawler(Crawler):
                 scrape_post, continue_scraping = self.check_post_number(thread.post, current_post.number)
                 date = current_post.date
                 if scrape_post:
-                    new_path = f"/{self.POST_NAME}{current_post.number}"
-                    parent_url = self.parse_url(new_path, thread.url)
+                    post_string = f"{self.POST_NAME}{current_post.number}"
+                    parent_url = thread.url / post_string
                     new_scrape_item = create(thread.url, possible_datetime=date, add_parent=parent_url)
                     trash: list[Tag] = title_block.find_all(self.selectors.quotes.element)
                     for element in trash:
@@ -334,7 +334,7 @@ class XenforoCrawler(Crawler):
         if not post_number:
             return
         post_string = f"{self.POST_NAME}{post_number}"
-        last_post_url = self.parse_url(post_string, thread_url)
+        last_post_url = thread_url / post_string
         await self.manager.log_manager.write_last_post_log(last_post_url)
 
     async def thread_pager(self, scrape_item: ScrapeItem) -> AsyncGenerator[BeautifulSoup]:
@@ -395,7 +395,7 @@ def get_thread_name_and_id(url: URL, thread_name_index: int) -> tuple[str, int]:
 
 
 def get_thread_canonical_url(url: URL, thread_name_index: int) -> URL:
-    new_parts = url.parts[: thread_name_index + 1]
+    new_parts = url.parts[1 : thread_name_index + 1]
     new_path = "/".join(new_parts)
     thread_url = url.with_path(new_path).with_fragment(None).with_query(None)
     return thread_url

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -7,7 +7,7 @@ import contextlib
 import re
 from dataclasses import dataclass
 from functools import partial, singledispatchmethod
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING
 
 from bs4 import BeautifulSoup
 from yarl import URL
@@ -96,7 +96,8 @@ class ForumPost:
         return self.number
 
 
-class ThreadInfo(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class ThreadInfo:
     name: str
     id_: int
     page: int

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -1,9 +1,11 @@
+# ruff : noqa: RUF009
+
 from __future__ import annotations
 
 import asyncio
 import contextlib
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial, singledispatchmethod
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -36,30 +38,30 @@ HTTP_URL_PATTERNS = [re.compile(regex) for regex in HTTP_URL_REGEX_STRS]
 @dataclass(frozen=True)
 class Selector:
     element: str
-    attribute: str = None
+    attribute: str | None = None
 
 
 @dataclass(frozen=True)
 class PostSelectors(Selector):
     element: str = "div[class*=message-main]"
-    attachments: Selector = field(default=Selector("section[class=message-attachments] a ", "href"))
-    content: Selector = field(default=Selector("div[class*=message-userContent]", None))
-    date: Selector = field(default=Selector("time", "data-timestamp"))
-    embeds: Selector = field(default=Selector("span[data-s9e-mediaembed-iframe]", "data-s9e-mediaembed-iframe"))
-    iframe: Selector = field(default=Selector("iframe[class=saint-iframe]", "href"))
-    images: Selector = field(default=Selector("img[class*=bbImage]", "src"))
-    links: Selector = field(default=Selector("a", "href"))
-    number: Selector = field(default=Selector("li[class=u-concealed] a", "href"))
-    videos: Selector = field(default=Selector("video source", "src"))
+    attachments: Selector = Selector("section[class=message-attachments] a ", "href")
+    content: Selector = Selector("div[class*=message-userContent]", None)
+    date: Selector = Selector("time", "data-timestamp")
+    embeds: Selector = Selector("span[data-s9e-mediaembed-iframe]", "data-s9e-mediaembed-iframe")
+    iframe: Selector = Selector("iframe[class=saint-iframe]", "href")
+    images: Selector = Selector("img[class*=bbImage]", "src")
+    links: Selector = Selector("a", "href")
+    number: Selector = Selector("li[class=u-concealed] a", "href")
+    videos: Selector = Selector("video source", "src")
 
 
 @dataclass(frozen=True)
 class XenforoSelectors:
-    next_page: Selector = field(default=Selector("a[class*=pageNav-jump--next]", "href"))
-    posts: PostSelectors = field(default=PostSelectors())
-    title: Selector = field(default=Selector("h1[class=p-title-value]", None))
-    title_trash: Selector = field(default=Selector("span", None))
-    quotes: Selector = field(default=Selector("blockquote", None))
+    next_page: Selector = Selector("a[class*=pageNav-jump--next]", "href")
+    posts: PostSelectors = PostSelectors()
+    title: Selector = Selector("h1[class=p-title-value]", None)
+    title_trash: Selector = Selector("span", None)
+    quotes: Selector = Selector("blockquote", None)
     post_name: str = "post-"
 
 

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -404,7 +404,7 @@ class XenforoCrawler(Crawler):
         await self.forum_login(login_url, session_cookie, username, password)
 
         if not (self.login_required or self.logged_in):
-            log(f"Scraping {self.domain} without an account", 30)
+            log(f"Scraping {self.folder_domain} without an account", 30)
 
     @error_handling_wrapper
     async def forum_login(self, login_url: URL, session_cookie: str, username: str, password: str) -> None:
@@ -412,13 +412,14 @@ class XenforoCrawler(Crawler):
 
         attempt = 0
         retries = wait_time = 5
-        missing_credentials = not (username and password) or session_cookie
+        manual_login = username and password
+        missing_credentials = not (manual_login or session_cookie)
         if missing_credentials:
-            msg = f"Login wasn't provided for {login_url.host}"
+            msg = f"Login info wasn't provided for {self.folder_domain}"
             raise LoginError(message=msg)
 
-        cookies = {"xf_user": session_cookie}
         if session_cookie:
+            cookies = {"xf_user": session_cookie}
             self.update_cookies(cookies)
 
         text, logged_in = await self.check_login_with_request(login_url)

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -151,8 +151,8 @@ class XenforoCrawler(Crawler):
                     element.decompose()
 
                 title = self.create_title(title_block.text.replace("\n", ""), thread_id=thread.id_)
+                scrape_item.add_to_parent_title(title)
 
-            scrape_item.add_to_parent_title(title)
             posts = soup.select(self.selectors.posts.element)
             continue_scraping = False
             create = partial(self.create_scrape_item, scrape_item)

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -342,7 +342,9 @@ class XenforoCrawler(Crawler):
         if not confirm_button:
             return
         link_str: str = confirm_button.get("href")
-        return self.parse_url(link_str)
+        link_str = link_str.split('" class="link link--internal', 1)[0]
+        new_link = self.parse_url(link_str)
+        return await self.get_absolute_link(new_link)
 
     def check_post_number(self, post_number: int, current_post_number: int) -> tuple[bool, bool]:
         """Checks if the program should scrape the current post.

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -390,7 +390,7 @@ class XenforoCrawler(Crawler):
 
         cookies = {"xf_user": session_cookie}
         if session_cookie:
-            self.update_cookies(cookies, self.primary_base_domain)
+            self.update_cookies(cookies)
 
         text, logged_in = await self.check_login_with_request(login_url)
         if logged_in:

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -35,13 +35,13 @@ HTTP_URL_REGEX_STRS = [
 HTTP_URL_PATTERNS = [re.compile(regex) for regex in HTTP_URL_REGEX_STRS]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Selector:
     element: str
     attribute: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PostSelectors(Selector):
     element: str = "div[class*=message-main]"
     attachments: Selector = Selector("section[class=message-attachments] a ", "href")
@@ -55,7 +55,7 @@ class PostSelectors(Selector):
     videos: Selector = Selector("video source", "src")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class XenforoSelectors:
     next_page: Selector = Selector("a[class*=pageNav-jump--next]", "href")
     posts: PostSelectors = PostSelectors()

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -221,7 +221,7 @@ class XenforoCrawler(Crawler):
             if not continue_scraping:
                 break
 
-        await self.write_last_forum_post(scrape_item, last_scraped_post_number)
+        await self.write_last_forum_post(thread_url, last_scraped_post_number)
 
     async def post(self, scrape_item: ScrapeItem, post: ForumPost) -> None:
         """Scrapes a post."""
@@ -348,13 +348,11 @@ class XenforoCrawler(Crawler):
         link_str: str = confirm_button.get("href")
         return self.parse_url(link_str)
 
-    async def write_last_forum_post(self, scrape_item: ScrapeItem, post_number: int) -> None:
+    async def write_last_forum_post(self, thread_url: URL, post_number: int) -> None:
         if not post_number:
             return
         post_string = f"{self.POST_NAME}{post_number}"
-        use_parent = "page-" in scrape_item.url.raw_name or self.POST_NAME in scrape_item.url.raw_name
-        base = scrape_item.url.parent if use_parent else scrape_item.url
-        last_post_url = self.parse_url(post_string, base)
+        last_post_url = self.parse_url(post_string, thread_url)
         await self.manager.log_manager.write_last_post_log(last_post_url)
 
     async def thread_pager(self, scrape_item: ScrapeItem) -> AsyncGenerator[BeautifulSoup]:

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -120,8 +120,10 @@ class XenforoCrawler(Crawler):
         scrape_item.url = await self.pre_filter_link(scrape_item.url)
         if self.is_attachment(scrape_item.url):
             await self.handle_internal_link(scrape_item.url, scrape_item)
-        else:
+        elif self.thread_url_part in scrape_item.url.parts:
             await self.thread(scrape_item)
+        else:
+            raise ValueError
 
     async def try_login(self) -> None:
         login_url = self.primary_base_domain / "login"
@@ -153,10 +155,6 @@ class XenforoCrawler(Crawler):
     @error_handling_wrapper
     async def thread(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a forum thread."""
-        if self.thread_url_part not in scrape_item.url.parts:
-            log(f"Scrape Failed: Unknown URL path: {scrape_item.url}", 40)
-            return
-
         if not self.logged_in and self.login_required:
             return
 

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -367,11 +367,6 @@ class XenforoCrawler(Crawler):
         """Logs into a forum."""
 
         attempt = 0
-        text, logged_in = await self.check_login_with_request(login_url)
-        if logged_in:
-            self.logged_in = True
-            return
-
         wait_time: int = 5
 
         if not ((username and password) or session_cookie) and self.login_required:
@@ -383,6 +378,11 @@ class XenforoCrawler(Crawler):
                 {"xf_user": session_cookie},
                 response_url=self.primary_base_domain,
             )
+
+        text, logged_in = await self.check_login_with_request(login_url)
+        if logged_in:
+            self.logged_in = True
+            return
 
         credentials = {"login": username, "password": password, "_xfRedirect": str(self.primary_base_domain)}
 

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -101,7 +101,7 @@ class XenforoCrawler(Crawler):
     def __init__(self, manager: Manager, site: str, folder_domain: str | None = None) -> None:
         super().__init__(manager, site, folder_domain)
         self.primary_base_domain = self.primary_base_domain or URL(f"https://{site}")
-        self.attachment_url_parts = ["attachments"]
+        self.attachment_url_parts = ["attachments", "data"]
         self.attachment_url_hosts = ["smgmedia", "attachments.f95zone"]
         self.logged_in = False
 

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -223,4 +223,4 @@ class XXXBunkerCrawler(Crawler):
             return
 
         cookies = {"PHPSESSID": self.session_cookie}
-        self.update_cookies(cookies, self.primary_base_domain)
+        self.update_cookies(cookies)

--- a/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xxxbunker_crawler.py
@@ -222,7 +222,5 @@ class XXXBunkerCrawler(Crawler):
             self.session_cookie = ""
             return
 
-        self.client.client_manager.cookies.update_cookies(
-            {"PHPSESSID": self.session_cookie},
-            response_url=self.primary_base_domain,
-        )
+        cookies = {"PHPSESSID": self.session_cookie}
+        self.update_cookies(cookies, self.primary_base_domain)

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -49,12 +49,14 @@ class ScrapeMapper:
         for crawler in CRAWLERS:
             if not crawler.SUPPORTED_SITES:
                 site_crawler = crawler(self.manager)
+                assert site_crawler.domain not in self.existing_crawlers
                 self.existing_crawlers[site_crawler.domain] = site_crawler
                 continue
 
             for site, domains in crawler.SUPPORTED_SITES.items():
                 site_crawler = crawler(self.manager, site)
                 for domain in domains:
+                    assert domain not in self.existing_crawlers
                     self.existing_crawlers[domain] = site_crawler
 
     def start_jdownloader(self) -> None:
@@ -245,7 +247,7 @@ class ScrapeMapper:
 
         if supported_domain:
             # get most restrictive domain if multiple domain matches
-            supported_domain = max(supported_domain, key=len)
+            supported_domain = min(supported_domain, key=len)
             scraper = self.existing_crawlers[supported_domain]
             if not scraper.ready:
                 await scraper.startup()

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -247,7 +247,7 @@ class ScrapeMapper:
 
         if supported_domain:
             # get most restrictive domain if multiple domain matches
-            supported_domain = min(supported_domain, key=len)
+            supported_domain = max(supported_domain, key=len)
             scraper = self.existing_crawlers[supported_domain]
             if not scraper.ready:
                 await scraper.startup()

--- a/cyberdrop_dl/utils/data_enums_classes/url_objects.py
+++ b/cyberdrop_dl/utils/data_enums_classes/url_objects.py
@@ -76,7 +76,7 @@ class ScrapeItem:
     parents: list[URL] = field(default_factory=list, init=False)
     children: int = field(default=0, init=False)
     children_limit: int = field(default=0, init=False)
-    type: int | None = field(default=None, init=False)
+    type: ScrapeItemType | None = field(default=None, init=False)
     completed_at: int | None = field(default=None, init=False)
     created_at: int | None = field(default=None, init=False)
     children_limits: list[int] = field(default_factory=list, init=False)
@@ -88,7 +88,7 @@ class ScrapeItem:
         title = sanitize_folder(title)
         self.parent_title = (self.parent_title + "/" + title) if self.parent_title else title
 
-    def set_type(self, scrape_item_type: ScrapeItemType, manager: Manager) -> None:
+    def set_type(self, scrape_item_type: ScrapeItemType | None, manager: Manager) -> None:
         self.type = scrape_item_type
         self.children_limits = manager.config_manager.settings_data.download_options.maximum_number_of_children
         self.reset_childen()
@@ -106,9 +106,11 @@ class ScrapeItem:
             raise MaxChildrenError(origin=self)
 
     def reset(self, reset_parents: bool = False, reset_parent_title: bool = False) -> None:
-        self.album_id = None
-        self.possible_datetime = None
-        self.type = None
+        """Resets `album_id`, `type` and `posible_datetime` back to `None`
+
+        Only useful when the scrape item will be send to a different crawler and you want to get a diferent download path
+        """
+        self.album_id = self.possible_datetime = self.type = None
         self.reset_childen()
         if reset_parents:
             self.parents = []


### PR DESCRIPTION
## Changes 
- Fix `write_last_forum_post`
- Fix nudostar base domain
- Add support for redirect URLs
- Add more conditions to `is_attachment` check
- Raise `ValueError` if an URL path is unsupported instead of manually logging it. This can be applied to all crawlers
- Handle `ValueError` inside `create_task_id`
- Assert that no 2 crawlers have mappings to the same domain
- Simplify `forum_login` and move it from the base crawler to the Xenforo crawler
- Send posts to the queue instead of awaiting them
- Refactor some methods of the crawler
- Fixes invalid `parse_url` usage on some other crawlers
- Related to #516 
- Fixes #519 
- Fixes #524 

It may actually fix 516 but i don't have an account to test it