### PR TITLE
refactor: add `referer` info to download errors logs

### DIFF
--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.scraper.crawler import ScrapeItem
     from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem
 
+
 # See: https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/
 CLOUDFLARE_ERRORS = {
     520: "Unexpected Response",
@@ -42,9 +43,7 @@ class CDLBaseError(Exception):
     ) -> None:
         self.ui_message = ui_message
         self.message = message or ui_message
-        self.origin = origin
-        if origin and not isinstance(origin, URL | Path):
-            self.origin = origin.parents[0] if origin.parents else None
+        self.origin = get_origin(origin)
         super().__init__(self.message)
         if status:
             self.status = status
@@ -204,3 +203,9 @@ def create_error_msg(error: int) -> str:
 @create_error_msg.register
 def _(error: str) -> str:
     return error
+
+
+def get_origin(origin: ScrapeItem | Path | MediaItem | URL | None = None) -> Path | URL | None:
+    if origin and not isinstance(origin, URL | Path):
+        return origin.parents[0] if origin.parents else None
+    return origin

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -163,9 +163,12 @@ class ScrapeError(CDLBaseError):
 
 
 class InvalidURLError(ScrapeError):
-    def __init__(self, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
+    def __init__(
+        self, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None, url: URL | str = ""
+    ) -> None:
         """This error will be thrown when parsed URL is not valid."""
         ui_message = "Invalid URL"
+        self.url = url
         super().__init__(ui_message, message=message, origin=origin)
 
 

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -97,11 +97,16 @@ class DDOSGuardError(CDLBaseError):
 
 class DownloadError(CDLBaseError):
     def __init__(
-        self, status: str | int, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None
+        self,
+        status: str | int,
+        message: str | None = None,
+        origin: ScrapeItem | MediaItem | URL | None = None,
+        retry: bool = False,
     ) -> None:
         """This error will be thrown when a download fails."""
         ui_message = create_error_msg(status)
         msg = message
+        self.retry = retry
         super().__init__(ui_message, message=msg, status=status, origin=origin)
 
 

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -160,8 +160,14 @@ class ScrapeError(CDLBaseError):
     ) -> None:
         """This error will be thrown when a scrape fails."""
         ui_message = create_error_msg(status)
