### PR TITLE
refactor: create base class for download and scrape failures + reformat stats

### DIFF
--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from dataclasses import field
 from datetime import timedelta
+from functools import partial
 from typing import TYPE_CHECKING
 
 from pydantic import ByteSize
@@ -74,49 +75,50 @@ class ProgressManager:
         """Prints the stats of the program."""
         end_time = time.perf_counter()
         runtime = timedelta(seconds=int(end_time - start_time))
+        data_size = ByteSize(self.file_progress.downloaded_data).human_readable(decimal=True)
+
+        log_cyan = partial(log_with_color, style="cyan", level=20)
+        log_yellow = partial(log_with_color, style="yellow", level=20)
+        log_green = partial(log_with_color, style="green", level=20)
+        log_red = partial(log_with_color, style="red", level=20)
 
         log("Printing Stats...\n", 20)
-        log_with_color(f"Run Stats (config: {self.manager.config_manager.loaded_config}):", "cyan", 20)
-        log_with_color(f"  Total Runtime: {runtime}", "yellow", 20)
-        data_size = ByteSize(self.file_progress.downloaded_data).human_readable(decimal=True)
-        log_with_color(f"  Total Downloaded Data: {data_size }", "yellow", 20)
+        log_cyan(f"Run Stats (config: {self.manager.config_manager.loaded_config}):")
+        log_yellow(f"  Total Runtime: {runtime}")
+        log_yellow(f"  Total Downloaded Data: {data_size}")
 
         log_spacer(20, "")
-        log_with_color("Download Stats:", "cyan", 20)
-        log_with_color(f"  Downloaded: {self.download_progress.completed_files} files", "green", 20)
-        log_with_color(
-            f"  Skipped (Previously Downloaded): {self.download_progress.previously_completed_files} files",
-            "yellow",
-            20,
-        )
-        log_with_color(f"  Skipped (By Config): {self.download_progress.skipped_files} files", "yellow", 20)
-        log_with_color(f"  Failed: {self.download_stats_progress.failed_files} files", "red", 20)
+        log_cyan("Download Stats:")
+        log_green(f"  Downloaded: {self.download_progress.completed_files:,} files")
+        log_yellow(f"  Skipped (Previously Downloaded): {self.download_progress.previously_completed_files:,} files")
+        log_yellow(f"  Skipped (By Config): {self.download_progress.skipped_files:,} files")
+        log_red(f"  Failed: {self.download_stats_progress.failed_files:,} files")
 
         log_spacer(20, "")
-        log_with_color("Unsupported URLs Stats:", "cyan", 20)
-        log_with_color(f"  Sent to Jdownloader: {self.scrape_stats_progress.sent_to_jdownloader}", "yellow", 20)
-        log_with_color(f"  Skipped: {self.scrape_stats_progress.unsupported_urls_skipped}", "yellow", 20)
+        log_cyan("Unsupported URLs Stats:")
+        log_yellow(f"  Sent to Jdownloader: {self.scrape_stats_progress.sent_to_jdownloader:,}")
+        log_yellow(f"  Skipped: {self.scrape_stats_progress.unsupported_urls_skipped:,}")
 
         log_spacer(20, "")
-        log_with_color("Dupe Stats:", "cyan", 20)
-        log_with_color(f"  Previously Hashed: {self.hash_progress.prev_hashed_files} files", "yellow", 20)
-        log_with_color(f"  Newly Hashed: {self.hash_progress.hashed_files} files", "yellow", 20)
-        log_with_color(f"  Removed (Downloads): {self.hash_progress.removed_files} files", "yellow", 20)
+        log_cyan("Dupe Stats:")
+        log_yellow(f"  Previously Hashed: {self.hash_progress.prev_hashed_files:,} files")
+        log_yellow(f"  Newly Hashed: {self.hash_progress.hashed_files:,} files")
+        log_yellow(f"  Removed (Downloads): {self.hash_progress.removed_files:,} files")
 
         log_spacer(20, "")
