### PR TITLE
feat: add `--dump-json` option

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -326,6 +326,7 @@ class DownloadClient:
     async def handle_media_item_completion(self, media_item: MediaItem, downloaded: bool = False) -> None:
         """Sends to hash client to handle hashing and marks as completed/current download."""
         try:
+            media_item.downloaded = downloaded
             await self.manager.hash_manager.hash_client.hash_item_during_download(media_item)
             self.manager.path_manager.add_completed(media_item)
         except Exception:

--- a/cyberdrop_dl/clients/hash_client.py
+++ b/cyberdrop_dl/clients/hash_client.py
@@ -41,7 +41,7 @@ class HashClient:
         self.md5 = "md5"
         self.sha256 = "sha256"
         self.hashed_media_items: set[MediaItem] = set()
-        self.hashes_dict: defaultdict[str, defaultdict[str, set[Path]]] = defaultdict(lambda: defaultdict(set))
+        self.hashes_dict: defaultdict[str, defaultdict[int, set[Path]]] = defaultdict(lambda: defaultdict(set))
 
     async def startup(self) -> None:
         pass
@@ -122,10 +122,12 @@ class HashClient:
             log(f"Error hashing {file} : {e}", 40, exc_info=True)
         return hash
 
-    def save_hash_data(self, media_item, hash):
+    def save_hash_data(self, media_item: MediaItem, hash: str):
         absolute_path = media_item.complete_file.resolve()
         size = media_item.complete_file.stat().st_size
         self.hashed_media_items.add(media_item)
+        if hash:
+            media_item.hash = hash
         self.hashes_dict[hash][size].add(absolute_path)
 
     async def cleanup_dupes_after_download(self) -> None:

--- a/cyberdrop_dl/config_definitions/config_settings.py
+++ b/cyberdrop_dl/config_definitions/config_settings.py
@@ -45,6 +45,7 @@ class DownloadOptions(BaseModel):
 class Files(AliasModel):
     download_folder: Path = Field(validation_alias="d", default=DOWNLOAD_STORAGE)
     input_file: Path = Field(validation_alias="i", default=APP_STORAGE / "Configs" / "{config}" / "URLs.txt")
+    dump_json: bool = Field(False, validation_alias="j")
 
 
 class Logs(AliasModel):

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -22,6 +22,7 @@ from cyberdrop_dl.scraper.scraper import ScrapeMapper
 from cyberdrop_dl.ui.program_ui import ProgramUI
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.apprise import send_apprise_notifications
+from cyberdrop_dl.utils.dumper import Dumper
 from cyberdrop_dl.utils.logger import RedactedConsole, add_custom_log_render, log, log_spacer, log_with_color
 from cyberdrop_dl.utils.sorting import Sorter
 from cyberdrop_dl.utils.utilities import check_latest_pypi, check_partials_and_empty_folders, send_webhook_message
@@ -112,6 +113,10 @@ async def post_runtime(manager: Manager) -> None:
 
     if manager.config_manager.settings_data.runtime_options.update_last_forum_post:
         await manager.log_manager.update_last_forum_post()
+
+    if manager.config_manager.settings_data.files.dump_json:
+        dumper = Dumper(manager)
+        await dumper.run()
 
 
 def setup_startup_logger() -> None:

--- a/cyberdrop_dl/utils/data_enums_classes/url_objects.py
+++ b/cyberdrop_dl/utils/data_enums_classes/url_objects.py
@@ -48,6 +48,8 @@ class MediaItem:
     partial_file: Path | None = field(default=None, init=False)
     complete_file: Path | None = field(default=None, init=False)
     task_id: TaskID | None = field(default=None, init=False, hash=False, compare=False)
+    hash: str | None = field(default=None, init=False, hash=False, compare=False)
+    downloaded: bool = field(default=False, init=False, hash=False, compare=False)
 
     # slots for __post_init__
     referer: URL = field(init=False)

--- a/cyberdrop_dl/utils/dumper.py
+++ b/cyberdrop_dl/utils/dumper.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    from cyberdrop_dl.managers.manager import Manager
+
+
+class Dumper:
+    def __init__(self, manager: Manager) -> None:
+        self.manager = manager
+        self.jsonl_file = manager.path_manager.main_log.with_suffix(".results.jsonl")
+
+    def get_media_items_as_dict(self) -> Generator[dict]:
+        for item in self.manager.path_manager.prev_downloads:
+            yield asdict(item)
+        for item in self.manager.path_manager.completed_downloads:
+            yield asdict(item)
+
+    def run(self):
+        dump_jsonl(self.get_media_items_as_dict(), self.jsonl_file)
+
+
+def dump_jsonl(data: Generator[dict], file: Path) -> None:
+    with file.open("w", encoding="utf8") as f:
+        for item in data:
+            json.dump(item, f)
+        f.write("\n")

