### PR TITLE
refactor: remove left padding from log files

### DIFF
--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -192,7 +192,7 @@ class InvalidYamlError(CDLBaseError):
     def __init__(self, file: Path, e: ConstructorError) -> None:
         """This error will be thrown when a yaml config file has invalid values."""
         mark = e.problem_mark if hasattr(e, "problem_mark") else e
-        message = f"File '{file.resolve()}' has an invalid config. Please verify and edit it manually\n {mark}\n\n{VALIDATION_ERROR_FOOTER}"
+        message = f"File '{file.resolve()}' has an invalid config. \n Please verify and edit it manually\n {mark}\n\n{VALIDATION_ERROR_FOOTER}"
         super().__init__("Invalid YAML", message=message, origin=file)
 
 

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -22,7 +22,7 @@ from cyberdrop_dl.scraper.scraper import ScrapeMapper
 from cyberdrop_dl.ui.program_ui import ProgramUI
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.apprise import send_apprise_notifications
-from cyberdrop_dl.utils.logger import RedactedConsole, log, log_spacer, log_with_color
+from cyberdrop_dl.utils.logger import RedactedConsole, add_custom_log_render, log, log_spacer, log_with_color
 from cyberdrop_dl.utils.sorting import Sorter
 from cyberdrop_dl.utils.utilities import check_latest_pypi, check_partials_and_empty_folders, send_webhook_message
 from cyberdrop_dl.utils.yaml import handle_validation_error
@@ -127,6 +127,7 @@ def setup_startup_logger() -> None:
         console=STARTUP_LOGGER_CONSOLE,
         level=10,
     )
+    add_custom_log_render(rich_file_handler)
     rich_handler = RichHandler(**(constants.RICH_HANDLER_CONFIG | {"show_time": False}), level=10)
     startup_logger.addHandler(rich_file_handler)
     startup_logger.addHandler(rich_handler)
@@ -152,7 +153,9 @@ def setup_debug_logger(manager: Manager) -> Path | None:
         level=manager.config_manager.settings_data.runtime_options.log_level,
     )
 
+    add_custom_log_render(rich_file_handler_debug)
     logger_debug.addHandler(rich_file_handler_debug)
+
     # aiosqlite_log = logging.getLogger("aiosqlite")
     # aiosqlite_log.setLevel(manager.config_manager.settings_data.runtime_options.log_level)
     # aiosqlite_log.addHandler(file_handler_debug)
@@ -182,7 +185,7 @@ def setup_logger(manager: Manager, config_name: str) -> None:
         ),
         level=manager.config_manager.settings_data.runtime_options.log_level,
     )
-
+    add_custom_log_render(rich_file_handler)
     if not manager.parsed_args.cli_only_args.fullscreen_ui:
         constants.CONSOLE_LEVEL = manager.config_manager.settings_data.runtime_options.console_log_level
 

--- a/cyberdrop_dl/utils/logger.py
+++ b/cyberdrop_dl/utils/logger.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from rich.console import Console
-from rich.text import Text
+from rich._log_render import LogRender
+from rich.console import Console, Group
+from rich.containers import Renderables
+from rich.measure import Measurement
+from rich.padding import Padding
+from rich.text import Text, TextType
 
 from cyberdrop_dl import env
 from cyberdrop_dl.utils import constants
