### PR TITLE
fix: handle errors while checking for updates

### DIFF
--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -22,9 +22,9 @@ from cyberdrop_dl.scraper.scraper import ScrapeMapper
 from cyberdrop_dl.ui.program_ui import ProgramUI
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.apprise import send_apprise_notifications
-from cyberdrop_dl.utils.check_updates import check_latest_pypi
 from cyberdrop_dl.utils.logger import RedactedConsole, log, log_spacer, log_with_color
 from cyberdrop_dl.utils.sorting import Sorter
+from cyberdrop_dl.utils.updates import check_latest_pypi
 from cyberdrop_dl.utils.utilities import check_partials_and_empty_folders, send_webhook_message
 from cyberdrop_dl.utils.yaml import handle_validation_error
 

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -22,9 +22,10 @@ from cyberdrop_dl.scraper.scraper import ScrapeMapper
 from cyberdrop_dl.ui.program_ui import ProgramUI
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.apprise import send_apprise_notifications
+from cyberdrop_dl.utils.check_updates import check_latest_pypi
 from cyberdrop_dl.utils.logger import RedactedConsole, log, log_spacer, log_with_color
 from cyberdrop_dl.utils.sorting import Sorter
-from cyberdrop_dl.utils.utilities import check_latest_pypi, check_partials_and_empty_folders, send_webhook_message
+from cyberdrop_dl.utils.utilities import check_partials_and_empty_folders, send_webhook_message
 from cyberdrop_dl.utils.yaml import handle_validation_error
 
 if TYPE_CHECKING:

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -17,9 +17,9 @@ from cyberdrop_dl.clients.hash_client import hash_directory_scanner
 from cyberdrop_dl.ui.prompts import user_prompts
 from cyberdrop_dl.ui.prompts.basic_prompts import ask_dir_path, enter_to_continue
 from cyberdrop_dl.ui.prompts.defaults import DONE_CHOICE, EXIT_CHOICE
-from cyberdrop_dl.utils.check_updates import check_latest_pypi
 from cyberdrop_dl.utils.cookie_management import clear_cookies
 from cyberdrop_dl.utils.sorting import Sorter
+from cyberdrop_dl.utils.updates import check_latest_pypi
 from cyberdrop_dl.utils.utilities import clear_term, open_in_text_editor
 
 if TYPE_CHECKING:

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -104,7 +104,7 @@ class ProgramUI:
 
     def _check_updates(self) -> None:
         """Checks Cyberdrop-DL updates."""
-        check_latest_pypi(call_from_ui=True)
+        check_latest_pypi(logging="CONSOLE")
         enter_to_continue()
 
     def _change_config(self) -> None:
@@ -267,7 +267,7 @@ class ProgramUI:
         """Get latest changelog file from github. Returns its content."""
         path = self.manager.path_manager.config_folder.parent / "CHANGELOG.md"
         url = "https://raw.githubusercontent.com/jbsparrow/CyberDropDownloader/refs/heads/master/CHANGELOG.md"
-        _, latest_version = check_latest_pypi(log_to_console=False)
+        _, latest_version = check_latest_pypi(logging="OFF")
         if not latest_version:
             return
         name = f"{path.stem}_{latest_version}{path.suffix}"

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -17,9 +17,10 @@ from cyberdrop_dl.clients.hash_client import hash_directory_scanner
 from cyberdrop_dl.ui.prompts import user_prompts
 from cyberdrop_dl.ui.prompts.basic_prompts import ask_dir_path, enter_to_continue
 from cyberdrop_dl.ui.prompts.defaults import DONE_CHOICE, EXIT_CHOICE
+from cyberdrop_dl.utils.check_updates import check_latest_pypi
 from cyberdrop_dl.utils.cookie_management import clear_cookies
 from cyberdrop_dl.utils.sorting import Sorter
-from cyberdrop_dl.utils.utilities import check_latest_pypi, clear_term, open_in_text_editor
+from cyberdrop_dl.utils.utilities import clear_term, open_in_text_editor
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -269,7 +269,9 @@ class ProgramUI:
         url = "https://raw.githubusercontent.com/jbsparrow/CyberDropDownloader/refs/heads/master/CHANGELOG.md"
         _, latest_version = check_latest_pypi(logging="OFF")
         if not latest_version:
-            return
+            self.print_error("UNABLE TO GET LATEST VERSION INFORMATION")
+            return None
+
         name = f"{path.stem}_{latest_version}{path.suffix}"
         changelog = path.with_name(name)
         if not changelog.is_file():

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -267,6 +267,8 @@ class ProgramUI:
         path = self.manager.path_manager.config_folder.parent / "CHANGELOG.md"
         url = "https://raw.githubusercontent.com/jbsparrow/CyberDropDownloader/refs/heads/master/CHANGELOG.md"
         _, latest_version = check_latest_pypi(log_to_console=False)
