### PR TITLE
feat: allow downloads of files with no extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Iceyfile.com support
 - Support cookie extraction from Arc Browser, Lynx and W3M
-- `exclude_files_with_no_extension` option: https://script-ware.gitbook.io/cyberdrop-dl/reference/configuration-options/settings/ignore_options#exclude_files_with_no_extension
+- `--exclude-files-with-no-extension` option: https://script-ware.gitbook.io/cyberdrop-dl/reference/configuration-options/settings/ignore_options#exclude_files_with_no_extension
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Iceyfile.com support
 - Support cookie extraction from Arc Browser, Lynx and W3M
+- `exclude_files_with_no_extension` option: https://script-ware.gitbook.io/cyberdrop-dl/reference/configuration-options/settings/ignore_options#exclude_files_with_no_extension
 
 ### Removed
 

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -270,7 +270,7 @@ class DownloadClient:
     async def add_file_size(self, domain: str, media_item: MediaItem) -> None:
         if not media_item.complete_file:
             media_item.complete_file = self.get_file_location(media_item)
-        if media_item.complete_file.exists():
+        if media_item.complete_file.is_file():
             await self.manager.db_manager.history_table.add_filesize(domain, media_item)
 
     async def handle_media_item_completion(self, media_item: MediaItem, downloaded: bool = False) -> None:
@@ -372,7 +372,7 @@ class DownloadClient:
         """Iterates the filename until it is unique."""
         partial_file = None
         for iteration in itertools.count(1):
