### PR TITLE
feat: add google drive support

### DIFF
--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -94,7 +94,9 @@ class ScraperClient:
         with_response_url: bool = False,
         cache_disabled: bool = False,
         retry: bool = True,
-    ) -> BeautifulSoup:
+        *,
+        with_response_headers: bool = False,
+    ) -> BeautifulSoup | tuple[BeautifulSoup, CIMultiDictProxy | URL]:
         """Returns a BeautifulSoup object from the given URL."""
         async with (
             cache_control_manager(client_session, disabled=cache_disabled),
@@ -127,6 +129,8 @@ class ScraperClient:
                     )
                 if with_response_url:
                     return soup, response_URL
+                if with_response_headers:
+                    return soup, response.headers
                 return soup
 
             content_type = response.headers.get("Content-Type")

--- a/cyberdrop_dl/scraper/__init__.py
+++ b/cyberdrop_dl/scraper/__init__.py
@@ -22,6 +22,7 @@ from cyberdrop_dl.scraper.crawlers.erome_crawler import EromeCrawler
 from cyberdrop_dl.scraper.crawlers.f95zone_crawler import F95ZoneCrawler
 from cyberdrop_dl.scraper.crawlers.fapello_crawler import FapelloCrawler
 from cyberdrop_dl.scraper.crawlers.gofile_crawler import GoFileCrawler
+from cyberdrop_dl.scraper.crawlers.google_drive_crawler import GoogleDriveCrawler
 from cyberdrop_dl.scraper.crawlers.hotpic_crawler import HotPicCrawler
 from cyberdrop_dl.scraper.crawlers.imagebam_crawler import ImageBamCrawler
 from cyberdrop_dl.scraper.crawlers.imgbb_crawler import ImgBBCrawler