--- a/cyberdrop_dl/utils/dumper.py
+++ b/cyberdrop_dl/utils/dumper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import asdict
 from typing import TYPE_CHECKING
@@ -22,12 +23,13 @@ class Dumper:
         for item in self.manager.path_manager.completed_downloads:
             yield asdict(item)
 
-    def run(self):
-        dump_jsonl(self.get_media_items_as_dict(), self.jsonl_file)
+    async def run(self) -> None:
+        await dump_jsonl(self.get_media_items_as_dict(), self.jsonl_file)
 
 
-def dump_jsonl(data: Generator[dict], file: Path) -> None:
+async def dump_jsonl(data: Generator[dict], file: Path) -> None:
     with file.open("w", encoding="utf8") as f:
         for item in data:
             json.dump(item, f)
-        f.write("\n")
+            f.write("\n")
+            await asyncio.sleep(0)  # required to update the UI, but there's no UI at the moment

--- a/cyberdrop_dl/utils/dumper.py
+++ b/cyberdrop_dl/utils/dumper.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
     from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem
 
 
+KEYS_TO_REMOVE = "file_lock_reference_name", "task_id"
+KEYS_TO_REPLACE = {"current_attempt": "attempts"}
+
+
 class Dumper:
     def __init__(self, manager: Manager) -> None:
         self.manager = manager
@@ -35,7 +39,10 @@ def convert_to_dict(media_item: MediaItem) -> dict:
     item = asdict(media_item)
     if date:
         item["datetime"] = datetime.datetime.fromtimestamp(date)
-    return item
+    for key, new_key in KEYS_TO_REPLACE.items():
+        item[new_key] = item[key]
+        del item[key]
+    return {k: v for k, v in item.items() if k not in KEYS_TO_REMOVE}
 
 
 async def dump_jsonl(data: Generator[dict], file: Path) -> None:

--- a/cyberdrop_dl/utils/dumper.py
+++ b/cyberdrop_dl/utils/dumper.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
+import enum
 import json
 from dataclasses import asdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Generator
     from pathlib import Path
 
     from cyberdrop_dl.managers.manager import Manager
+    from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem
 
 
 class Dumper:
@@ -19,17 +22,41 @@ class Dumper:
 
     def get_media_items_as_dict(self) -> Generator[dict]:
         for item in self.manager.path_manager.prev_downloads:
-            yield asdict(item)
+            yield convert_to_dict(item)
         for item in self.manager.path_manager.completed_downloads:
-            yield asdict(item)
+            yield convert_to_dict(item)
 
     async def run(self) -> None:
         await dump_jsonl(self.get_media_items_as_dict(), self.jsonl_file)
 
 
+def convert_to_dict(media_item: MediaItem) -> dict:
+    date = media_item.datetime
+    item = asdict(media_item)
+    if date:
+        item["datetime"] = datetime.datetime.fromtimestamp(date)
+    return item
+
+
 async def dump_jsonl(data: Generator[dict], file: Path) -> None:
     with file.open("w", encoding="utf8") as f:
         for item in data:
-            json.dump(item, f)
+            json.dump(item, f, cls=JSONStrEncoder)
             f.write("\n")
             await asyncio.sleep(0)  # required to update the UI, but there's no UI at the moment
+
+
+class JSONStrEncoder(json.JSONEncoder):
+    """Serialize incompatible objects as str"""
+
+    def default(self, obj: Any) -> str:
+        if isinstance(obj, datetime.datetime):
+            obj = obj.isoformat()
+        if isinstance(obj, enum.Enum):
+            obj = obj.value
+        if isinstance(obj, set):
+            obj = sorted(obj)
+        try:
+            return super().default(obj)
+        except TypeError:
+            return str(obj)


### PR DESCRIPTION
## Changes
- Save `downloaded` and `hash` as properties of `MediaItem`
- Add `--dump-json` option to create a jsonl file with the info of all the items processed in this run *

Not all items are saved because we do not keep a reference for the skipped ones. Keeping track of them will require a bigger refactor but i will wait until #557 is merged to do it

I added the option to the `Files` category and not `Logs` because the results are not "logged". The file is only created at the end of a run, inside `post_runtime`. If CDL crashes or is stopped by the user, the file will not be created