-        msg = message
-        super().__init__(ui_message, message=msg, status=status, origin=origin)
+        super().__init__(ui_message, message=message, status=status, origin=origin)
+
+
+class InvalidURLError(ScrapeError):
+    def __init__(self, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
+        """This error will be thrown when parsed URL is not valid."""
+        ui_message = "Invalid URL"
+        super().__init__(ui_message, message=message, origin=origin)
 
 
 class LoginError(CDLBaseError):

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -60,7 +60,7 @@ def retry(func: Callable) -> Callable:
                     continue
 
                 self.manager.progress_manager.download_stats_progress.add_failure(e.ui_message)
-                await self.manager.log_manager.write_download_error_log(media_item.url, e.message, media_item.referer)
+                await self.manager.log_manager.write_download_error_log(media_item, e.message)
                 self.manager.progress_manager.download_progress.add_failed()
                 break
 
@@ -161,7 +161,6 @@ class Downloader:
     @retry
     async def download(self, media_item: MediaItem) -> None:
         """Downloads the media item."""
-        origin = media_item.referer
         try:
             media_item.current_attempt = media_item.current_attempt or 1
             media_item.duration = await self.manager.db_manager.history_table.get_duration(self.domain, media_item)
@@ -186,7 +185,7 @@ class Downloader:
                 full_message = f"{e.status} - {e.message}"
             log_message_short = log_message = full_message
             log(f"{self.log_prefix} failed: {media_item.url} with error: {log_message}", 40)
-            await self.manager.log_manager.write_download_error_log(media_item.url, log_message_short, origin)
+            await self.manager.log_manager.write_download_error_log(media_item, log_message_short)
             self.manager.progress_manager.download_stats_progress.add_failure(ui_message)
             self.manager.progress_manager.download_progress.add_failed()
             self.attempt_task_removal(media_item)

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -16,7 +16,6 @@ from cyberdrop_dl.clients.errors import (
     DurationError,
     InsufficientFreeSpaceError,
     RestrictedFiletypeError,
-    create_error_msg,
 )
 from cyberdrop_dl.utils.constants import CustomHTTPStatus
 from cyberdrop_dl.utils.logger import log
@@ -40,6 +39,8 @@ def retry(func: Callable) -> Callable:
             try:
                 return await func(self, *args, **kwargs)
             except DownloadError as e:
+                if not e.retry:
+                    raise
                 self.attempt_task_removal(media_item)
                 max_attempts = self.manager.config_manager.global_settings_data.rate_limiting_options.download_attempts
                 if self.manager.config_manager.settings_data.download_options.disable_download_attempt_limit:
@@ -59,10 +60,7 @@ def retry(func: Callable) -> Callable:
                     log(retry_msg, 20)
                     continue
 
-                self.manager.progress_manager.download_stats_progress.add_failure(e.ui_message)
-                await self.manager.log_manager.write_download_error_log(media_item, e.message)
-                self.manager.progress_manager.download_progress.add_failed()
-                break
+                raise
 
     return wrapper
 
@@ -178,17 +176,8 @@ class Downloader:
             self.manager.progress_manager.download_progress.add_skipped()
             self.attempt_task_removal(media_item)
 
-        except (DownloadError, ClientResponseError) as e:
-            ui_message = create_error_msg(getattr(e, "ui_message", e.status))
-            full_message = e.message
-            if e.message != ui_message:
-                full_message = f"{e.status} - {e.message}"
-            log_message_short = log_message = full_message
-            log(f"{self.log_prefix} failed: {media_item.url} with error: {log_message}", 40)
-            await self.manager.log_manager.write_download_error_log(media_item, log_message_short)
-            self.manager.progress_manager.download_stats_progress.add_failure(ui_message)
-            self.manager.progress_manager.download_progress.add_failed()
-            self.attempt_task_removal(media_item)
+        except (DownloadError, ClientResponseError):
+            raise
 
         except (
             ConnectionResetError,
@@ -204,13 +193,21 @@ class Downloader:
                     media_item.filename in self._current_attempt_filesize
                     and self._current_attempt_filesize[media_item.filename] >= size
                 ):
-                    raise DownloadError(ui_message, message=f"{self.log_prefix} failed") from None
+                    raise DownloadError(ui_message, message=f"{self.log_prefix} failed", retry=True) from None
                 self._current_attempt_filesize[media_item.filename] = size
                 media_item.current_attempt = 0
-                raise DownloadError(status=999, message="Download timeout reached, retrying") from None
+                raise DownloadError(status=999, message="Download timeout reached, retrying", retry=True) from None
 
             message = str(e)
-            raise DownloadError(ui_message, message) from e
+            raise DownloadError(ui_message, message, retry=True) from e
+
+    async def write_download_error(self, media_item: MediaItem, log_msg: str, ui_msg: str, exc_info=None) -> None:
+        self.attempt_task_removal(media_item)
+        full_message = f"{self.log_prefix} Failed: {media_item.url} ({log_msg} \n -> Referer: {media_item.referer})"
+        log(full_message, 40, exc_info=exc_info)  # type: ignore
+        await self.manager.log_manager.write_download_error_log(media_item, log_msg)  # type: ignore
+        self.manager.progress_manager.download_stats_progress.add_failure(ui_msg)
+        self.manager.progress_manager.download_progress.add_failed()
 
     @staticmethod
     def is_failed(status: int):

--- a/cyberdrop_dl/managers/log_manager.py
+++ b/cyberdrop_dl/managers/log_manager.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import aiofiles
 
+from cyberdrop_dl.clients.errors import get_origin
 from cyberdrop_dl.utils.constants import CSV_DELIMITER
 from cyberdrop_dl.utils.logger import log, log_spacer
 
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from yarl import URL
 
     from cyberdrop_dl.managers.manager import Manager
+    from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem
 
 
 class LogManager:
@@ -53,9 +55,12 @@ class LogManager:
         """Writes to the unsupported urls log."""
         await self.write_to_csv(self.unsupported_urls_log, url=url, origin=origin)
 
-    async def write_download_error_log(self, url: URL, error_message: str, origin: URL | None = None) -> None:
+    async def write_download_error_log(self, media_item: MediaItem, error_message: str) -> None:
         """Writes to the download error log."""
-        await self.write_to_csv(self.download_error_log, url=url, error=error_message, origin=origin)
+        origin = get_origin(media_item)
+        await self.write_to_csv(
+            self.download_error_log, url=media_item.url, error=error_message, referer=media_item.referer, origin=origin
+        )
 
     async def write_scrape_error_log(self, url: URL, error_message: str, origin: URL | None = None) -> None:
         """Writes to the scrape error log."""

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 from aiolimiter import AsyncLimiter
 from yarl import URL
 
+from cyberdrop_dl.clients.errors import InvalidURLError
 from cyberdrop_dl.downloader.downloader import Downloader
 from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem, ScrapeItem
 from cyberdrop_dl.utils.database.tables.history_table import get_db_path
@@ -270,12 +271,15 @@ class Crawler(ABC):
         scrape_item.add_to_parent_title(title)
 
     def parse_url(self, link_str: str, relative_to: URL | None = None) -> URL:
-        assert link_str
-        assert isinstance(link_str, str)
-        link_str = clean_link_str(link_str)
-        encoded = "%" in link_str
-        base = relative_to or self.primary_base_domain
-        new_url = URL(link_str, encoded=encoded)
+        try:
+            assert link_str
+            assert isinstance(link_str, str)
+            link_str = clean_link_str(link_str)
+            encoded = "%" in link_str
+            base = relative_to or self.primary_base_domain
+            new_url = URL(link_str, encoded=encoded)
+        except (AssertionError, AttributeError, ValueError, TypeError) as e:
+            raise InvalidURLError(str(e)) from e
         if not new_url.absolute:
             new_url = base.join(new_url)
         if not new_url.scheme:

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -279,7 +279,7 @@ class Crawler(ABC):
             base = relative_to or self.primary_base_domain
             new_url = URL(link_str, encoded=encoded)
         except (AssertionError, AttributeError, ValueError, TypeError) as e:
-            raise InvalidURLError(str(e)) from e
+            raise InvalidURLError(str(e), url=link_str) from e
         if not new_url.absolute:
             new_url = base.join(new_url)
         if not new_url.scheme:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -73,7 +73,7 @@ def error_handling_wrapper(func: Callable) -> Callable:
 
         log_prefix = getattr(self, "log_prefix", None)
         if log_prefix:
-            await self.write_download_error(item, log_message, e_ui_failure, exc_info)  # type: ignore
+            await self.write_download_error(item, log_message_short, e_ui_failure, exc_info)  # type: ignore
             return
 
         log(f"Scrape Failed: {link} ({log_message})", 40, exc_info=exc_info)

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -75,7 +75,7 @@ def error_handling_wrapper(func: Callable) -> Callable:
         log(f"{log_prefix or 'Scrape'} Failed: {link} ({log_message})", 40, exc_info=exc_info)
         if log_prefix:
             self.attempt_task_removal(item)
-            await self.manager.log_manager.write_download_error_log(link, log_message_short, origin or item.referer)
+            await self.manager.log_manager.write_download_error_log(item, log_message_short)  # type: ignore
             self.manager.progress_manager.download_stats_progress.add_failure(e_ui_failure)
             self.manager.progress_manager.download_progress.add_failed()
             return None

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -72,14 +72,11 @@ def error_handling_wrapper(func: Callable) -> Callable:
                 e_ui_failure = "Unknown"
 
         log_prefix = getattr(self, "log_prefix", None)
-        log(f"{log_prefix or 'Scrape'} Failed: {link} ({log_message})", 40, exc_info=exc_info)
         if log_prefix:
-            self.attempt_task_removal(item)
-            await self.manager.log_manager.write_download_error_log(item, log_message_short)  # type: ignore
-            self.manager.progress_manager.download_stats_progress.add_failure(e_ui_failure)
-            self.manager.progress_manager.download_progress.add_failed()
-            return None
+            await self.write_download_error(item, log_message, e_ui_failure, exc_info)  # type: ignore
+            return
 
+        log(f"Scrape Failed: {link} ({log_message})", 40, exc_info=exc_info)
         await self.manager.log_manager.write_scrape_error_log(link, log_message_short, origin)
         self.manager.progress_manager.scrape_stats_progress.add_failure(e_ui_failure)
         return None

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -18,7 +18,7 @@ from rich.text import Text
 from yarl import URL
 
 from cyberdrop_dl import __version__ as current_version
-from cyberdrop_dl.clients.errors import CDLBaseError, InvalidExtensionError, NoExtensionError
+from cyberdrop_dl.clients.errors import CDLBaseError, InvalidExtensionError, NoExtensionError, get_origin
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.logger import log, log_debug, log_spacer, log_with_color
 
@@ -47,7 +47,7 @@ def error_handling_wrapper(func: Callable) -> Callable:
         except CDLBaseError as e:
             log_message_short = e_ui_failure = e.ui_message
             log_message = f"{e.ui_message} - {e.message}" if e.ui_message != e.message else e.message
-            origin = e.origin
+            origin = e.origin or get_origin(item)
         except TimeoutError:
             log_message_short = log_message = e_ui_failure = "Timeout"
         except ClientConnectorError as e:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -18,7 +18,13 @@ from rich.text import Text
 from yarl import URL
 
 from cyberdrop_dl import __version__ as current_version
-from cyberdrop_dl.clients.errors import CDLBaseError, InvalidExtensionError, NoExtensionError, get_origin
+from cyberdrop_dl.clients.errors import (
+    CDLBaseError,
+    InvalidExtensionError,
+    InvalidURLError,
+    NoExtensionError,
+    get_origin,
+)
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.logger import log, log_debug, log_spacer, log_with_color
 
@@ -48,6 +54,8 @@ def error_handling_wrapper(func: Callable) -> Callable:
             log_message_short = e_ui_failure = e.ui_message
             log_message = f"{e.ui_message} - {e.message}" if e.ui_message != e.message else e.message
             origin = e.origin or get_origin(item)
+            if isinstance(e, InvalidURLError):
+                link = e.url or link
         except TimeoutError:
             log_message_short = log_message = e_ui_failure = "Timeout"
         except ClientConnectorError as e:


### PR DESCRIPTION
- Add referer column to download errors csv
- Add referer info to messages in the main log file
- Simplify handling of download errors
- See: https://github.com/jbsparrow/CyberDropDownloader/pull/631#issuecomment-2662689692
- Needs #641