### PR TITLE
fix: don't update download_filename unless the value is not empty

### DIFF
--- a/cyberdrop_dl/utils/database/tables/history_table.py
+++ b/cyberdrop_dl/utils/database/tables/history_table.py
@@ -159,10 +159,11 @@ class HistoryTable:
                 0,
             ),
         )
-        await self.db_conn.execute(
-            """UPDATE media SET download_filename = ? WHERE domain = ? and url_path = ?""",
-            (download_filename, domain, url_path),
-        )
+        if download_filename:
+            await self.db_conn.execute(
+                """UPDATE media SET download_filename = ? WHERE domain = ? and url_path = ?""",
+                (download_filename, domain, url_path),
+            )
         await self.db_conn.commit()
 
     async def mark_complete(self, domain: str, media_item: MediaItem) -> None:


### PR DESCRIPTION
fixes a bug where download filename is overwritten as a empty value 
before the filename check can check the existence of the previous download_filename
leading to the previous file never resuming as iterate_filename is called