+        if not latest_version:
+            return
         name = f"{path.stem}_{latest_version}{path.suffix}"
         changelog = path.with_name(name)
         if not changelog.is_file():

--- a/cyberdrop_dl/utils/check_updates.py
+++ b/cyberdrop_dl/utils/check_updates.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import re
+
+import rich
+from requests import request
+from rich.text import Text
+
+from cyberdrop_dl import __version__ as current_version
+from cyberdrop_dl.utils import constants
+from cyberdrop_dl.utils.logger import log_with_color
+
+
+def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -> tuple[str, str]:
+    """Checks if the current version is the latest version."""
+
+    try:
+        with request("GET", constants.PYPI_JSON_URL, timeout=30) as response:
+            contents = response.content
+    except Exception:
+        color = "bold_red"
+        message = Text("Unable to get latest version information", style=color)
+        if call_from_ui:
+            rich.print(message)
+        elif log_to_console:
+            log_with_color(message.plain, color, 40, show_in_stats=False)
+        return "", ""
+
+    data: dict[str, dict] = json.loads(contents)
+    latest_version: str = data["info"]["version"]
+    releases = list(data["releases"].keys())
+    color = ""
+    level = 30
+    is_prerelease, latest_testing_version, message = check_prelease_version(releases)
+
+    if current_version not in releases:
+        message = Text("You are on an unreleased version, skipping version check")
+        color = "bold_yellow"
+    elif is_prerelease:
+        latest_version = latest_testing_version
+        color = "bold_red"
+    elif current_version != latest_version:
+        message_mkup = f"A new version of Cyberdrop-DL is available: [cyan]{latest_version}[/cyan]"
+        message = Text.from_markup(message_mkup)
+    else:
+        message = Text.from_markup("You are currently on the latest version of Cyberdrop-DL :white_check_mark:")
+        level = 20
+
+    if call_from_ui:
+        rich.print(message)
+    elif log_to_console:
+        log_with_color(message.plain, color, level, show_in_stats=False)
+
+    return current_version, latest_version
+
+
+def check_prelease_version(releases: list[str]) -> tuple[bool, str, Text]:
+    match = re.match(constants.PRELEASE_VERSION_PATTERN, current_version)
+    latest_testing_version = ""
+    message = Text("")
+    running_prerelease = next((tag for tag in constants.PRERELEASE_TAGS if tag in current_version), False)
+
+    if running_prerelease and match:
+        major_version, minor_version, patch_version, dot_tag, no_dot_tag = match.groups()
+        test_tag = dot_tag if dot_tag else no_dot_tag
+        regex_str = rf"{major_version}\.{minor_version}\.{patch_version}(\.{test_tag}\d+|{test_tag}\d+)"
+        rough_matches = [release for release in releases if re.match(regex_str, release)]
+        latest_testing_version = max(rough_matches, key=lambda x: int(re.search(r"(\d+)$", x).group()))  # type: ignore
+        ui_tag = constants.PRERELEASE_TAGS.get(test_tag, "Testing").lower()
+
+        if current_version != latest_testing_version:
+            message = f"A new {ui_tag} version of Cyberdrop-DL is available: "
+            message = Text(message).append_text(Text(latest_testing_version, style="cyan"))
+        else:
+            message = f"You are currently on the latest {ui_tag} version of [b cyan]{major_version}.{minor_version}.{patch_version}[/b cyan]"
+            message = Text.from_markup(message)
+    return bool(running_prerelease), latest_testing_version, message

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -71,16 +71,7 @@ class NotificationResult(Enum):
 
 
 # Pypi
-PRERELEASE_TAGS = {
-    "dev": "Development",
-    "pre": "Pre-Release",
-    "rc": "Release Candidate",
-    "a": "Alpha",
-    "b": "Beta",
-}
 
