### PR TITLE
fix: duplicated entries (pixhost)

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/pixhost_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixhost_crawler.py
@@ -29,7 +29,7 @@ class PixHostCrawler(Crawler):
     @create_task_id
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         """Determines where to send the scrape item based on the url."""
-        if is_thumbnail(scrape_item.url):
+        if is_cdn(scrape_item.url):
             link = scrape_item.url
             scrape_item.url = get_canonical_url(link)
             await self.handle_direct_link(scrape_item, link)
@@ -104,7 +104,12 @@ def thumbnail_to_img(url: URL) -> URL:
 
 def is_thumbnail(url: URL) -> bool:
     assert url.host
-    return "thumbs" in url.parts and len(url.host.split(".")) >= 2
+    return "thumbs" in url.parts and is_cdn(url)
+
+
+def is_cdn(url: URL) -> bool:
+    assert url.host
+    return len(url.host.split(".")) >= 2
 
 
 def get_canonical_url(url: URL) -> URL:

--- a/cyberdrop_dl/scraper/crawlers/pixhost_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/pixhost_crawler.py
@@ -14,8 +14,11 @@ if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
 
 
+PRIMARY_BASE_DOMAIN = URL("https://pixhost.to/")
+
+
 class PixHostCrawler(Crawler):
-    primary_base_domain = URL("https://pixhost.to/")
+    primary_base_domain = PRIMARY_BASE_DOMAIN
     update_unsupported = True
 
     def __init__(self, manager: Manager) -> None:
@@ -27,7 +30,9 @@ class PixHostCrawler(Crawler):
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         """Determines where to send the scrape item based on the url."""
         if is_thumbnail(scrape_item.url):
-            await self.handle_direct_link(scrape_item)
+            link = scrape_item.url
+            scrape_item.url = get_canonical_url(link)
+            await self.handle_direct_link(scrape_item, link)
         elif "gallery" in scrape_item.url.parts:
             await self.gallery(scrape_item)
         elif "show" in scrape_item.url.parts:
@@ -57,15 +62,18 @@ class PixHostCrawler(Crawler):
             if not (thumb_link_str and link_str):
                 continue
             link = self.parse_url(link_str)
+            link = get_canonical_url(link)
             thumb_link = self.parse_url(thumb_link_str)
-            if not self.check_album_results(link, results):
+            src = thumbnail_to_img(thumb_link)
+            if not self.check_album_results(src, results):
                 new_scrape_item = self.create_scrape_item(scrape_item, link, add_parent=scrape_item.url)
-                await self.handle_direct_link(new_scrape_item, thumb_link)
+                await self.handle_direct_link(new_scrape_item, src)
             scrape_item.add_children()
 
     @error_handling_wrapper
     async def image(self, scrape_item: ScrapeItem) -> None:
         """Scrapes an image."""
+
         if await self.check_complete_from_referer(scrape_item):
             return
 
@@ -80,19 +88,27 @@ class PixHostCrawler(Crawler):
     async def handle_direct_link(self, scrape_item: ScrapeItem, url: URL | None = None):
         link = url or scrape_item.url
         if is_thumbnail(link):
-            link = self.thumbnail_to_img(link)
+            link = thumbnail_to_img(link)
         filename, ext = get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)
 
-    def thumbnail_to_img(self, url: URL):
-        assert url.host
-        thumb_server_id: str = url.host.split(".", 1)[0].split("t")[-1]
-        img_host = f"img{thumb_server_id}.{self.primary_base_domain.host}"
-        new_parts = ["images"] + [p for p in url.parts if p not in ("thumbs", "/")]
-        new_path = "/".join(new_parts)
-        return url.with_host(img_host).with_path(new_path)
+
+def thumbnail_to_img(url: URL) -> URL:
+    assert url.host
+    thumb_server_id: str = url.host.split(".", 1)[0].split("t")[-1]
+    img_host = f"img{thumb_server_id}.{PRIMARY_BASE_DOMAIN.host}"
+    new_parts = ["images"] + [p for p in url.parts if p not in ("thumbs", "/")]
+    new_path = "/".join(new_parts)
+    return url.with_host(img_host).with_path(new_path)
 
 
 def is_thumbnail(url: URL) -> bool:
     assert url.host
     return "thumbs" in url.parts and len(url.host.split(".")) >= 2
+
+
+def get_canonical_url(url: URL) -> URL:
+    new_parts = list(url.parts)[1:]
+    new_parts[0] = "show"
+    new_path = "/".join(new_parts)
+    return PRIMARY_BASE_DOMAIN / new_path

--- a/cyberdrop_dl/utils/database/tables/history_table.py
+++ b/cyberdrop_dl/utils/database/tables/history_table.py
@@ -47,7 +47,9 @@ class HistoryTable:
 
     async def update_previously_unsupported(self, crawlers: dict[str, Crawler]) -> None:
         """Update old `no_crawler` entries that are now supported."""
-        domains_to_update = [(c.domain, f"{c.primary_base_domain}%") for c in crawlers.values() if c.update_unsupported]
+        domains_to_update = [
+            (c.domain, f"http%{c.primary_base_domain.host}%") for c in crawlers.values() if c.update_unsupported
+        ]
         if not domains_to_update:
             return
         referers = [(d[1],) for d in domains_to_update]


### PR DESCRIPTION
- Use canonical URL to make sure the referer is always the same (pixhost)
- Handle any kind of cdn as input: thumbs or images (pixhost)
- Never download thumbnails, always download the full res image, even if the input URL is a thumb (pixhost)
- Change `update_unsupported` to also update all possible subdomains in the database (all crawlers)