### PR TITLE
fix: handle invalid urls

### DIFF
--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.scraper.crawler import ScrapeItem
     from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem
 
+
 # See: https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/
 CLOUDFLARE_ERRORS = {
     520: "Unexpected Response",
@@ -42,9 +43,7 @@ class CDLBaseError(Exception):
     ) -> None:
         self.ui_message = ui_message
         self.message = message or ui_message
-        self.origin = origin
-        if origin and not isinstance(origin, URL | Path):
-            self.origin = origin.parents[0] if origin.parents else None
+        self.origin = get_origin(origin)
         super().__init__(self.message)
         if status:
             self.status = status
@@ -204,3 +203,9 @@ def create_error_msg(error: int) -> str:
 @create_error_msg.register
 def _(error: str) -> str:
     return error
+
+
+def get_origin(origin: ScrapeItem | Path | MediaItem | URL | None = None) -> Path | URL | None:
+    if origin and not isinstance(origin, URL | Path):
+        return origin.parents[0] if origin.parents else None
+    return origin

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -163,9 +163,12 @@ class ScrapeError(CDLBaseError):
 
 
 class InvalidURLError(ScrapeError):
-    def __init__(self, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
+    def __init__(
+        self, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None, url: URL | str = ""
+    ) -> None:
         """This error will be thrown when parsed URL is not valid."""
         ui_message = "Invalid URL"
+        self.url = url
         super().__init__(ui_message, message=message, origin=origin)
 
 

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -160,8 +160,14 @@ class ScrapeError(CDLBaseError):
     ) -> None:
         """This error will be thrown when a scrape fails."""
         ui_message = create_error_msg(status)
-        msg = message
-        super().__init__(ui_message, message=msg, status=status, origin=origin)
+        super().__init__(ui_message, message=message, status=status, origin=origin)
+
+
+class InvalidURLError(ScrapeError):
+    def __init__(self, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
+        """This error will be thrown when parsed URL is not valid."""
+        ui_message = "Invalid URL"
+        super().__init__(ui_message, message=message, origin=origin)
 
 
 class LoginError(CDLBaseError):

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 from aiolimiter import AsyncLimiter
 from yarl import URL
 
+from cyberdrop_dl.clients.errors import InvalidURLError
 from cyberdrop_dl.downloader.downloader import Downloader
 from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem, ScrapeItem
 from cyberdrop_dl.utils.database.tables.history_table import get_db_path
@@ -270,12 +271,15 @@ class Crawler(ABC):
         scrape_item.add_to_parent_title(title)
 
     def parse_url(self, link_str: str, relative_to: URL | None = None) -> URL:
-        assert link_str
-        assert isinstance(link_str, str)
-        link_str = clean_link_str(link_str)
-        encoded = "%" in link_str
-        base = relative_to or self.primary_base_domain
-        new_url = URL(link_str, encoded=encoded)
+        try:
+            assert link_str
+            assert isinstance(link_str, str)
+            link_str = clean_link_str(link_str)
+            encoded = "%" in link_str
+            base = relative_to or self.primary_base_domain
+            new_url = URL(link_str, encoded=encoded)
+        except (AssertionError, AttributeError, ValueError, TypeError) as e:
+            raise InvalidURLError(str(e)) from e
         if not new_url.absolute:
             new_url = base.join(new_url)
         if not new_url.scheme:

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -279,7 +279,7 @@ class Crawler(ABC):
             base = relative_to or self.primary_base_domain
             new_url = URL(link_str, encoded=encoded)
         except (AssertionError, AttributeError, ValueError, TypeError) as e:
-            raise InvalidURLError(str(e)) from e
+            raise InvalidURLError(str(e), url=link_str) from e
         if not new_url.absolute:
             new_url = base.join(new_url)
         if not new_url.scheme:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -18,7 +18,7 @@ from rich.text import Text
 from yarl import URL
 
 from cyberdrop_dl import __version__ as current_version
-from cyberdrop_dl.clients.errors import CDLBaseError, InvalidExtensionError, NoExtensionError
+from cyberdrop_dl.clients.errors import CDLBaseError, InvalidExtensionError, NoExtensionError, get_origin
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.logger import log, log_debug, log_spacer, log_with_color
 
@@ -47,7 +47,7 @@ def error_handling_wrapper(func: Callable) -> Callable:
         except CDLBaseError as e:
             log_message_short = e_ui_failure = e.ui_message
             log_message = f"{e.ui_message} - {e.message}" if e.ui_message != e.message else e.message
-            origin = e.origin
+            origin = e.origin or get_origin(item)
         except TimeoutError:
             log_message_short = log_message = e_ui_failure = "Timeout"
         except ClientConnectorError as e:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -18,7 +18,13 @@ from rich.text import Text
 from yarl import URL
 
 from cyberdrop_dl import __version__ as current_version
-from cyberdrop_dl.clients.errors import CDLBaseError, InvalidExtensionError, NoExtensionError, get_origin
+from cyberdrop_dl.clients.errors import (
+    CDLBaseError,
+    InvalidExtensionError,
+    InvalidURLError,
+    NoExtensionError,
+    get_origin,
+)
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.logger import log, log_debug, log_spacer, log_with_color
 
@@ -48,6 +54,8 @@ def error_handling_wrapper(func: Callable) -> Callable:
             log_message_short = e_ui_failure = e.ui_message
             log_message = f"{e.ui_message} - {e.message}" if e.ui_message != e.message else e.message
             origin = e.origin or get_origin(item)
+            if isinstance(e, InvalidURLError):
+                link = e.url or link
         except TimeoutError:
             log_message_short = log_message = e_ui_failure = "Timeout"
         except ClientConnectorError as e:


### PR DESCRIPTION
The scrape progress for crawlers that handle multiple items within the same method (like albums) may still fail. If a single invalid URL is found, the entire album scrape process will stop. but at least CDL will not crash.

Realistically, this would never happen. It will only happen inside forums crawlers because CDL has to process raw input from their users.

- Fixes #561
- Fixes #638
- Resolves #640