### PR TITLE
fix: attachments downloads + `NoExtensionError` handling (xenforo)

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -315,18 +315,16 @@ class XenforoCrawler(Crawler):
         if not link or link == self.primary_base_domain:
             return
         assert link.host
-        try:
-            if self.is_attachment(link):
-                return await self.handle_internal_link(link, scrape_item)
-            if self.primary_base_domain.host in link.host:  # type: ignore
-                origin = scrape_item.parents[0]
-                return log(f"Skipping nested thread URL {link} found on {origin}", 10)
-            new_scrape_item = self.create_scrape_item(scrape_item, link)
-            new_scrape_item.set_type(None, self.manager)
-            self.handle_external_links(new_scrape_item)
-        except TypeError:
-            log(f"Scrape Failed: encountered while handling {link}", 40)
+        if self.is_attachment(link):
+            return await self.handle_internal_link(link, scrape_item)
+        if self.primary_base_domain.host in link.host:  # type: ignore
+            origin = scrape_item.parents[0]
+            return log(f"Skipping nested thread URL {link} found on {origin}", 10)
+        new_scrape_item = self.create_scrape_item(scrape_item, link)
+        new_scrape_item.set_type(None, self.manager)
+        self.handle_external_links(new_scrape_item)
 
+    @error_handling_wrapper
     async def handle_internal_link(self, link: URL, scrape_item: ScrapeItem) -> None:
         """Handles internal links."""
         filename, ext = get_filename_and_ext(link.name, True)

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -316,9 +316,9 @@ class XenforoCrawler(Crawler):
             return
         assert link.host
         try:
+            if self.is_attachment(link):
+                return await self.handle_internal_link(link, scrape_item)
             if self.primary_base_domain.host in link.host:  # type: ignore
-                if self.is_attachment(link):
-                    return await self.handle_internal_link(link, scrape_item)
                 origin = scrape_item.parents[0]
                 return log(f"Skipping nested thread URL {link} found on {origin}", 10)
             new_scrape_item = self.create_scrape_item(scrape_item, link)

--- a/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/xenforo_crawler.py
@@ -317,7 +317,7 @@ class XenforoCrawler(Crawler):
         assert link.host
         new_scrape_item = self.create_scrape_item(scrape_item, link)
         if self.is_attachment(link):
-            return await self.handle_internal_link(scrape_item)
+            return await self.handle_internal_link(new_scrape_item)
         if self.primary_base_domain.host in link.host:  # type: ignore
             origin = scrape_item.parents[0]
             return log(f"Skipping nested thread URL {link} found on {origin}", 10)


### PR DESCRIPTION
- Supersedes and closes #541 
- Check if the link is an attachment before checking the link host
- Make `handle_internal_link` take an `ScrapeItem` instead of a `link` + `scrape_item`
- Use `error_handling_wrapper` for `handle_internal_link`