-        log_with_color("Sort Stats:", "cyan", 20)
-        log_with_color(f"  Organized: {self.sort_progress.audio_count} Audios", "green", 20)
-        log_with_color(f"  Organized: {self.sort_progress.image_count} Images", "green", 20)
-        log_with_color(f"  Organized: {self.sort_progress.video_count} Videos", "green", 20)
-        log_with_color(f"  Organized: {self.sort_progress.other_count} Other Files", "green", 20)
+        log_cyan("Sort Stats:")
+        log_green(f"  Audios: {self.sort_progress.audio_count:,}")
+        log_green(f"  Images: {self.sort_progress.image_count:,}")
+        log_green(f"  Videos: {self.sort_progress.video_count:,}")
+        log_green(f"  Other Files: {self.sort_progress.other_count:,}")
 
         def log_failures(failures: dict, title: str = "Failures:") -> None:
             log_spacer(20, "")
-            log_with_color(title, "cyan", 20)
+            log_cyan(title)
             if not failures:
-                log_with_color("  None", "green", 20)
+                log_green("  None")
             for name, count in failures.items():
-                log_with_color(f"  ({name}): {count}", "red", 20)
+                log_red(f"  {name}: {count:,}")
 
         log_failures(self.scrape_stats_progress.return_totals(), "Scrape Failures:")
         log_failures(self.download_stats_progress.return_totals(), "Download Failures:")

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -113,17 +113,21 @@ class ProgressManager:
         log_green(f"  Videos: {self.sort_progress.video_count:,}")
         log_green(f"  Other Files: {self.sort_progress.other_count:,}")
 
-        log_failures(self.scrape_stats_progress.return_totals(), "Scrape Failures:")
-        log_failures(self.download_stats_progress.return_totals(), "Download Failures:")
+        last_padding = log_failures(self.scrape_stats_progress.return_totals(), "Scrape Failures:")
+        log_failures(self.download_stats_progress.return_totals(), "Download Failures:", last_padding)
 
 
-def log_failures(failures: list[UiFailureTotal], title: str = "Failures:") -> None:
+def log_failures(failures: list[UiFailureTotal], title: str = "Failures:", last_padding: int = 0) -> int:
     log_spacer(20, "")
     log_cyan(title)
     if not failures:
-        return log_green("  None")
+        log_green("  None")
+        return 0
+    error_padding = last_padding
     error_codes = (f.error_code for f in failures if f.error_code is not None)
-    error_padding = len(str(max(error_codes)))
+    if error_codes:
+        error_padding = max(len(str(max(error_codes))), error_padding)
     for f in failures:
         error = f.error_code if f.error_code is not None else ""
-        log_red(f"  {error:>{error_padding}} {f.msg}: {f.count:,}")
+        log_red(f"  {error:>{error_padding}}{' ' if error_padding else ''}{f.msg}: {f.count:,}")
+    return error_padding

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -90,8 +90,8 @@ class ProgressManager:
         log_spacer(20, "")
         log_cyan("Download Stats:")
         log_green(f"  Downloaded: {self.download_progress.completed_files:,} files")
-        log_yellow(f"  Skipped (Previously Downloaded): {self.download_progress.previously_completed_files:,} files")
         log_yellow(f"  Skipped (By Config): {self.download_progress.skipped_files:,} files")
+        log_yellow(f"  Skipped (Previously Downloaded): {self.download_progress.previously_completed_files:,} files")
         log_red(f"  Failed: {self.download_stats_progress.failed_files:,} files")
 
         log_spacer(20, "")
@@ -101,8 +101,8 @@ class ProgressManager:
 
         log_spacer(20, "")
         log_cyan("Dupe Stats:")
-        log_yellow(f"  Previously Hashed: {self.hash_progress.prev_hashed_files:,} files")
         log_yellow(f"  Newly Hashed: {self.hash_progress.hashed_files:,} files")
+        log_yellow(f"  Previously Hashed: {self.hash_progress.prev_hashed_files:,} files")
         log_yellow(f"  Removed (Downloads): {self.hash_progress.removed_files:,} files")
 
         log_spacer(20, "")

--- a/cyberdrop_dl/ui/progress/deque_progress.py
+++ b/cyberdrop_dl/ui/progress/deque_progress.py
@@ -23,8 +23,8 @@ class DequeProgress(ABC):
     type_str: str = "Files"
     color = "plum3"
     progress_str = "[{color}]{description}"
