### PR TITLE
fix: delete old rows of previously unsupported URLs

### DIFF
--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -37,6 +37,7 @@ class Crawler(ABC):
     domain: str = None  # type: ignore
     primary_base_domain: URL = None  # type: ignore
     DEFAULT_POST_TITLE_FORMAT = "{date} - {number} - {title}"
+    update_unsupported = False
 
     def __init__(self, manager: Manager, domain: str, folder_domain: str | None = None) -> None:
         self.manager = manager

--- a/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/cyberfile_crawler.py
@@ -26,6 +26,7 @@ class CyberfileCrawler(Crawler):
 
     FOLDER_DOMAINS: ClassVar[dict[str, str]] = {"cyberfile": "Cyberfile", "iceyfile": "Iceyfile"}
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {"cyberfile": ["cyberfile"], "iceyfile": ["iceyfile"]}
+    update_unsupported = True
 
     def __init__(self, manager: Manager, site: str) -> None:
         super().__init__(manager, site, self.FOLDER_DOMAINS.get(site, "Cyberfile"))

--- a/cyberdrop_dl/scraper/crawlers/pixhost_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixhost_crawler.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 class PixHostCrawler(Crawler):
     primary_base_domain = URL("https://pixhost.to/")
+    update_unsupported = True
 
     def __init__(self, manager: Manager) -> None:
         super().__init__(manager, "pixhost", "PixHost")

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -80,6 +80,7 @@ class ScrapeMapper:
         self.manager.scrape_mapper = self
         self.manager.client_manager.load_cookie_files()
         self.start_scrapers()
+        await self.manager.db_manager.history_table.update_previously_unsupported(self.existing_crawlers)
         self.start_jdownloader()
         await self.start_real_debrid()
         self.no_crawler_downloader.startup()


### PR DESCRIPTION
I notice this with `--retry-failed`. Some URLs were being marked as previously downloaded immediately, even though they were supposed to have failed

The URLs were duplicated in the database. 1 as `no_crawler` and 1 for the actual crawler.

I only enabled this for Iceyfile and PixHost. I may have missed another crawler that may also need to be updated