-PRELEASE_VERSION_PATTERN = r"(\d+)\.(\d+)\.(\d+)(?:\.([a-z]+)\d+|([a-z]+)\d+)"
-PYPI_JSON_URL = "https://pypi.org/pypi/cyberdrop-dl-patched/json"
 
 # file formats
 FILE_FORMATS = {

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -70,9 +70,6 @@ class NotificationResult(Enum):
     NONE = Text("No Notifications Sent", "yellow")
 
 
-# Pypi
-
-
 # file formats
 FILE_FORMATS = {
     "Images": {

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -36,7 +36,7 @@ class UpdateInfo(NamedTuple):
 
 
 INFO = LogInfo(20, "")
-WARNING = LogInfo(30, "bold_yellow")
+WARNING = LogInfo(30, "yellow")
 ERROR = LogInfo(40, "bold_red")
 
 
@@ -92,16 +92,16 @@ def get_update_info(package_info: PackageInfo) -> UpdateInfo:
 
     if package_info.is_from_the_future or package_info.is_unreleased or not latest_version:
         msg = Text("You are on an unreleased version, skipping version check", style=WARNING.style)
-        UpdateInfo(msg, WARNING, latest_version)
+        return UpdateInfo(msg, WARNING, latest_version)
 
     version_text = Text(str(latest_version), style="cyan")
 
-    if package_info.current_version == latest_version:
+    if package_info.current_version >= latest_version:
         msg_mkp = "You are currently on the latest version of Cyberdrop-DL :white_check_mark:"
         if pre_tag:
-            msg_mkp = f"You are currently on the latest {pre_tag} version:"
+            msg_mkp = f"You are currently on the latest {pre_tag} version: "
         msg = Text.from_markup(msg_mkp, style=INFO.style).append_text(version_text)
-        UpdateInfo(msg, INFO, latest_version)
+        return UpdateInfo(msg, INFO, latest_version)
 
     spacer = f"{pre_tag} " if pre_tag else ""
     msg_str = f"A new {spacer}version of Cyberdrop-DL is available: "

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -8,15 +8,24 @@ from requests import request
 from rich.text import Text
 
 from cyberdrop_dl import __version__ as current_version
-from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.logger import log_with_color
+
+PYPI_JSON_URL = "https://pypi.org/pypi/cyberdrop-dl-patched/json"
+PRELEASE_VERSION_PATTERN = r"(\d+)\.(\d+)\.(\d+)(?:\.([a-z]+)\d+|([a-z]+)\d+)"
+PRERELEASE_TAGS = {
+    "dev": "Development",
+    "pre": "Pre-Release",
+    "rc": "Release Candidate",
+    "a": "Alpha",
+    "b": "Beta",
+}
 
 
 def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -> tuple[str, str]:
     """Checks if the current version is the latest version."""
 
     try:
-        with request("GET", constants.PYPI_JSON_URL, timeout=30) as response:
+        with request("GET", PYPI_JSON_URL, timeout=30) as response:
             contents = response.content
     except Exception:
         color = "bold_red"
@@ -56,10 +65,10 @@ def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -
 
 
 def check_prelease_version(releases: list[str]) -> tuple[bool, str, Text]:
-    match = re.match(constants.PRELEASE_VERSION_PATTERN, current_version)
+    match = re.match(PRELEASE_VERSION_PATTERN, current_version)
     latest_testing_version = ""
     message = Text("")
-    running_prerelease = next((tag for tag in constants.PRERELEASE_TAGS if tag in current_version), False)
+    running_prerelease = next((tag for tag in PRERELEASE_TAGS if tag in current_version), False)
 
     if running_prerelease and match:
         major_version, minor_version, patch_version, dot_tag, no_dot_tag = match.groups()
@@ -67,7 +76,7 @@ def check_prelease_version(releases: list[str]) -> tuple[bool, str, Text]:
         regex_str = rf"{major_version}\.{minor_version}\.{patch_version}(\.{test_tag}\d+|{test_tag}\d+)"
         rough_matches = [release for release in releases if re.match(regex_str, release)]
         latest_testing_version = max(rough_matches, key=lambda x: int(re.search(r"(\d+)$", x).group()))  # type: ignore
-        ui_tag = constants.PRERELEASE_TAGS.get(test_tag, "Testing").lower()
+        ui_tag = PRERELEASE_TAGS.get(test_tag, "Testing").lower()
 
         if current_version != latest_testing_version:
             message = f"A new {ui_tag} version of Cyberdrop-DL is available: "

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 from enum import StrEnum
 from functools import cached_property
-from typing import Literal, NamedTuple, Self
+from typing import TYPE_CHECKING, Literal, NamedTuple, Self
 
 import rich
 from packaging.version import Version
@@ -13,6 +13,9 @@ from rich.text import Text
 
 from cyberdrop_dl import __version__
 from cyberdrop_dl.utils.logger import log_with_color
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 PYPI_JSON_URL = "https://pypi.org/pypi/cyberdrop-dl-patched/json"
 current_version = Version(__version__)
@@ -77,7 +80,7 @@ def process_pypi_response(response: bytes | str) -> UpdateInfo:
         return UpdateInfo(error_message, ERROR, None)
 
     data: dict[str, dict] = json.loads(response)
-    releases = list(data["releases"].keys())
+    releases = data["releases"].keys()
     package_info = PackageInfo.create(releases)
     return get_update_info(package_info)
 
@@ -190,6 +193,6 @@ class PackageInfo:
         return self.current_version > self.latest
 
     @classmethod
-    def create(cls, releases: list[str]) -> Self:
+    def create(cls, releases: Iterable[str]) -> Self:
         all_releases = tuple([Version(release) for release in releases])
         return cls(current_version, all_releases)

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -33,21 +33,20 @@ class UpdateDetails(NamedTuple):
     message: Text
     log_level: int
     color: str
-    version: str
+    version: str | None
 
 
-def check_latest_pypi(logging: Literal["OFF", "CONSOLE", "ON"] = UpdateLogLevel.ON) -> tuple[str, str]:
+def check_latest_pypi(logging: Literal["OFF", "CONSOLE", "ON"] = UpdateLogLevel.ON) -> tuple[str, str | None]:
     """Checks if the current version is the latest version.
 
     Args:
-        log_to (str, optional): Controls where version information is logged.
+        logging (str, optional): Controls where version information is logged.
             - OFF: Do not log version information.
             - CONSOLE: Log version information to the console.
             - ON: Log version information to both the console and the main log file.
 
     Returns:
-        tuple[str, str]: A tuple containing the current version and the latest
-        available version.
+        tuple[str, str | None]: current_version, latest_version. Returns None for latest_version if any error occurs
     """
 
     try:
@@ -73,7 +72,7 @@ def process_pypi_response(response: bytes | str) -> UpdateDetails:
         color = "bold_red"
         message = Text("Unable to get latest version information", style=color)
         level = 40
-        return UpdateDetails(message, level, color, "")
+        return UpdateDetails(message, level, color, None)
 
     data: dict[str, dict] = json.loads(response)
     latest_version: str = data["info"]["version"]
@@ -127,4 +126,5 @@ def check_prerelease_version(releases: list[str]) -> tuple[bool, str, Text]:
         else:
             message = f"You are currently on the latest {ui_tag} version of [b cyan]{major_version}.{minor_version}.{patch_version}[/b cyan]"
             message = Text.from_markup(message)
+
     return bool(running_prerelease), latest_testing_version, message

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -97,11 +97,17 @@ def get_update_info(package_info: PackageInfo) -> UpdateInfo:
     version_text = Text(str(latest_version), style="cyan")
 
     if package_info.current_version >= latest_version:
+        log_level = INFO
         msg_mkp = "You are currently on the latest version of Cyberdrop-DL :white_check_mark:"
         if pre_tag:
             msg_mkp = f"You are currently on the latest {pre_tag} version: "
-        msg = Text.from_markup(msg_mkp, style=INFO.style).append_text(version_text)
-        return UpdateInfo(msg, INFO, latest_version)
+            if package_info.latest_prerelease_version > package_info.current_version:
+                version_text = Text(str(package_info.latest_prerelease_version), style="cyan")
+                new_tag = get_prerelease_tag(package_info.latest_prerelease_version)
+                msg_mkp += f" {latest_version} , but a newer prerelease version of type {new_tag} is available: "
+                log_level = WARNING
+        msg = Text.from_markup(msg_mkp, style=log_level.style).append_text(version_text)
+        return UpdateInfo(msg, log_level, latest_version)
 
     spacer = f"{pre_tag} " if pre_tag else ""
     msg_str = f"A new {spacer}version of Cyberdrop-DL is available: "

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -79,13 +79,13 @@ def process_pypi_response(response: bytes | str) -> UpdateDetails:
     releases = list(data["releases"].keys())
     color = ""
     level = 30
-    is_prerelease, latest_testing_version, message = check_prerelease_version(releases)
+    is_prerelease, latest_prerelease_version, message = check_prerelease_version(releases)
 
     if current_version not in releases:
         color = "bold_yellow"
         message = Text("You are on an unreleased version, skipping version check", style=color)
     elif is_prerelease:
-        latest_version = latest_testing_version
+        latest_version = latest_prerelease_version
         color = "bold_red"
         message.stylize(color)
     elif current_version != latest_version:
@@ -108,7 +108,7 @@ def check_prerelease_version(releases: list[str]) -> tuple[bool, str, Text]:
         tuple[bool, str, Text]: running_prerelease, latest_prerelease_version, release_info_message
     """
     match = re.match(PRELEASE_VERSION_PATTERN, current_version)
-    latest_testing_version = ""
+    latest_prerelease_version = ""
     message = Text("")
     running_prerelease = next((tag for tag in PRERELEASE_TAGS if tag in current_version), False)
 
@@ -117,14 +117,14 @@ def check_prerelease_version(releases: list[str]) -> tuple[bool, str, Text]:
         test_tag = dot_tag if dot_tag else no_dot_tag
         regex_str = rf"{major_version}\.{minor_version}\.{patch_version}(\.{test_tag}\d+|{test_tag}\d+)"
         rough_matches = [release for release in releases if re.match(regex_str, release)]
-        latest_testing_version = max(rough_matches, key=lambda x: int(re.search(r"(\d+)$", x).group()))  # type: ignore
+        latest_prerelease_version = max(rough_matches, key=lambda x: int(re.search(r"(\d+)$", x).group()))  # type: ignore
         ui_tag = PRERELEASE_TAGS.get(test_tag, "Testing").lower()
 
-        if current_version != latest_testing_version:
+        if current_version != latest_prerelease_version:
             message = f"A new {ui_tag} version of Cyberdrop-DL is available: "
-            message = Text(message).append_text(Text(latest_testing_version, style="cyan"))
+            message = Text(message).append_text(Text(latest_prerelease_version, style="cyan"))
         else:
             message = f"You are currently on the latest {ui_tag} version of [b cyan]{major_version}.{minor_version}.{patch_version}[/b cyan]"
             message = Text.from_markup(message)
 
-    return bool(running_prerelease), latest_testing_version, message
+    return bool(running_prerelease), latest_prerelease_version, message

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -83,7 +83,7 @@ def process_pypi_response(response: bytes | str) -> UpdateInfo:
 
 
 def get_update_info(package_info: PackageInfo) -> UpdateInfo:
-    latest_version = package_info.latest_stable_release
+    latest_version = package_info.latest_stable
     pre_tag = None
 
     if package_info.is_prerelease:
@@ -99,10 +99,10 @@ def get_update_info(package_info: PackageInfo) -> UpdateInfo:
     if package_info.current_version >= latest_version:
         log_level = INFO
         msg_mkp, log_level = get_using_latest_mkp(package_info, latest_version)
-        if pre_tag and package_info.latest_prerelease_version > package_info.current_version:
-            version_text = Text(str(package_info.latest_prerelease_version), style="cyan")
+        if pre_tag and package_info.latest_prerelease > package_info.current_version:
+            version_text = Text(str(package_info.latest_prerelease), style="cyan")
         msg = Text.from_markup(msg_mkp, style=log_level.style).append_text(version_text)
-        if package_info.latest_version > package_info.current_version:
+        if pre_tag and package_info.latest > package_info.current_version:
             msg = msg.append_text(get_latest_stable_msg(package_info))
         return UpdateInfo(msg, log_level, latest_version)
 
@@ -114,7 +114,7 @@ def get_update_info(package_info: PackageInfo) -> UpdateInfo:
 
 def get_latest_stable_msg(package_info: PackageInfo) -> Text:
     msg_mkp = "\n\nLatest stable version of Cyberdrop-DL: "
-    version_text = Text(str(package_info.latest_stable_release), style="cyan")
+    version_text = Text(str(package_info.latest_stable), style="cyan")
     return Text.from_markup(msg_mkp).append_text(version_text)
 
 
@@ -125,10 +125,10 @@ def get_using_latest_mkp(package_info: PackageInfo, latest_version: Version) -> 
         return msg_mkp, INFO
 
     msg_mkp = f"You are currently on the latest {package_info.prerelease_tag} version: "
-    if package_info.latest_prerelease_version <= package_info.current_version:
+    if package_info.latest_prerelease <= package_info.current_version:
         return msg_mkp, INFO
 
-    new_tag = get_prerelease_tag(package_info.latest_prerelease_version)
+    new_tag = get_prerelease_tag(package_info.latest_prerelease)
     msg_mkp += f"{latest_version}, but a newer prerelease version of type {new_tag} is available: "
     return msg_mkp, WARNING
 
@@ -146,15 +146,15 @@ class PackageInfo:
     releases: list[Version]
 
     @cached_property
-    def latest_version(self) -> Version:
+    def latest(self) -> Version:
         return max(self.releases)
 
     @cached_property
-    def latest_non_prerelease_version(self) -> Version:
+    def latest_non_prerelease(self) -> Version:
         return max(self.releases)
 
     @cached_property
-    def latest_prerelease_version(self) -> Version:
+    def latest_prerelease(self) -> Version:
         return max(self.prereleases)
 
     @cached_property
@@ -174,7 +174,7 @@ class PackageInfo:
         return [r for r in self.releases if not get_prerelease_tag(r)]
 
     @cached_property
-    def latest_stable_release(self) -> Version:
+    def latest_stable(self) -> Version:
         return max(self.stable_releases)
 
     @cached_property
@@ -190,7 +190,7 @@ class PackageInfo:
     @cached_property
     def is_from_the_future(self) -> bool:
         # Faster to compute than is_unreleased
-        return self.current_version > self.latest_version
+        return self.current_version > self.latest
 
     @classmethod
     def create(cls, releases: list[str]) -> Self:

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -49,10 +49,10 @@ def check_latest_pypi(logging: Literal["OFF", "CONSOLE", "ON"] = UpdatesLogLevel
     except Exception:
         color = "bold_red"
         message = Text("Unable to get latest version information", style=color)
-        if logging == UpdatesLogLevel.CONSOLE:
-            rich.print(message)
-        elif logging == UpdatesLogLevel.ON:
+        if logging == UpdatesLogLevel.ON:
             log_with_color(message.plain, color, 40, show_in_stats=False)
+        elif logging == UpdatesLogLevel.CONSOLE:
+            rich.print(message)
         return "", ""
 
     data: dict[str, dict] = json.loads(contents)
@@ -63,11 +63,12 @@ def check_latest_pypi(logging: Literal["OFF", "CONSOLE", "ON"] = UpdatesLogLevel
     is_prerelease, latest_testing_version, message = check_prerelease_version(releases)
 
     if current_version not in releases:
-        message = Text("You are on an unreleased version, skipping version check")
         color = "bold_yellow"
+        message = Text("You are on an unreleased version, skipping version check", style=color)
     elif is_prerelease:
         latest_version = latest_testing_version
         color = "bold_red"
+        message.stylize(color)
     elif current_version != latest_version:
         message_mkup = f"A new version of Cyberdrop-DL is available: [cyan]{latest_version}[/cyan]"
         message = Text.from_markup(message_mkup)
@@ -75,10 +76,10 @@ def check_latest_pypi(logging: Literal["OFF", "CONSOLE", "ON"] = UpdatesLogLevel
         message = Text.from_markup("You are currently on the latest version of Cyberdrop-DL :white_check_mark:")
         level = 20
 
-    if logging == UpdatesLogLevel.CONSOLE:
-        rich.print(message)
-    elif logging == UpdatesLogLevel.ON:
+    if logging == UpdatesLogLevel.ON:
         log_with_color(message.plain, color, level, show_in_stats=False)
+    elif logging == UpdatesLogLevel.CONSOLE:
+        rich.print(message)
 
     return current_version, latest_version
 

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -22,7 +22,15 @@ PRERELEASE_TAGS = {
 
 
 def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -> tuple[str, str]:
-    """Checks if the current version is the latest version."""
+    """Checks if the current version is the latest version.
+
+    Args:
+        log_to_console (bool, optional): Log message to file and shows in console.
+        call_from_ui (bool, optional): Only shows message in console. Ignores `log_to_console`.
+
+    Returns:
+        tuple[str, str]: current_version, latest_version
+    """
 
     try:
         with request("GET", PYPI_JSON_URL, timeout=30) as response:
@@ -65,6 +73,14 @@ def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -
 
 
 def check_prelease_version(releases: list[str]) -> tuple[bool, str, Text]:
+    """Checks if the current version is a prerelease
+
+    Args:
+        releases (list[str]): List of releases form pypi
+
+    Returns:
+        tuple[bool, str, Text]: running_prerelease, latest_prerelease_version, message
+    """
     match = re.match(PRELEASE_VERSION_PATTERN, current_version)
     latest_testing_version = ""
     message = Text("")

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -98,21 +98,39 @@ def get_update_info(package_info: PackageInfo) -> UpdateInfo:
 
     if package_info.current_version >= latest_version:
         log_level = INFO
-        msg_mkp = "You are currently on the latest version of Cyberdrop-DL :white_check_mark:"
-        if pre_tag:
-            msg_mkp = f"You are currently on the latest {pre_tag} version: "
-            if package_info.latest_prerelease_version > package_info.current_version:
-                version_text = Text(str(package_info.latest_prerelease_version), style="cyan")
-                new_tag = get_prerelease_tag(package_info.latest_prerelease_version)
-                msg_mkp += f" {latest_version} , but a newer prerelease version of type {new_tag} is available: "
-                log_level = WARNING
+        msg_mkp, log_level = get_using_latest_mkp(package_info, latest_version)
+        if pre_tag and package_info.latest_prerelease_version > package_info.current_version:
+            version_text = Text(str(package_info.latest_prerelease_version), style="cyan")
         msg = Text.from_markup(msg_mkp, style=log_level.style).append_text(version_text)
+        if package_info.latest_version > package_info.current_version:
+            msg = msg.append_text(get_latest_stable_msg(package_info))
         return UpdateInfo(msg, log_level, latest_version)
 
     spacer = f"{pre_tag} " if pre_tag else ""
     msg_str = f"A new {spacer}version of Cyberdrop-DL is available: "
     msg = Text(msg_str, style=WARNING.style).append_text(version_text)
     return UpdateInfo(msg, WARNING, latest_version)
+
+
+def get_latest_stable_msg(package_info: PackageInfo) -> Text:
+    msg_mkp = "\n\nLatest stable version of Cyberdrop-DL: "
+    version_text = Text(str(package_info.latest_stable_release), style="cyan")
+    return Text.from_markup(msg_mkp).append_text(version_text)
+
+
+def get_using_latest_mkp(package_info: PackageInfo, latest_version: Version) -> tuple[str, LogInfo]:
+    msg_mkp = "You are currently on the latest version of Cyberdrop-DL :white_check_mark:"
+
+    if not package_info.prerelease_tag:
+        return msg_mkp, INFO
+
+    msg_mkp = f"You are currently on the latest {package_info.prerelease_tag} version: "
+    if package_info.latest_prerelease_version <= package_info.current_version:
+        return msg_mkp, INFO
+
+    new_tag = get_prerelease_tag(package_info.latest_prerelease_version)
+    msg_mkp += f"{latest_version}, but a newer prerelease version of type {new_tag} is available: "
+    return msg_mkp, WARNING
 
 
 def get_prerelease_tag(version: Version) -> str | None:

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from enum import StrEnum
 from functools import cached_property
 from typing import TYPE_CHECKING, Literal, NamedTuple, Self
 
@@ -26,12 +25,6 @@ class LogInfo(NamedTuple):
     style: str
 
 
-class UpdateLogLevel(StrEnum):
-    OFF = "OFF"
-    CONSOLE = "CONSOLE"
-    ON = "ON"
-
-
 class UpdateInfo(NamedTuple):
     message: Text
     log_info: LogInfo
@@ -48,7 +41,7 @@ ERROR_UPDATE_INFO = UpdateInfo(ERROR_TEXT, ERROR, None)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@dataclass
+@dataclass(order=True)
 class PackageInfo:
     current_version: Version
     releases: tuple[Version, ...]
@@ -93,7 +86,7 @@ class PackageInfo:
 
     @cached_property
     def is_from_the_future(self) -> bool:
-        # Faster to compute than is_unreleased
+        # Faster to compute than is_unreleased if self.latest is already cached
         return self.current_version > self.latest
 
     @classmethod
@@ -105,7 +98,7 @@ class PackageInfo:
 #  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-def check_latest_pypi(logging: Literal["OFF", "CONSOLE", "ON"] = UpdateLogLevel.ON) -> tuple[Version, Version | None]:
+def check_latest_pypi(logging: Literal["OFF", "CONSOLE", "ON"] = "ON") -> tuple[Version, Version | None]:
     """Get latest version from Pypi.
 
     Args:
@@ -128,9 +121,9 @@ def check_latest_pypi(logging: Literal["OFF", "CONSOLE", "ON"] = UpdateLogLevel.
 
     update = process_pypi_response(contents)
 
-    if logging == UpdateLogLevel.ON:
+    if logging == "ON":
         log_with_color(update.message.plain, update.log_info.style, update.log_info.level, show_in_stats=False)
-    elif logging == UpdateLogLevel.CONSOLE:
+    elif logging == "CONSOLE":
         rich.print(update.message)
 
     return current_version, update.version

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -144,7 +144,7 @@ def get_prerelease_tag(version: Version) -> str | None:
 @dataclass
 class PackageInfo:
     current_version: Version
-    releases: list[Version]
+    releases: tuple[Version, ...]
 
     @cached_property
     def latest(self) -> Version:
@@ -167,12 +167,12 @@ class PackageInfo:
         return bool(self.prerelease_tag)
 
     @cached_property
-    def prereleases(self) -> list[Version]:
-        return [r for r in self.releases if get_prerelease_tag(r)]
+    def prereleases(self) -> tuple[Version, ...]:
+        return tuple([r for r in self.releases if get_prerelease_tag(r)])
 
     @cached_property
-    def stable_releases(self) -> list[Version]:
-        return [r for r in self.releases if not get_prerelease_tag(r)]
+    def stable_releases(self) -> tuple[Version, ...]:
+        return tuple([r for r in self.releases if not get_prerelease_tag(r)])
 
     @cached_property
     def latest_stable(self) -> Version:
@@ -195,5 +195,5 @@ class PackageInfo:
 
     @classmethod
     def create(cls, releases: list[str]) -> Self:
-        all_releases = [Version(release) for release in releases]
+        all_releases = tuple([Version(release) for release in releases])
         return cls(current_version, all_releases)

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -86,8 +86,6 @@ def process_pypi_response(response: bytes | str) -> UpdateDetails:
         message = Text("You are on an unreleased version, skipping version check", style=color)
     elif is_prerelease:
         latest_version = latest_prerelease_version
-        color = "bold_red"
-        message.stylize(color)
     elif current_version != latest_version:
         message_mkup = f"A new version of Cyberdrop-DL is available: [cyan]{latest_version}[/cyan]"
         message = Text.from_markup(message_mkup)

--- a/cyberdrop_dl/utils/updates.py
+++ b/cyberdrop_dl/utils/updates.py
@@ -151,10 +151,6 @@ class PackageInfo:
         return max(self.releases)
 
     @cached_property
-    def latest_non_prerelease(self) -> Version:
-        return max(self.releases)
-
-    @cached_property
     def latest_prerelease(self) -> Version:
         return max(self.prereleases)
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -13,11 +13,8 @@ from typing import TYPE_CHECKING
 import aiofiles
 import rich
 from aiohttp import ClientConnectorError, ClientSession, FormData
-from requests import request
-from rich.text import Text
 from yarl import URL
 
-from cyberdrop_dl import __version__ as current_version
 from cyberdrop_dl.clients.errors import (
     CDLBaseError,
     InvalidExtensionError,
@@ -30,6 +27,8 @@ from cyberdrop_dl.utils.logger import log, log_debug, log_spacer, log_with_color
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from rich.text import Text
 
     from cyberdrop_dl.downloader.downloader import Downloader
     from cyberdrop_dl.managers.manager import Manager
@@ -235,72 +234,6 @@ def delete_empty_folders(manager: Manager):
     purge_dir_tree(manager.path_manager.download_folder)
     if manager.path_manager.sorted_folder and manager.config_manager.settings_data.sorting.sort_downloads:
         purge_dir_tree(manager.path_manager.sorted_folder)
-
-
-def check_latest_pypi(log_to_console: bool = True, call_from_ui: bool = False) -> tuple[str, str]:
-    """Checks if the current version is the latest version."""
-
-    try:
-        with request("GET", constants.PYPI_JSON_URL, timeout=30) as response:
-            contents = response.content
-    except Exception:
-        color = "bold_red"
-        message = Text("Unable to get latest version information", style=color)
-        if call_from_ui:
-            rich.print(message)
-        elif log_to_console:
-            log_with_color(message.plain, color, 40, show_in_stats=False)
-        return "", ""
-
-    data: dict[str, dict] = json.loads(contents)
-    latest_version: str = data["info"]["version"]
-    releases = list(data["releases"].keys())
-    color = ""
-    level = 30
-    is_prerelease, latest_testing_version, message = check_prelease_version(releases)
-
-    if current_version not in releases:
-        message = Text("You are on an unreleased version, skipping version check")
-        color = "bold_yellow"
-    elif is_prerelease:
-        latest_version = latest_testing_version
-        color = "bold_red"
-    elif current_version != latest_version:
-        message_mkup = f"A new version of Cyberdrop-DL is available: [cyan]{latest_version}[/cyan]"
-        message = Text.from_markup(message_mkup)
-    else:
-        message = Text.from_markup("You are currently on the latest version of Cyberdrop-DL :white_check_mark:")
-        level = 20
-
-    if call_from_ui:
-        rich.print(message)
-    elif log_to_console:
-        log_with_color(message.plain, color, level, show_in_stats=False)
-
-    return current_version, latest_version
-
-
-def check_prelease_version(releases: list[str]) -> tuple[bool, str, Text]:
-    match = re.match(constants.PRELEASE_VERSION_PATTERN, current_version)
-    latest_testing_version = ""
-    message = Text("")
-    running_prerelease = next((tag for tag in constants.PRERELEASE_TAGS if tag in current_version), False)
-
-    if running_prerelease and match:
-        major_version, minor_version, patch_version, dot_tag, no_dot_tag = match.groups()
-        test_tag = dot_tag if dot_tag else no_dot_tag
-        regex_str = rf"{major_version}\.{minor_version}\.{patch_version}(\.{test_tag}\d+|{test_tag}\d+)"
-        rough_matches = [release for release in releases if re.match(regex_str, release)]
-        latest_testing_version = max(rough_matches, key=lambda x: int(re.search(r"(\d+)$", x).group()))  # type: ignore
-        ui_tag = constants.PRERELEASE_TAGS.get(test_tag, "Testing").lower()
-
-        if current_version != latest_testing_version:
-            message = f"A new {ui_tag} version of Cyberdrop-DL is available: "
-            message = Text(message).append_text(Text(latest_testing_version, style="cyan"))
-        else:
-            message = f"You are currently on the latest {ui_tag} version of [b cyan]{major_version}.{minor_version}.{patch_version}[/b cyan]"
-            message = Text.from_markup(message)
-    return bool(running_prerelease), latest_testing_version, message
 
 
 async def send_webhook_message(manager: Manager) -> None:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -282,7 +282,7 @@ async def send_webhook_message(manager: Manager) -> None:
         logger(f"Webhook Notifications Results: {result_to_log}")
 
 
-def open_in_text_editor(file_path: Path) -> bool:
+def open_in_text_editor(file_path: Path) -> bool | None:
     """Opens file in OS text editor."""
     using_desktop_enviroment = (
         any(var in os.environ for var in ("DISPLAY", "WAYLAND_DISPLAY")) and "SSH_CONNECTION" not in os.environ


### PR DESCRIPTION
- Ignore any error that may raise while checking for updates
- Move update utils and constants to its own module
- Show update messages with color when running `check updates` from the main UI
- Use stdlib `packaging.version` instead of regex to parse versions
- Refactor all the functions
- Fixes #667

When running a prerelease version:
- Show a warning if a newer prerelease version of the same kind is available (this was the current behavior)
- Show a warning if a newer prerelease version is available but from a different kind
- Show a warning if the latest stable version is newer that the current prerelease version
