### PR TITLE
fix: delete invalid database rows on startup

### DIFF
--- a/cyberdrop_dl/managers/db_manager.py
+++ b/cyberdrop_dl/managers/db_manager.py
@@ -45,6 +45,12 @@ class DBManager:
         await self.history_table.startup()
         await self.hash_table.startup()
         await self.temp_referer_table.startup()
+        await self.run_fixes()
+
+    async def run_fixes(self):
+        if not self.manager.cache_manager.get("fixed_empty_download_filenames"):
+            await self.history_table.delete_invalid_rows()
+            self.manager.cache_manager.save("fixed_empty_download_filenames", True)
 
     async def close(self) -> None:
         """Close the DBManager."""

--- a/cyberdrop_dl/utils/database/tables/history_table.py
+++ b/cyberdrop_dl/utils/database/tables/history_table.py
@@ -50,6 +50,12 @@ class HistoryTable:
         await cursor.execute(query)
         await self.db_conn.commit()
 
+    async def delete_invalid_rows(self) -> None:
+        query = """DELETE FROM media WHERE download_filename = '' """
+        cursor = await self.db_conn.cursor()
+        await cursor.execute(query)
+        await self.db_conn.commit()
+
     async def check_complete(self, domain: str, url: URL, referer: URL) -> bool:
         """Checks whether an individual file has completed given its domain and url path."""
         if self.ignore_history:


### PR DESCRIPTION
Previously downloaded media files will never be updated so it better to just delete them

- Related to #522