-            filename = f"{complete_file.stem} ({iteration}){media_item.ext}"
+            filename = f"{complete_file.stem} ({iteration}){complete_file.suffix}"
             temp_complete_file = media_item.download_folder / filename
             if (
                 not temp_complete_file.exists()

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -54,6 +54,13 @@ class NoExtensionError(CDLBaseError):
         super().__init__(ui_message, message=message, origin=origin)
 
 
+class InvalidExtensionError(NoExtensionError):
+    def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
+        """This error will be thrown when no extension is given for a file."""
+        super().__init__(message=message, origin=origin)
+        self.ui_message = "Invalid File Extension"
+
+
 class PasswordProtectedError(CDLBaseError):
     def __init__(self, message: str | None = None, *, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when a file is password protected."""

--- a/cyberdrop_dl/config_definitions/config_settings.py
+++ b/cyberdrop_dl/config_definitions/config_settings.py
@@ -111,6 +111,7 @@ class IgnoreOptions(BaseModel):
     skip_hosts: list[NonEmptyStr] = []
     only_hosts: list[NonEmptyStr] = []
     filename_regex_filter: NonEmptyStr | None = None
+    exclude_files_with_no_extension: bool = True
 
     @field_validator("skip_hosts", "only_hosts", mode="before")
     @classmethod

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -107,7 +107,7 @@ async def post_runtime(manager: Manager) -> None:
         sorter = Sorter(manager)
         await sorter.run()
 
-    await check_partials_and_empty_folders(manager)
+    check_partials_and_empty_folders(manager)
 
     if manager.config_manager.settings_data.runtime_options.update_last_forum_post:
         await manager.log_manager.update_last_forum_post()

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from dataclasses import field
 from datetime import datetime
 from functools import wraps
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 from aiolimiter import AsyncLimiter
@@ -16,7 +17,7 @@ from cyberdrop_dl.downloader.downloader import Downloader
 from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem, ScrapeItem
 from cyberdrop_dl.utils.database.tables.history_table import get_db_path
 from cyberdrop_dl.utils.logger import log
-from cyberdrop_dl.utils.utilities import get_download_path, remove_file_id
+from cyberdrop_dl.utils.utilities import get_download_path, get_filename_and_ext, remove_file_id
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -59,6 +60,18 @@ class Crawler(ABC):
     @property
     def allow_no_extension(self) -> bool:
         return not self.manager.config_manager.settings_data.ignore_options.exclude_files_with_no_extension
+
+    def get_filename_and_ext(self, filename: str, *args, assume_ext: str | None = None, **kwargs):
+        """Wrapper around `utils.get_filename_and_ext` to suppress `NoExtensionError` if `asumme_ext` is supplied.
+
+        Does nothing unless `ignore_options.exclude_files_with_no_extension` is `False`
+        """
+        filename_as_path = Path(filename)
+        if assume_ext and self.allow_no_extension and not filename_as_path.suffix:
+            filename_as_path = filename_as_path.with_suffix(assume_ext)
+            new_filename, ext = get_filename_and_ext(filename_as_path.name, *args, *kwargs)
+            return Path(new_filename).stem, ext
+        return get_filename_and_ext(filename, *args, *kwargs)
 
     async def startup(self) -> None:
         """Starts the crawler."""

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -110,14 +110,7 @@ class Crawler(ABC):
             original_filename = filename
 
         download_folder = get_download_path(self.manager, scrape_item, self.folder_domain)
-        media_item = MediaItem(
-            url,
-            scrape_item,
-            download_folder,
-            filename,
-            original_filename,
-            debrid_link,
-        )
+        media_item = MediaItem(url, scrape_item, download_folder, filename, original_filename, debrid_link, ext)
 
         check_complete = await self.manager.db_manager.history_table.check_complete(self.domain, url, scrape_item.url)
         if check_complete:

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -56,6 +56,10 @@ class Crawler(ABC):
         self.scraped_items: list = []
         self.waiting_items = 0
 
+    @property
+    def allow_no_extension(self) -> bool:
+        return not self.manager.config_manager.settings_data.ignore_options.exclude_files_with_no_extension
+
     async def startup(self) -> None:
         """Starts the crawler."""
         async with self.startup_lock:

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -78,7 +78,7 @@ class BunkrrCrawler(Crawler):
         """Scrapes an album."""
         if not scrape_item.url:
             return
-        allow_no_extension = self.manager.config_manager.settings_data.ignore_options.exclude_files_with_no_extension
+
         scrape_item.url = self.primary_base_domain.with_path(scrape_item.url.path)
         album_id = scrape_item.url.parts[2]
         scrape_item.album_id = album_id
@@ -123,8 +123,8 @@ class BunkrrCrawler(Crawler):
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             else:
-                src_filename, ext = get_filename_and_ext(src.name, allow_no_extension=allow_no_extension)
-                filename, _ = get_filename_and_ext(filename, allow_no_extension=allow_no_extension)
+                src_filename, ext = get_filename_and_ext(src.name, allow_no_extension=self.allow_no_extension)
+                filename, _ = get_filename_and_ext(filename, allow_no_extension=self.allow_no_extension)
                 if not self.check_album_results(src, results):
                     await self.handle_file(src, new_scrape_item, src_filename, ext, custom_filename=filename)
 
@@ -182,7 +182,6 @@ class BunkrrCrawler(Crawler):
         If `link` is not supplied, `scrape_item.url` will be used by default
 
         `fallback_filename` will only be used if the link has not `n` query parameter"""
-        allow_no_extension = self.manager.config_manager.settings_data.ignore_options.exclude_files_with_no_extension
         link = url or scrape_item.url
         if self.is_reinforced_link(link):
             link: URL = await self.handle_reinforced_link(link, scrape_item)
@@ -192,7 +191,7 @@ class BunkrrCrawler(Crawler):
         try:
             src_filename, ext = get_filename_and_ext(link.name)
         except NoExtensionError:
-            src_filename, ext = get_filename_and_ext(scrape_item.url.name, allow_no_extension=allow_no_extension)
+            src_filename, ext = get_filename_and_ext(scrape_item.url.name, allow_no_extension=self.allow_no_extension)
         filename = link.query.get("n") or fallback_filename
         if not url:
             scrape_item = self.create_scrape_item(scrape_item, URL("https://get.bunkrr.su/"))

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -12,7 +12,7 @@ from cyberdrop_dl.scraper.crawler import Crawler, create_task_id
 from cyberdrop_dl.utils.constants import FILE_FORMATS
 from cyberdrop_dl.utils.data_enums_classes.url_objects import FILE_HOST_ALBUM, ScrapeItem
 from cyberdrop_dl.utils.logger import log
-from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.utils.utilities import error_handling_wrapper
 
 if TYPE_CHECKING:
     from bs4 import BeautifulSoup, Tag
@@ -123,8 +123,8 @@ class BunkrrCrawler(Crawler):
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             else:
-                src_filename, ext = get_filename_and_ext(src.name, allow_no_extension=self.allow_no_extension)
-                filename, _ = get_filename_and_ext(filename, allow_no_extension=self.allow_no_extension)
+                src_filename, ext = self.get_filename_and_ext(src.name, assume_ext=".mp4")
+                filename, _ = self.get_filename_and_ext(filename, assume_ext=".mp4")
                 if not self.check_album_results(src, results):
                     await self.handle_file(src, new_scrape_item, src_filename, ext, custom_filename=filename)
 
@@ -189,9 +189,9 @@ class BunkrrCrawler(Crawler):
         if not link:
             return
         try:
-            src_filename, ext = get_filename_and_ext(link.name)
+            src_filename, ext = self.get_filename_and_ext(link.name)
         except NoExtensionError:
-            src_filename, ext = get_filename_and_ext(scrape_item.url.name, allow_no_extension=self.allow_no_extension)
+            src_filename, ext = self.get_filename_and_ext(scrape_item.url.name, assume_ext=".mp4")
         filename = link.query.get("n") or fallback_filename
         if not url:
             scrape_item = self.create_scrape_item(scrape_item, URL("https://get.bunkrr.su/"))

--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -123,8 +123,8 @@ class BunkrrCrawler(Crawler):
                 self.manager.task_group.create_task(self.run(new_scrape_item))
 
             else:
-                src_filename, ext = get_filename_and_ext(src.name, raise_error=allow_no_extension)
-                filename, _ = get_filename_and_ext(filename, raise_error=allow_no_extension)
+                src_filename, ext = get_filename_and_ext(src.name, allow_no_extension=allow_no_extension)
+                filename, _ = get_filename_and_ext(filename, allow_no_extension=allow_no_extension)
                 if not self.check_album_results(src, results):
                     await self.handle_file(src, new_scrape_item, src_filename, ext, custom_filename=filename)
 
@@ -192,7 +192,7 @@ class BunkrrCrawler(Crawler):
         try:
             src_filename, ext = get_filename_and_ext(link.name)
         except NoExtensionError:
-            src_filename, ext = get_filename_and_ext(scrape_item.url.name, raise_error=allow_no_extension)
+            src_filename, ext = get_filename_and_ext(scrape_item.url.name, allow_no_extension=allow_no_extension)
         filename = link.query.get("n") or fallback_filename
         if not url:
             scrape_item = self.create_scrape_item(scrape_item, URL("https://get.bunkrr.su/"))

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -106,6 +106,7 @@ class GoFileCrawler(Crawler):
     async def handle_children(self, children: dict, scrape_item: ScrapeItem) -> None:
         """Sends files to downloader and adds subfolder to scrape queue."""
         subfolders = []
+        allow_no_extension = self.manager.config_manager.settings_data.ignore_options.exclude_files_with_no_extension
         for child in children.values():
             if child["type"] == "folder":
                 folder_url = self.primary_base_domain / "d" / child["code"]
@@ -118,7 +119,7 @@ class GoFileCrawler(Crawler):
 
             link = self.parse_url(link_str)
             date = child["createTime"]
-            filename, ext = get_filename_and_ext(link.name)
+            filename, ext = get_filename_and_ext(link.name, raise_error=allow_no_extension)
             new_scrape_item = self.create_scrape_item(scrape_item, scrape_item.url, possible_datetime=date)
             await self.handle_file(link, new_scrape_item, filename, ext)
             scrape_item.add_children()

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -119,7 +119,7 @@ class GoFileCrawler(Crawler):
 
             link = self.parse_url(link_str)
             date = child["createTime"]
-            filename, ext = get_filename_and_ext(link.name, raise_error=allow_no_extension)
+            filename, ext = get_filename_and_ext(link.name, allow_no_extension=allow_no_extension)
             new_scrape_item = self.create_scrape_item(scrape_item, scrape_item.url, possible_datetime=date)
             await self.handle_file(link, new_scrape_item, filename, ext)
             scrape_item.add_children()

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -106,7 +106,6 @@ class GoFileCrawler(Crawler):
     async def handle_children(self, children: dict, scrape_item: ScrapeItem) -> None:
         """Sends files to downloader and adds subfolder to scrape queue."""
         subfolders = []
-        allow_no_extension = self.manager.config_manager.settings_data.ignore_options.exclude_files_with_no_extension
         for child in children.values():
             if child["type"] == "folder":
                 folder_url = self.primary_base_domain / "d" / child["code"]
@@ -119,7 +118,7 @@ class GoFileCrawler(Crawler):
 
             link = self.parse_url(link_str)
             date = child["createTime"]
-            filename, ext = get_filename_and_ext(link.name, allow_no_extension=allow_no_extension)
+            filename, ext = get_filename_and_ext(link.name, allow_no_extension=self.allow_no_extension)
             new_scrape_item = self.create_scrape_item(scrape_item, scrape_item.url, possible_datetime=date)
             await self.handle_file(link, new_scrape_item, filename, ext)
             scrape_item.add_children()

--- a/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/gofile_crawler.py
@@ -12,7 +12,7 @@ from yarl import URL
 from cyberdrop_dl.clients.errors import DownloadError, PasswordProtectedError, ScrapeError
 from cyberdrop_dl.scraper.crawler import Crawler, create_task_id
 from cyberdrop_dl.utils.data_enums_classes.url_objects import FILE_HOST_ALBUM, ScrapeItem
-from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.utils.utilities import error_handling_wrapper
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -118,7 +118,7 @@ class GoFileCrawler(Crawler):
 
             link = self.parse_url(link_str)
             date = child["createTime"]
-            filename, ext = get_filename_and_ext(link.name, allow_no_extension=self.allow_no_extension)
+            filename, ext = self.get_filename_and_ext(link.name, assume_ext=".mp4")
             new_scrape_item = self.create_scrape_item(scrape_item, scrape_item.url, possible_datetime=date)
             await self.handle_file(link, new_scrape_item, filename, ext)
             scrape_item.add_children()

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -29,6 +29,7 @@ This is not a bug. Do not open issues related to this"""
 RAR_MULTIPART_PATTERN = re.compile(r"^part\d+")
 SANITIZE_FILENAME_PATTERN = re.compile(r'[<>:"/\\|?*\']')
 REGEX_LINKS = re.compile(r"(?:http.*?)(?=($|\n|\r\n|\r|\s|\"|\[/URL]|']\[|]\[|\[/img]))")
+DEFAULT_FILE_EXT = ".mp4"
 
 
 class CustomHTTPStatus(IntEnum):

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -29,7 +29,6 @@ This is not a bug. Do not open issues related to this"""
 RAR_MULTIPART_PATTERN = re.compile(r"^part\d+")
 SANITIZE_FILENAME_PATTERN = re.compile(r'[<>:"/\\|?*\']')
 REGEX_LINKS = re.compile(r"(?:http.*?)(?=($|\n|\r\n|\r|\s|\"|\[/URL]|']\[|]\[|\[/img]))")
-DEFAULT_FILE_EXT = ".mp4"
 
 
 class CustomHTTPStatus(IntEnum):

--- a/cyberdrop_dl/utils/data_enums_classes/url_objects.py
+++ b/cyberdrop_dl/utils/data_enums_classes/url_objects.py
@@ -37,6 +37,7 @@ class MediaItem:
     filename: str
     original_filename: str | None = None
     debrid_link: URL | None = field(default=None, hash=False, compare=False)
+    ext: str = ""
 
     # exclude from __init__
     file_lock_reference_name: str | None = field(default=None, init=False)
@@ -50,14 +51,13 @@ class MediaItem:
     # slots for __post_init__
     referer: URL = field(init=False)
     album_id: str | None = field(init=False)
-    ext: str = field(init=False)
     datetime: int | None = field(init=False, hash=False, compare=False)
     parents: list[URL] = field(init=False, hash=False, compare=False)
 
     def __post_init__(self, origin: ScrapeItem) -> None:
         self.referer = origin.url
         self.album_id = origin.album_id
-        self.ext = Path(self.filename).suffix
+        self.ext = self.ext or Path(self.filename).suffix
         self.original_filename = self.original_filename or self.filename
         self.parents = origin.parents.copy()
         self.datetime = origin.possible_datetime

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -113,13 +113,10 @@ def truncate_str(text: str, max_length: int = 0) -> str:
     return text.strip()
 
 
-def get_filename_and_ext(filename: str, forum: bool = False, *, allow_no_extension: bool = True) -> tuple[str, str]:
+def get_filename_and_ext(filename: str, forum: bool = False) -> tuple[str, str]:
     """Returns the filename and extension of a given file, throws `NoExtensionError` if there is no extension."""
     filename_as_path = Path(filename)
     if not filename_as_path.suffix:
-        if not allow_no_extension:
-            new_filename, ext = get_filename_and_ext(filename + constants.DEFAULT_FILE_EXT)
-            return Path(new_filename).stem, ext
         raise NoExtensionError
     if filename_as_path.suffix.isnumeric() and forum:
         name, ext = filename_as_path.name.rsplit("-", 1)

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -18,7 +18,7 @@ from rich.text import Text
 from yarl import URL
 
 from cyberdrop_dl import __version__ as current_version
-from cyberdrop_dl.clients.errors import CDLBaseError, NoExtensionError
+from cyberdrop_dl.clients.errors import CDLBaseError, InvalidExtensionError, NoExtensionError
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.logger import log, log_debug, log_spacer, log_with_color
 
@@ -125,7 +125,7 @@ def get_filename_and_ext(filename: str, forum: bool = False, raise_error: bool =
         name, ext = filename_as_path.name.rsplit("-", 1)
         filename_as_path = Path(f"{name}.{ext}")
     if len(filename_as_path.suffix) > 5:
-        raise NoExtensionError
+        raise InvalidExtensionError
 
     filename_as_path = filename_as_path.with_suffix(filename_as_path.suffix.lower())
     filename_as_path = Path(truncate_str(filename_as_path.stem.removesuffix(".")) + filename_as_path.suffix)

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -113,11 +113,11 @@ def truncate_str(text: str, max_length: int = 0) -> str:
     return text.strip()
 
 
-def get_filename_and_ext(filename: str, forum: bool = False, raise_error: bool = True) -> tuple[str, str]:
+def get_filename_and_ext(filename: str, forum: bool = False, *, allow_no_extension: bool = True) -> tuple[str, str]:
     """Returns the filename and extension of a given file, throws `NoExtensionError` if there is no extension."""
     filename_as_path = Path(filename)
     if not filename_as_path.suffix:
-        if not raise_error:
+        if not allow_no_extension:
             new_filename, ext = get_filename_and_ext(filename + constants.DEFAULT_FILE_EXT)
             return Path(new_filename).stem, ext
         raise NoExtensionError

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -128,8 +128,8 @@ def get_filename_and_ext(filename: str, forum: bool = False, *, allow_no_extensi
         raise InvalidExtensionError
 
     filename_as_path = filename_as_path.with_suffix(filename_as_path.suffix.lower())
-    filename_as_path = Path(truncate_str(filename_as_path.stem.removesuffix(".")) + filename_as_path.suffix)
-    filename_as_path = Path(sanitize_filename(filename_as_path.name))
+    filename_as_str = truncate_str(filename_as_path.stem.removesuffix(".")) + filename_as_path.suffix
+    filename_as_path = Path(sanitize_filename(filename_as_str))
     return filename_as_path.name, filename_as_path.suffix
 
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -6,7 +6,7 @@ import os
 import platform
 import re
 import subprocess
-from functools import wraps
+from functools import partial, wraps
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
     from cyberdrop_dl.scraper.crawler import Crawler
     from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem, ScrapeItem
+
+
+subprocess_get_text = partial(subprocess.run, capture_output=True, text=True, check=False)
 
 
 def error_handling_wrapper(func: Callable) -> Callable:
@@ -92,32 +95,37 @@ def sanitize_folder(title: str) -> str:
     title = title.rstrip(".").strip()
 
     if all(char in title for char in ("(", ")")):
-        new_title = title.rsplit("(")[0].strip()
-        new_title = new_title[: constants.MAX_NAME_LENGTHS["FOLDER"]].strip()
-        domain_part = title.rsplit("(")[1].strip()
-        title = f"{new_title} ({domain_part}"
-    else:
-        title = title[: constants.MAX_NAME_LENGTHS["FOLDER"]].strip()
-    return title
+        new_title, domain_part = title.rsplit("(", 1)
+        new_title = truncate_str(new_title, constants.MAX_NAME_LENGTHS["FOLDER"])
+        return f"{new_title} ({domain_part.strip()}"
+    return truncate_str(title, constants.MAX_NAME_LENGTHS["FOLDER"])
+
+
+def truncate_str(text: str, max_length: int = 0) -> str:
+    """Truncates and strip strings to the desired len.
+
+    If `max_length` is 0, uses `constants.MAX_NAME_LENGTHS["FILE"]`"""
+    truncate_to = max_length or constants.MAX_NAME_LENGTHS["FILE"]
+    if len(text) > truncate_to:
+        return text[:truncate_to].strip()
+    return text.strip()
 
 
 def get_filename_and_ext(filename: str, forum: bool = False) -> tuple[str, str]:
     """Returns the filename and extension of a given file, throws `NoExtensionError` if there is no extension."""
-    filename_parts = filename.rsplit(".", 1)
-    if len(filename_parts) == 1:
+    filename_as_path = Path(filename)
+    if not filename_as_path.suffix:
         raise NoExtensionError
-    if filename_parts[-1].isnumeric() and forum:
-        filename_parts = filename_parts[0].rsplit("-", 1)
-    if len(filename_parts[-1]) > 5:
+    if filename_as_path.suffix.isnumeric() and forum:
+        name, ext = filename_as_path.name.rsplit("-", 1)
+        filename_as_path = Path(name + ext)
+    if len(filename_as_path.suffix) > 5:
         raise NoExtensionError
-    ext = "." + filename_parts[-1].lower()
-    filename = filename_parts[0]
-    if len(filename) > constants.MAX_NAME_LENGTHS["FILE"]:
-        filename = filename_parts[0][: constants.MAX_NAME_LENGTHS["FILE"]]
 
-    filename = filename.strip().rstrip(".")
-    filename = sanitize_filename(filename + ext)
-    return filename, ext
+    filename_as_path = filename_as_path.with_suffix(filename_as_path.suffix.lower())
+    filename_as_path = Path(truncate_str(filename_as_path.stem.removesuffix(".")) + filename_as_path.suffix)
+    filename_as_path = Path(sanitize_filename(filename_as_path.name))
+    return filename_as_path.name, filename_as_path.suffix
 
 
 def get_download_path(manager: Manager, scrape_item: ScrapeItem, domain: str) -> Path:
@@ -167,7 +175,7 @@ def parse_rich_text_by_style(text: Text, style_map: dict, default_style_map_key:
     plain_text = ""
     for span in text.spans:
         span_text = text.plain[span.start : span.end].rstrip("\n")
-        plain_line: str = style_map.get(span.style) or style_map.get(default_style_map_key)
+        plain_line: str | None = style_map.get(span.style) or style_map.get(default_style_map_key)
         if plain_line:
             plain_text += plain_line.format(span_text) + "\n"
 
@@ -186,28 +194,38 @@ def purge_dir_tree(dirname: Path) -> None:
             dir_to_remove.rmdir()
 
 
-async def check_partials_and_empty_folders(manager: Manager) -> None:
-    """Checks for partial downloads and empty folders."""
-    if manager.config_manager.settings_data.runtime_options.delete_partial_files:
-        log_with_color("Deleting partial downloads...", "bold_red", 20)
-        partial_downloads = manager.path_manager.download_folder.rglob("*.part")
-        for file in partial_downloads:
-            file.unlink(missing_ok=True)
+def check_partials_and_empty_folders(manager: Manager) -> None:
+    """Checks for partial downloads, deletes partial files and empty folders."""
+    delete_partial_files(manager)
+    check_for_partial_files(manager)
+    delete_empty_folders(manager)
 
-    elif not manager.config_manager.settings_data.runtime_options.skip_check_for_partial_files:
-        log_with_color("Checking for partial downloads...", "yellow", 20)
-        partial_downloads = any(manager.path_manager.download_folder.rglob("*.part"))
-        if partial_downloads:
-            log_with_color("There are partial downloads in the downloads folder", "yellow", 20)
 
-    if not manager.config_manager.settings_data.runtime_options.skip_check_for_empty_folders:
-        log_with_color("Checking for empty folders...", "yellow", 20)
-        purge_dir_tree(manager.path_manager.download_folder)
-        if (
-            isinstance(manager.path_manager.sorted_folder, Path)
-            and manager.config_manager.settings_data.sorting.sort_downloads
-        ):
-            purge_dir_tree(manager.path_manager.sorted_folder)
+def delete_partial_files(manager: Manager) -> None:
+    if not manager.config_manager.settings_data.runtime_options.delete_partial_files:
+        return
+    log_red("Deleting partial downloads...")
+    partial_downloads = manager.path_manager.download_folder.rglob("*.part")
+    for file in partial_downloads:
+        file.unlink(missing_ok=True)
+
+
+def check_for_partial_files(manager: Manager):
+    if manager.config_manager.settings_data.runtime_options.skip_check_for_partial_files:
+        return
+    log_yellow("Checking for partial downloads...")
+    partial_downloads = any(manager.path_manager.download_folder.rglob("*.part"))
+    if partial_downloads:
+        log_yellow("There are partial downloads in the downloads folder")
+
+
+def delete_empty_folders(manager: Manager):
+    if manager.config_manager.settings_data.runtime_options.skip_check_for_empty_folders:
+        return
+    log_yellow("Checking for empty folders...")
+    purge_dir_tree(manager.path_manager.download_folder)
+    if manager.path_manager.sorted_folder and manager.config_manager.settings_data.sorting.sort_downloads:
+        purge_dir_tree(manager.path_manager.sorted_folder)
 
 
 def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -> tuple[str, str]:
@@ -222,8 +240,8 @@ def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -
 
     data: dict[str, dict] = json.loads(contents)
     latest_version: str = data["info"]["version"]
-    releases = data["releases"].keys()
-    message = color = None
+    releases = list(data["releases"].keys())
+    color = ""
     level = 30
     is_prerelease, latest_testing_version, message = check_prelease_version(current_version, releases)
 
@@ -234,8 +252,8 @@ def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -
         latest_version = latest_testing_version
         color = "bold_red"
     elif current_version != latest_version:
-        message = f"A new version of Cyberdrop-DL is available: [cyan]{latest_version}[/cyan]"
-        message = Text.from_markup(message)
+        message_mkup = f"A new version of Cyberdrop-DL is available: [cyan]{latest_version}[/cyan]"
+        message = Text.from_markup(message_mkup)
     else:
         message = Text.from_markup("You are currently on the latest version of Cyberdrop-DL :white_check_mark:")
         level = 20
@@ -248,9 +266,9 @@ def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -
     return current_version, latest_version
 
 
-def check_prelease_version(current_version: str, releases: list[str]) -> tuple[str, Text]:
+def check_prelease_version(current_version: str, releases: list[str]) -> tuple[bool, str, Text]:
     match = re.match(constants.PRELEASE_VERSION_PATTERN, current_version)
-    latest_testing_version = message = None
+    latest_testing_version = ""
 
     if constants.RUNNING_PRERELEASE and match:
         major_version, minor_version, patch_version, dot_tag, no_dot_tag = match.groups()
@@ -348,31 +366,28 @@ def open_in_text_editor(file_path: Path) -> bool:
 
 
 def set_default_app_if_none(file_path: Path) -> bool:
-    mimetype = subprocess.run(
-        ["xdg-mime", "query", "filetype", str(file_path)],
-        capture_output=True,
-        text=True,
-        check=False,
-    ).stdout.strip()
+    mimetype = xdg_mime_query("filetype", str(file_path))
     if not mimetype:
         return False
 
-    default_app = subprocess.run(
-        ["xdg-mime", "query", "default", mimetype],
-        capture_output=True,
-        text=True,
-        check=False,
-    ).stdout.strip()
+    default_app = xdg_mime_query("default", mimetype)
     if default_app:
         return True
 
-    text_default = subprocess.run(
-        ["xdg-mime", "query", "default", "text/plain"],
-        capture_output=True,
-        text=True,
-        check=False,
-    ).stdout.strip()
+    text_default = xdg_mime_query("default", "text/plain")
     if text_default:
         return subprocess.call(["xdg-mime", "default", text_default, mimetype]) == 0
 
     return False
+
+
+def xdg_mime_query(*args) -> str:
+    assert args
+    arg_list = ["xdg-mime", "query", *args]
+    return subprocess_get_text(arg_list).stdout.strip()
+
+
+log_cyan = partial(log_with_color, style="cyan", level=20)
+log_yellow = partial(log_with_color, style="yellow", level=20)
+log_green = partial(log_with_color, style="green", level=20)
+log_red = partial(log_with_color, style="red", level=20)

--- a/docs/reference/configuration-options/settings/ignore_options.md
+++ b/docs/reference/configuration-options/settings/ignore_options.md
@@ -32,6 +32,18 @@ When this is set to `true`, the program will skip downloading audio files.
 
 When this is set to `true`, the program will skip downloading non media files files.
 
+## `exclude_files_with_no_extension`
+
+| Type                | Default  |
+|---------------------|----------|
+| `bool`              | `true`   |
+
+When this is set to `true`, the program will skip downloading files without an extension.
+
+{% hint style="info" %}
+CDL internally assumes any file without an extension is an `.mp4` file. That means any option that applies to videos like `--exclude-videos` and `--minimum-video-size` will apply to them. The actual file will still be downloaded without an extension
+{% endhint %}
+
 ## `ignore_coomer_ads`
 
 | Type  | Default |


### PR DESCRIPTION
- Split util functions into single responsibility functions
- Use `pathlib.Path` instead of bare strings when possible
- Allow downloading files with no extension
- Resolves #200 

This feature works by just assuming any file without an extension is an `.mp4` file. That means any option that applies to videos like `--exclude-videos` and `--minimum-video-size` will apply to them

The actual file will be downloaded without an extension cause the filename always comes from the`MediaItem.filename` property but the config checks are done with the `MediaItem.ext` property. We are just manually setting `MediaItem.ext` to `.mp4`

There will be a config setting to enable this but it will do nothing by the default. Its needs to be implemented on a per crawler basis by calling `get_filename_and_ext` with `raise_error = False` because a lot of crawlers make assumptions from the extension.

Filenames that have an invalid extension (more than 5 characters) will still trigger an error

## TODO
- [ ] ~~Make `MediaItem.partial_file` a property~~
- [x] Add config toggle (`--skip-downloads-with-no-extension`, defaults to `true`)
- [x] Add to Bunkr crawler
- [x] Add to GoFile crawler