### PR TITLE
feat: improve hotpic crawler

### DIFF
--- a/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
@@ -39,8 +39,7 @@ class HotPicCrawler(Crawler):
             return await self.file(scrape_item)
         elif any(p in scrape_item.url.parts for p in ("uploads", "reddit")):
             return await self.handle_direct_link(scrape_item)
-        else:
-            raise ValueError
+        raise ValueError
 
     @error_handling_wrapper
     async def album(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yarl import URL
 
@@ -16,10 +16,11 @@ if TYPE_CHECKING:
 
 
 class HotPicCrawler(Crawler):
+    SUPPORTED_SITES: ClassVar[dict[str, list]] = {"hotpic": ["hotpic", "2385290.xyz"]}
     primary_base_domain = URL("https://hotpic.cc")
 
-    def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, "hotpic", "HotPic")
+    def __init__(self, manager: Manager, site: str) -> None:
+        super().__init__(manager, site, "HotPic")
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
@@ -30,7 +31,7 @@ class HotPicCrawler(Crawler):
             return await self.album(scrape_item)
         elif "i" in scrape_item.url.parts:
             return await self.image(scrape_item)
-        elif "uploads" in scrape_item.url.parts:
+        elif any(p in scrape_item.url.parts for p in ("uploads", "reddit")):
             return await self.handle_direct_link(scrape_item)
         else:
             raise ValueError

--- a/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
@@ -23,6 +23,7 @@ ALBUM_ITEM_SELECTOR = "a[class*=spotlight]"
 class HotPicCrawler(Crawler):
     SUPPORTED_SITES: ClassVar[dict[str, list]] = {"hotpic": ["hotpic", "2385290.xyz"]}
     primary_base_domain = URL("https://hotpic.cc")
+    update_unsupported = True
 
     def __init__(self, manager: Manager, site: str) -> None:
         super().__init__(manager, site, "HotPic")

--- a/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/hotpic_crawler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from yarl import URL
@@ -26,9 +27,11 @@ class HotPicCrawler(Crawler):
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         """Determines where to send the scrape item based on the url."""
         if "album" in scrape_item.url.parts:
-            await self.album(scrape_item)
+            return await self.album(scrape_item)
         elif "i" in scrape_item.url.parts:
-            await self.image(scrape_item)
+            return await self.image(scrape_item)
+        elif "uploads" in scrape_item.url.parts:
+            return await self.handle_direct_link(scrape_item)
         else:
             raise ValueError
 
@@ -39,14 +42,14 @@ class HotPicCrawler(Crawler):
             soup: BeautifulSoup = await self.client.get_soup(self.domain, scrape_item.url, origin=scrape_item)
 
         scrape_item.album_id = scrape_item.url.parts[2]
-        title = self.create_title(soup.select_one("title").text.rsplit(" - ")[0], scrape_item.album_id)
+        title = self.create_title(soup.title.text.rsplit(" - ")[0], scrape_item.album_id)  # type: ignore
         scrape_item.add_to_parent_title(title)
         scrape_item.part_of_album = True
         scrape_item.set_type(FILE_HOST_ALBUM, self.manager)
 
         files = soup.select("a[class*=spotlight]")
         for file in files:
-            link_str: str = file.get("href")
+            link_str: str = file.get("href")  # type: ignore
             link = self.parse_url(link_str)
             filename, ext = get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)
@@ -61,7 +64,28 @@ class HotPicCrawler(Crawler):
         async with self.request_limiter:
             soup: BeautifulSoup = await self.client.get_soup(self.domain, scrape_item.url, origin=scrape_item)
 
-        link_str: str = soup.select_one("img[id*=main-image]").get("src")
+        link_str: str = soup.select_one("img[id*=main-image]").get("src")  # type: ignore
         link = self.parse_url(link_str)
         filename, ext = get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)
+
+    @error_handling_wrapper
+    async def handle_direct_link(self, scrape_item: ScrapeItem) -> None:
+        link = thumbnail_to_img(scrape_item.url)
+        filename, ext = get_filename_and_ext(link.name)
+        await self.handle_file(link, scrape_item, filename, ext)
+
+
+def thumbnail_to_img(url: URL) -> URL:
+    if "thumb" not in url.parts:
+        return url
+
+    url = with_suffix_encoded(url, ".jpg")
+    new_parts = [p for p in url.parts if p not in ("/", "thumb")]
+    new_path = "/".join(new_parts)
+    return url.with_path(new_path)
+
+
+def with_suffix_encoded(url: URL, suffix: str) -> URL:
+    name = Path(url.raw_name).with_suffix(suffix)
+    return url.parent.joinpath(str(name), encoded=True).with_query(url.query).with_fragment(url.fragment)


### PR DESCRIPTION
- Add support for direct URLs as input
- Always download full res images instead of thumbnails
- Add support for their alternative domain, 2385290.xyz
- Add support for videos
- Use canonical URL for database