### PR TITLE
fix: bunkr missed sanitize_filename

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/bunkrr_crawler.py
@@ -210,7 +210,7 @@ class BunkrrCrawler(Crawler):
             src_filename, ext = self.get_filename_and_ext(link.name)
         except NoExtensionError:
             src_filename, ext = self.get_filename_and_ext(scrape_item.url.name, assume_ext=".mp4")
-        filename = link.query.get("n") or fallback_filename
+        filename, _ = self.get_filename_and_ext(link.query.get("n") or fallback_filename)
         if not url:
             referer = referer or URL("https://get.bunkrr.su/")
             scrape_item = self.create_scrape_item(scrape_item, referer)


### PR DESCRIPTION
The refactor fallback_filename from h1 bypasses `utils.sanitize_filename` codepath (which I can't see used directly so running through `get_filename_and_ext`)

fixes 3ff244e630cd39881b1aa96f6b88e4941f55351a