--- a/cyberdrop_dl/scraper/crawlers/google_drive_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/google_drive_crawler.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: GPL-3.0
+#
+# Licensed under GPL-3.0 as detailed in the root LICENSE file
+#
+# The code in this file has been adapted from an MIT-licensed source.
+# See the MIT License section below for details.
+#
+# Original code from https://github.com/wkentaro/gdown by Kentaro Wada (wkentaro)
+#
+# ----------------------------------------------------------------------
+# MIT License
+# ----------------------------------------------------------------------
+#
+# Copyright (c) 2015 Kentaro Wada
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import calendar
+import re
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING, ClassVar
+
+from aiolimiter import AsyncLimiter
+from dateutil import parser
+from yarl import URL
+
+from cyberdrop_dl.clients.errors import DownloadError, ScrapeError
+from cyberdrop_dl.scraper.crawler import Crawler, create_task_id
+from cyberdrop_dl.utils.data_enums_classes.url_objects import FILE_HOST_ALBUM
+from cyberdrop_dl.utils.utilities import error_handling_wrapper
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bs4 import BeautifulSoup
+
+    from cyberdrop_dl.managers.manager import Manager
+    from cyberdrop_dl.utils.data_enums_classes.url_objects import ScrapeItem
+
+
+FILENAME_REGEX_STR = r"filename\*=UTF-8''(.+)|.*filename=\"(.*?)\""
+FILENAME_REGEX = re.compile(FILENAME_REGEX_STR, re.IGNORECASE)
+VALID_FILE_URL_PARTS = "file", "document", "presentation", "spreadsheets"
+ITEM_SELECTOR = "div.flip-entry-info > a"
+
+
+@dataclass(frozen=True, slots=True)
+class GoogleDriveFolder:
+    id_: str
+    title: str
+    items: tuple[str]
+
+
+class GoogleDriveCrawler(Crawler):
+    SUPPORTED_SITES: ClassVar[dict[str, list]] = {"drive.google": ["drive.google", "docs.google"]}
+    primary_base_domain = URL("https://drive.google.com")
+
+    def __init__(self, manager: Manager, site: str) -> None:
+        super().__init__(manager, site, "GoogleDrive")
+        self.request_limiter = AsyncLimiter(4, 6)
+
+    """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
+
+    @create_task_id
+    async def fetch(self, scrape_item: ScrapeItem) -> None:
+        """Determines where to send the scrape item based on the url."""
+        if is_folder(scrape_item.url):
+            return await self.folder(scrape_item)
+
+        file_id = get_file_id(scrape_item.url)
+        if not file_id:
+            raise ValueError
+
+        await self.file(scrape_item)
+
+    @error_handling_wrapper
+    async def folder(self, scrape_item: ScrapeItem) -> None:
+        folder = await self.get_folder_details(scrape_item)
+        title = self.create_title(folder.title, folder.id_)
+        scrape_item.add_to_parent_title(title)
+        scrape_item.album_id = folder.id_
+        # Do not reset children inside nested folders
+        if scrape_item.type != FILE_HOST_ALBUM:
+            scrape_item.set_type(FILE_HOST_ALBUM, self.manager)
+
+        results = await self.get_album_results(scrape_item.album_id)
+        create = partial(self.create_scrape_item, scrape_item, add_parent=scrape_item.url)
+
+        subfolders = []
+        for link_str in folder.items:
+            link: URL = self.parse_url(link_str)
+            if is_folder(link):
+                subfolders.append(link)
+                continue
+            if not self.check_album_results(link, results):
+                new_scrape_item = create(link)
+                self.manager.task_group.create_task(self.run(new_scrape_item))
+            scrape_item.add_children()
+
+        for folder in subfolders:
+            new_scrape_item = create(folder)
+            self.manager.task_group.create_task(self.run(new_scrape_item))
+            scrape_item.add_children()
+
+    async def get_folder_details(self, scrape_item: ScrapeItem) -> GoogleDriveFolder:
+        folder_id = get_folder_id(scrape_item.url)
+        download_url = get_download_url(folder_id, folder=True)
+        async with self.request_limiter:
+            soup: BeautifulSoup = await self.client.get_soup(self.domain, download_url)
+
+        title: str = soup.title.text.strip()  # type: ignore
+        children = []
+        for item in soup.select(ITEM_SELECTOR):
+            link = item.get("href")
+            if not link:
+                continue
+            children.append(link)
+        children = tuple(children)
+        return GoogleDriveFolder(folder_id, title, children)
+
+    @error_handling_wrapper
+    async def file(self, scrape_item: ScrapeItem, file_id: str = "") -> None:  # type: ignore
+        file_id = file_id or get_file_id(scrape_item.url)
+        if not file_id:
+            raise ScrapeError(422)
+
+        canonical_url = get_canonical_url(file_id)
+        if await self.check_complete_from_referer(canonical_url):
+            return
+
+        download_url = get_download_url(file_id)
+        link, headers = await self.get_file_url_and_headers(download_url, file_id)
+        scrape_item.url = canonical_url
+
+        filename = get_filename_from_headers(headers) or link.name
+        date = get_datetime_from_headers(headers)
+        scrape_item.possible_datetime = date
+        filename, ext = self.get_filename_and_ext(filename)
+        await self.handle_file(canonical_url, scrape_item, filename, ext, debrid_link=link)
+
+    async def get_file_url_and_headers(self, url: URL, file_id: str) -> tuple[URL, dict]:
+        soup: BeautifulSoup | None = None
+        current_url: URL | None = url
+        try_file_open_url = True
+        last_error = None
+        headers = {}
+        while current_url:
+            current_url, headers = await self.add_headers(current_url)
+            if are_valid_headers(headers):
+                return current_url, headers
+
+            try:
+                async with self.request_limiter:
+                    soup, headers = await self.client.get_soup(self.domain, current_url, with_response_headers=True)
+            except DownloadError as e:
+                last_error = e
+                if e.status == 500 and try_file_open_url:
+                    current_url = URL(f"https://drive.google.com/open?id={file_id}")
+                    try_file_open_url = False
+                    continue
+
+            if not soup:
+                raise last_error or ScrapeError(400)
+
+            docs_url = get_docs_url(soup, file_id)
+            if docs_url:
+                current_url = docs_url
+                continue
+
+            if are_valid_headers(headers):
+                return current_url, headers
+
+            current_url = get_url_from_download_button(soup, self.parse_url)
+            if not current_url:
+                break
+            return await self.add_headers(current_url)
+
+        raise ScrapeError(422)
+
+    async def add_headers(self, url: URL) -> tuple[URL, dict]:
+        async with self.request_limiter:
+            headers: dict = await self.client.get_head(self.domain, url)
+        location = headers.get("location")
+        if location:
+            link = self.parse_url(location)
+            return await self.add_headers(link)
+        return url, headers
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+def get_docs_url(soup: BeautifulSoup, file_id: str) -> URL | None:
+    title: str = soup.title.text  # type: ignore
+    if title.endswith(" - Google Docs"):
+        return URL(f"https://docs.google.com/document/d/{file_id}/export?format=docx")
+    if title.endswith(" - Google Sheets"):
+        return URL(f"https://docs.google.com/spreadsheets/d/{file_id}/export?format=xlsx")
+    if title.endswith(" - Google Slides"):
+        return URL(f"https://docs.google.com/presentation/d/{file_id}/export?format=pptx")
+
+
+def get_id_from_query(url: URL) -> str | None:
+    item_id = url.query.get("id")
+    if item_id:
+        if len(item_id) == 1:
+            return item_id[1]
+        return item_id
+
+
+def get_file_id(url: URL) -> str:
+    file_id = get_id_from_query(url)
+    if file_id:
+        return file_id
+
+    if "d" in url.parts and any(p in url.parts for p in VALID_FILE_URL_PARTS):
+        file_id_index = url.parts.index("d") + 1
+        return url.parts[file_id_index]
+    return ""
+
+
+def get_folder_id(url: URL) -> str:
+    # URL should have been pre-validated with `is_folder`
+    folder_id = get_id_from_query(url)
+    if folder_id:
+        return folder_id
+
+    folder_id_index = url.parts.index("folders") + 1
+    return url.parts[folder_id_index]
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+def get_filename_from_headers(headers: dict) -> str | None:
+    content_disposition = headers.get("Content-Disposition")
+    if not content_disposition:
+        return ""
+    match = re.search(FILENAME_REGEX, content_disposition)
+    if match:
+        matches = match.groups()
+        return matches[0] or matches[1]
+
+
+def get_datetime_from_headers(headers: dict) -> int | None:
+    date_str = headers.get("Last-Modified")
+    if date_str:
+        parsed_date = parser.parse(date_str)
+        return calendar.timegm(parsed_date.timetuple())
+
+
+def get_canonical_url(id_: str, folder: bool = False) -> URL:
+    if folder:
+        return URL(f"https://drive.google.com/drive/folders/{id_}")
+    return URL(f"https://drive.google.com/file/d/{id_}")
+
+
+def get_download_url(id_: str, folder: bool = False) -> URL:
+    if folder:
+        return URL(f"https://drive.google.com/embeddedfolderview?id={id_}")
+    return URL(f"https://drive.google.com/uc?id={id_}")
+
+
+def get_url_from_download_button(soup: BeautifulSoup, url_parser: Callable[..., URL]) -> URL | None:
+    ### Todo handle docs,slides and spread sheets
+    form = soup.select_one("#download-form")
+    if not form:
+        return None
+
+    url_str: str = form["action"]  # type: ignore
+    url: URL = url_parser(url_str.replace("&amp;", "&"))
+    query_params = dict(url.query)
+
+    input_tags = soup.select('input[type="hidden"]')
+    for input_tag in input_tags:
+        query_params[input_tag.get("name")] = input_tag.get("value")  # type: ignore
+
+    return url.with_query(query_params)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+def are_valid_headers(headers: dict):
+    return "Content-Disposition" in headers and not is_html(headers)
+
+
+def is_html(headers: dict) -> bool:
+    content_type: str = headers.get("Content-Type", "").lower()
+    return any(s in content_type for s in ("html", "text"))
+
+
+def is_folder(url: URL) -> bool:
+    return "/drive/folders/" in url.path or "embeddedfolderview" in url.parts
+
+
+def is_download_page(url: URL) -> bool:
+    return url.name == "uc" or "usercontent" in url.host  # type: ignore


### PR DESCRIPTION
- Add support for files and folders from google drive, google docs, sheets and slides
- Does not require auth and does not use the API. It will only work with public links unless cookies are used
- Most of the logic is from [gdown](https://github.com/wkentaro/gdown). They essentially reversed engineered how google creates the requests and how to get the required parameters for it
- This implementation can download folders with any number of files (`gdown` only supports folders with up to 50 files)

Current state is fully working but I had to change some core functionality from unrelated modules to get this to work. I will split this into multiple PRs and clean up the code.

The main difference is that we need both the soup and the headers to get all required info. But right now `get_soup` only returns the soup. We have to make another request with `get_head` to get the headers

### The problem with making 2 requests
Request for folders could take over 60 seconds because the list is generated server side on each request. Making 2 requests for each folder is not really optimal, considering google drive supports an unlimited number of files in a folder and unlimited number of nested folders.

There are 2 options:
1. Refactor `get_soup` to make it return the headers alongside the soup 
2. Add yet another kwarg argument to return the headers as well

I did (2) because is easier. (1) will require updating all crawlers but i think is worth doing.
`get_soup` should always return a  tuple: the soup, the response URL and the headers


Doing this will remove some of the kwarg arguments, remove the `get_soup_and_return_url` method and simplify the calls. Crawlers would just drop any of the values they don't need


## TODO
- [ ] Always request the English version of the pages 
- [x] Split into multiple PRs
- [x] Handle a few edge cases
- [x] Raise `ScrapeError` according to edge cases