-    overflow_str = "[{color}]... And {number} Other {type_str}"
-    queue_str = "[{color}]... And {number} {type_str} In {title} Queue"
+    overflow_str = "[{color}]... and {number:,} other {type_str}"
+    queue_str = "[{color}]... and {number:,} {type_str} in {title} queue"
 
     def __init__(self, title: str, visible_tasks_limit: int) -> None:
         self.title = title

--- a/cyberdrop_dl/ui/progress/downloads_progress.py
+++ b/cyberdrop_dl/ui/progress/downloads_progress.py
@@ -20,7 +20,7 @@ class DownloadsProgress:
             BarColumn(bar_width=None),
             "[progress.percentage]{task.percentage:>6.2f}%",
             "━",
-            "{task.completed}",
+            "{task.completed:,}",
         )
         self.progress_group = Group(self.progress)
 
@@ -38,7 +38,7 @@ class DownloadsProgress:
             title=f"Config: {self.manager.config_manager.loaded_config}",
             border_style="green",
             padding=(1, 1),
-            subtitle=f"Total Files: [white]{self.total_files}",
+            subtitle=f"Total Files: [white]{self.total_files:,}",
         )
 
     def get_progress(self) -> Panel:
@@ -52,7 +52,7 @@ class DownloadsProgress:
         self.progress.update(self.previously_completed_files_task_id, total=self.total_files)
         self.progress.update(self.skipped_files_task_id, total=self.total_files)
         self.progress.update(self.failed_files_task_id, total=self.total_files)
-        self.panel.subtitle = f"Total Files: [white]{self.total_files}"
+        self.panel.subtitle = f"Total Files: [white]{self.total_files:,}"
 
     def add_completed(self) -> None:
         """Adds a completed file to the progress bar."""

--- a/cyberdrop_dl/ui/progress/hash_progress.py
+++ b/cyberdrop_dl/ui/progress/hash_progress.py
@@ -40,7 +40,7 @@ class HashProgress:
         )
 
     def create_generic_progress(self) -> Progress:
-        return Progress("[progress.description]{task.description}", BarColumn(bar_width=None), "{task.completed}")
+        return Progress("[progress.description]{task.description}", BarColumn(bar_width=None), "{task.completed:,}")
 
     def get_renderable(self) -> Panel:
         """Returns the progress bar."""

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -136,8 +136,8 @@ class ScrapeStatsProgress(StatsProgress):
 
 
 def prettify_failure(failure: str) -> str:
-    return split_by_uppercase(failure).capitalize()
+    return " ".join(s.capitalize() for s in split_by_uppercase(failure))
 
 
-def split_by_uppercase(text: str) -> str:
-    return " ".join(re.findall(SPLIT_BY_UPPERCASE_REGEX, text))
+def split_by_uppercase(text: str) -> list[str]:
+    return re.findall(SPLIT_BY_UPPERCASE_REGEX, text)

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -61,7 +61,7 @@ class StatsProgress:
             BarColumn(bar_width=None),
             "[progress.percentage]{task.percentage:>6.2f}%",
             "━",
-            "{task.completed}",
+            "{task.completed:,}",
         )
         self.progress_group = Group(self.progress)
         self.failure_types: dict[str, TaskID] = {}

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import re
 from typing import NamedTuple
 
 from rich.console import Group
 from rich.panel import Panel
 from rich.progress import BarColumn, Progress, TaskID
+
+SPLIT_BY_UPPERCASE_REGEX = re.compile(r"[A-Z][a-z]*|[a-z]+|\d+")
 
 
 class TaskInfo(NamedTuple):
@@ -88,6 +91,7 @@ class StatsProgress:
     def add_failure(self, failure_type: str) -> None:
         """Adds a failed file to the progress bar."""
         self.failed_files += 1
+        failure_type = prettify_failure(failure_type)
         if failure_type in self.failure_types:
             self.progress.advance(self.failure_types[failure_type], 1)
         else:
@@ -129,3 +133,11 @@ class ScrapeStatsProgress(StatsProgress):
             self.sent_to_jdownloader += 1
         else:
             self.unsupported_urls_skipped += 1
+
+
+def prettify_failure(failure: str) -> str:
+    return split_by_uppercase(failure).capitalize()
+
+
+def split_by_uppercase(text: str) -> str:
+    return " ".join(re.findall(SPLIT_BY_UPPERCASE_REGEX, text))

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 from typing import NamedTuple
 
 from rich.console import Group