@@ -15,6 +20,104 @@ console = Console()
 
 ERROR_PREFIX = "\n[bold red]ERROR: [/bold red]"
 USER_NAME = Path.home().resolve().parts[-1]
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+    from datetime import datetime
+
+    from rich.console import ConsoleRenderable
+    from rich.logging import RichHandler
+
+
+class NoPaddingLogRender(LogRender):
+    cdl_padding = 0
+
+    def __call__(
+        self,
+        console: Console,
+        renderables: Iterable[ConsoleRenderable],
+        log_time: datetime | None = None,
+        time_format: str | Callable[[datetime], Text] | None = None,
+        level: TextType = "",
+        path: str | None = None,
+        line_no: int | None = None,
+        link_path: str | None = None,
+    ):
+        output = Text(no_wrap=True)
+        if self.show_time:
+            log_time = log_time or console.get_datetime()
+            time_format = time_format or self.time_format
+            log_time_display = (
+                time_format(log_time)
+                if callable(time_format)
+                else Text(log_time.strftime(time_format), style="log.time")
+            )
+            if log_time_display == self._last_time and self.omit_repeated_times:
+                output.append(" " * len(log_time_display), style="log.time")
+                output.pad_right(1)
+            else:
+                output.append(log_time_display)
+                output.pad_right(1)
+                self._last_time = log_time_display
+        if self.show_level:
+            output.append(level)
+            output.pad_right(1)
+
+        if self.show_path and path and "logger.py" not in path:
+            path_text = Text(style="log.path")
+            path_text.append(path, style=f"link file://{link_path}" if link_path else "")
+            if line_no:
+                path_text.append(":")
+                path_text.append(
+                    f"{line_no}",
+                    style=f"link file://{link_path}#{line_no}" if link_path else "",
+                )
+            output.append(path_text)
+            output.pad_right(1)
+
+        padded_lines: list[ConsoleRenderable] = []
+        if not self.cdl_padding:
+            self.cdl_padding = get_renderable_length(output)
+        for renderable in Renderables(renderables):  # type: ignore
+            if isinstance(renderable, Text):
+                renderable = indent_text(renderable)
+                renderable.stylize("log.message")
+                output.append(renderable)
+                output.pad_right(1)
+                continue
+            padded_lines.append(Padding(renderable, (0, 0, 0, self.cdl_padding), expand=False))
+
+        output = Group(output, *padded_lines)
+        return output
+
+
+def get_renderable_length(renderable) -> int:
+    measurement = Measurement.get(console, console.options, renderable)
+    return measurement.maximum
+
+
+def indent_text(text: Text, indent: int = 30) -> Text:
+    """Indents each line of a Text object except the first one."""
+    indent_str = Text("\n" + (" " * indent))
+    new_text = Text()
+    lines = text.split("\n")
+    first_line = lines[0]
+    other_lines = lines[1:]
+    for line in other_lines:
+        line.rstrip()
+        new_text.append(indent_str + line)
+    first_line.rstrip()
+    return first_line.append(new_text)
+
+
+def add_custom_log_render(rich_handler: RichHandler) -> None:
+    rich_handler._log_render = NoPaddingLogRender(
+        omit_repeated_times=True,
+        show_time=True,
+        show_level=True,
+        show_path=True,
+    )
 
 
 class RedactedConsole(Console):

--- a/cyberdrop_dl/utils/logger.py
+++ b/cyberdrop_dl/utils/logger.py
@@ -64,6 +64,9 @@ class NoPaddingLogRender(LogRender):
             output.append(level)
             output.pad_right(1)
 
+        if not self.cdl_padding:
+            self.cdl_padding = get_renderable_length(output)
+
         if self.show_path and path and "logger.py" not in path:
             path_text = Text(style="log.path")
             path_text.append(path, style=f"link file://{link_path}" if link_path else "")
@@ -77,14 +80,12 @@ class NoPaddingLogRender(LogRender):
             output.pad_right(1)
 
         padded_lines: list[ConsoleRenderable] = []
-        if not self.cdl_padding:
-            self.cdl_padding = get_renderable_length(output)
+
         for renderable in Renderables(renderables):  # type: ignore
             if isinstance(renderable, Text):
-                renderable = indent_text(renderable)
+                renderable = indent_text(renderable, self.cdl_padding)
                 renderable.stylize("log.message")
                 output.append(renderable)
-                output.pad_right(1)
                 continue
             padded_lines.append(Padding(renderable, (0, 0, 0, self.cdl_padding), expand=False))
 


### PR DESCRIPTION
This was pointed out by @datawhores in #345. I was checking the linked issue in rich and someone proposed their own custom class to not pad the log lines. See: https://github.com/Textualize/rich/discussions/344#discussioncomment-11788991

I modified it to only remove the right padding.

## Changes

- Do not pad the logs to the right
- Do not show the file path if it is `logger.py:...`
- The file path (if any) will show up right next to the log level

## Before

![image](https://github.com/user-attachments/assets/5f891688-0584-4fa5-8bc7-e63c5128b785)


![Before](https://github.com/user-attachments/assets/eb23dd61-170d-4480-bc51-f3061fb61529)

## After

![after](https://github.com/user-attachments/assets/4ebded8f-46c3-4f26-8834-4e91e3a79c85)

![image](https://github.com/user-attachments/assets/d690ceda-9d64-48b8-b0ea-1a27fe856a63)

## Tracebacks

The main reason for using a rich logger is for the rich tracebacks, so i tested those as well and they look fine:

![image](https://github.com/user-attachments/assets/c6c3ae25-581a-4d7f-9fab-ce590b181a28)

![image](https://github.com/user-attachments/assets/ae3941d8-3050-453d-a6f9-5ea418b22b17)