@@ -132,6 +133,7 @@ class ScrapeStatsProgress(StatsProgress):
             self.unsupported_urls_skipped += 1
 
 
+@lru_cache
 def prettify_failure(failure: str) -> str:
     return " ".join(s.capitalize() for s in split_by_uppercase(failure))
 

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from http import HTTPStatus
 from typing import NamedTuple
 
 from rich.console import Group
@@ -9,14 +8,14 @@ from rich.progress import BarColumn, Progress, TaskID
 
 
 class TaskInfo(NamedTuple):
-    id: int
+    id: TaskID
     description: str
     completed: int
     total: int
     progress: float
 
 
-def get_tasks_info_sorted(progress: Progress) -> tuple:
+def get_tasks_info_sorted(progress: Progress) -> tuple[list[TaskInfo], bool]:
     tasks = [
         TaskInfo(
             id=task.id,
@@ -33,8 +32,10 @@ def get_tasks_info_sorted(progress: Progress) -> tuple:
     return tasks_sorted, were_sorted
 
 
-class DownloadStatsProgress:
-    """Class that keeps track of download failures and reasons."""
+class StatsProgress:
+    """Base Class that keeps track of failures and reasons."""
+
+    title = "Download Failures"
 
     def __init__(self) -> None:
         self.progress = Progress(
@@ -45,19 +46,19 @@ class DownloadStatsProgress:
             "{task.completed}",
         )
         self.progress_group = Group(self.progress)
-
         self.failure_types: dict[str, TaskID] = {}
         self.failed_files = 0
-        self.unsupported_urls = 0
-        self.sent_to_jdownloader = 0
-        self.unsupported_urls_skipped = 0
         self.panel = Panel(
             self.progress_group,
-            title="Download Failures",
+            title=self.title,
             border_style="green",
             padding=(1, 1),
-            subtitle=f"Total Download Failures: [white]{self.failed_files}",
+            subtitle=self.subtitle,
         )
+
+    @property
+    def subtitle(self) -> str:
+        return f"Total {self.title}: [white]{self.failed_files}"
 
     def get_progress(self) -> Panel:
         """Returns the progress bar."""
@@ -65,33 +66,28 @@ class DownloadStatsProgress:
 
     def update_total(self, total: int) -> None:
         """Updates the total number download failures."""
-        self.panel.subtitle = f"Total Download Failures: [white]{self.failed_files}"
+        self.panel.subtitle = self.subtitle
         for key in self.failure_types:
             self.progress.update(self.failure_types[key], total=total)
 
-        # Sort tasks on UI
         tasks_sorted, were_sorted = get_tasks_info_sorted(self.progress)
-
         if not were_sorted:
-            for task_id in [task.id for task in tasks_sorted]:
-                self.progress.remove_task(task_id)
+            self.sort_tasks(tasks_sorted)
 
-            for task in tasks_sorted:
-                self.failure_types[task.description] = self.progress.add_task(
-                    task.description,
-                    total=task.total,
-                    completed=task.completed,
-                )
+    def sort_tasks(self, tasks_sorted: list[TaskInfo]) -> None:
+        for task_id in [task.id for task in tasks_sorted]:
+            self.progress.remove_task(task_id)
 
-    def add_failure(self, failure_type: str | int) -> None:
+        for task in tasks_sorted:
+            self.failure_types[task.description] = self.progress.add_task(
+                task.description,
+                total=task.total,
+                completed=task.completed,
+            )
+
+    def add_failure(self, failure_type: str) -> None:
         """Adds a failed file to the progress bar."""
         self.failed_files += 1
-        if isinstance(failure_type, int):
-            try:
-                failure_type = f"{failure_type} {HTTPStatus(failure_type).phrase}"
-            except ValueError:
-                failure_type = f"{failure_type} HTTP Error"
-
         if failure_type in self.failure_types:
             self.progress.advance(self.failure_types[failure_type], 1)
         else:
@@ -101,89 +97,6 @@ class DownloadStatsProgress:
                 completed=1,
             )
         self.update_total(self.failed_files)
-
-    def return_totals(self) -> dict:
-        """Returns the total number of failed files."""
-        failures = {}
-        for failure_type, task_id in self.failure_types.items():
-            task = next(task for task in self.progress.tasks if task.id == task_id)
-            failures[failure_type] = task.completed
-        return dict(sorted(failures.items()))
-
-
-class ScrapeStatsProgress:
-    """Class that keeps track of scraping failures and reasons."""
-
-    def __init__(self) -> None:
-        self.progress = Progress(
-            "[progress.description]{task.description}",
-            BarColumn(bar_width=None),
-            "[progress.percentage]{task.percentage:>6.2f}%",
-            "━",
-            "{task.completed}",
-        )
-        self.progress_group = Group(self.progress)
-
-        self.failure_types: dict[str, TaskID] = {}
-        self.failed_files = 0
-        self.unsupported_urls = 0
-        self.sent_to_jdownloader = 0
-        self.unsupported_urls_skipped = 0
-        self.panel = Panel(
-            self.progress_group,
-            title="Scrape Failures",
-            border_style="green",
-            padding=(1, 1),
-            subtitle=f"Total Scrape Failures: [white]{self.failed_files}",
-        )
-
-    def get_progress(self) -> Panel:
-        """Returns the progress bar."""
-        return self.panel
-
-    def update_total(self, total: int) -> None:
-        """Updates the total number of scrape failures."""
-        self.panel.subtitle = f"Total Scrape Failures: [white]{self.failed_files}"
-        for key in self.failure_types:
-            self.progress.update(self.failure_types[key], total=total)
-
-        # Sort tasks on UI
-        tasks_sorted, were_sorted = get_tasks_info_sorted(self.progress)
-
-        if not were_sorted:
-            for task_id in [task.id for task in tasks_sorted]:
-                self.progress.remove_task(task_id)
-
-            for task in tasks_sorted:
-                self.failure_types[task.description] = self.progress.add_task(
-                    task.description,
-                    total=task.total,
-                    completed=task.completed,
-                )
-
-    def add_failure(self, failure_type: str | int) -> None:
-        """Adds a failed site to the progress bar."""
-        self.failed_files += 1
-        if isinstance(failure_type, int):
-            failure_type = str(failure_type) + " HTTP Status"
-
-        if failure_type in self.failure_types:
-            self.progress.advance(self.failure_types[failure_type], 1)
-        else:
-            self.failure_types[failure_type] = self.progress.add_task(
-                failure_type,
-                total=self.failed_files,
-                completed=1,
-            )
-        self.update_total(self.failed_files)
-
-    def add_unsupported(self, sent_to_jdownloader: bool = False) -> None:
-        """Adds an unsupported url to the progress bar."""
-        self.unsupported_urls += 1
-        if sent_to_jdownloader:
-            self.sent_to_jdownloader += 1
-        else:
-            self.unsupported_urls_skipped += 1
 
     def return_totals(self) -> dict:
         """Returns the total number of failed sites and reasons."""
@@ -192,3 +105,27 @@ class ScrapeStatsProgress:
             task = next(task for task in self.progress.tasks if task.id == task_id)
             failures[failure_type] = task.completed
         return dict(sorted(failures.items()))
+
+
+class DownloadStatsProgress(StatsProgress):
+    """Class that keeps track of download failures and reasons."""
+
+
+class ScrapeStatsProgress(StatsProgress):
+    """Class that keeps track of scraping failures and reasons."""
+
+    title = "Scrape Failures"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.unsupported_urls = 0
+        self.sent_to_jdownloader = 0
+        self.unsupported_urls_skipped = 0
+
+    def add_unsupported(self, sent_to_jdownloader: bool = False) -> None:
+        """Adds an unsupported url to the progress bar."""
+        self.unsupported_urls += 1
+        if sent_to_jdownloader:
+            self.sent_to_jdownloader += 1
+        else:
+            self.unsupported_urls_skipped += 1


### PR DESCRIPTION
Wait for a new release before merging this
***
- Create a base `StatsProgress` class for both download and scrape failures, to reduce code duplication
- Prettify failures by splitting them and capitalizing them if necessary (ex: `ClientConnectorError` - > `Client Connector Error`)
- Change the way some stats are printed
- Use thousand separator for number in stats
- Resolves #476 

## TODO
- [x] Use thousand separator for all numbers in the UI
- [x] Get error code from failures before printing them

