### PR TITLE
feat: replace `no_crawler` with a generic crawler to download from unsupported sites

### DIFF
--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -75,13 +75,16 @@ def retry(func: Callable) -> Callable:
     return wrapper
 
 
+GENERIC_CRAWLERS = ".", "no_crawler"
+
+
 class Downloader:
     def __init__(self, manager: Manager, domain: str) -> None:
         self.manager: Manager = manager
         self.domain: str = domain
 
         self.client: DownloadClient = field(init=False)
-        self.log_prefix = "Download attempt (unsupported domain)" if domain == "no_crawler" else "Download"
+        self.log_prefix = "Download attempt (unsupported domain)" if domain in GENERIC_CRAWLERS else "Download"
         self.processed_items: set = set()
         self.waiting_items = 0
 

--- a/cyberdrop_dl/scraper/__init__.py
+++ b/cyberdrop_dl/scraper/__init__.py
@@ -22,8 +22,8 @@ from cyberdrop_dl.scraper.crawlers.eporner_crawler import EpornerCrawler
 from cyberdrop_dl.scraper.crawlers.erome_crawler import EromeCrawler
 from cyberdrop_dl.scraper.crawlers.f95zone_crawler import F95ZoneCrawler
 from cyberdrop_dl.scraper.crawlers.fapello_crawler import FapelloCrawler
-from cyberdrop_dl.scraper.crawlers.generic_crawler import GenericCrawler
 from cyberdrop_dl.scraper.crawlers.fileditch_crawler import FileditchCrawler
+from cyberdrop_dl.scraper.crawlers.generic_crawler import GenericCrawler
 from cyberdrop_dl.scraper.crawlers.gofile_crawler import GoFileCrawler
 from cyberdrop_dl.scraper.crawlers.google_drive_crawler import GoogleDriveCrawler
 from cyberdrop_dl.scraper.crawlers.hotpic_crawler import HotPicCrawler

--- a/cyberdrop_dl/scraper/__init__.py
+++ b/cyberdrop_dl/scraper/__init__.py
@@ -22,6 +22,7 @@ from cyberdrop_dl.scraper.crawlers.eporner_crawler import EpornerCrawler
 from cyberdrop_dl.scraper.crawlers.erome_crawler import EromeCrawler
 from cyberdrop_dl.scraper.crawlers.f95zone_crawler import F95ZoneCrawler
 from cyberdrop_dl.scraper.crawlers.fapello_crawler import FapelloCrawler
+from cyberdrop_dl.scraper.crawlers.generic_crawler import GenericCrawler
 from cyberdrop_dl.scraper.crawlers.fileditch_crawler import FileditchCrawler
 from cyberdrop_dl.scraper.crawlers.gofile_crawler import GoFileCrawler
 from cyberdrop_dl.scraper.crawlers.google_drive_crawler import GoogleDriveCrawler

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -43,6 +43,7 @@ class Crawler(ABC):
     DEFAULT_POST_TITLE_FORMAT = "{date} - {number} - {title}"
     update_unsupported = False
     skip_pre_check = False
+    scrape_prefix = "Scraping:"
 
     def __init__(self, manager: Manager, domain: str, folder_domain: str | None = None) -> None:
         self.manager = manager
@@ -99,7 +100,7 @@ class Crawler(ABC):
         async with self._semaphore:
             self.waiting_items -= 1
             if item.url.path_qs not in self.scraped_items:
-                log(f"Scraping: {item.url}", 20)
+                log(f"{self.scrape_prefix} {item.url}", 20)
                 self.scraped_items.append(item.url.path_qs)
                 await self.fetch(item)
             else:

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -44,6 +44,7 @@ class Crawler(ABC):
     update_unsupported = False
     skip_pre_check = False
     scrape_prefix = "Scraping:"
+    scrape_mapper_domain = ""
 
     def __init__(self, manager: Manager, domain: str, folder_domain: str | None = None) -> None:
         self.manager = manager

--- a/cyberdrop_dl/scraper/crawlers/generic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/generic_crawler.py
@@ -49,12 +49,11 @@ class FakeURL:
 
 class GenericCrawler(Crawler):
     primary_base_domain = FakeURL(host=".")  # type: ignore
-    domain = "."  # for scrape mapper matching
     scrape_prefix = "Scraping (unsupported domain):"
+    scrape_mapper_domain = "."
 
     def __init__(self, manager: Manager) -> None:
-        super().__init__(manager, ".", "Generic")
-        self.domain = "generic"  # For UI and database
+        super().__init__(manager, "generic", "Generic")
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/scraper/crawlers/generic_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/generic_crawler.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import mimetypes
+from functools import wraps
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from cyberdrop_dl.clients.errors import InvalidContentTypeError, NoExtensionError, ScrapeError
+from cyberdrop_dl.scraper.crawler import Crawler, create_task_id
+from cyberdrop_dl.scraper.filters import has_valid_extension
+from cyberdrop_dl.utils.logger import log
+from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bs4 import BeautifulSoup
+    from yarl import URL
+
+    from cyberdrop_dl.managers.manager import Manager
+    from cyberdrop_dl.utils.data_enums_classes.url_objects import ScrapeItem
+
+
+VIDEO_SELECTOR = "video > source"
+
+
+@error_handling_wrapper
+def log_unsupported_wrapper(func: Callable) -> Callable:
+    @wraps(func)
+    async def wrapper(self: GenericCrawler, item: ScrapeItem, *args, **kwargs):
+        try:
+            return await func(self, *args, **kwargs)
+        except (InvalidContentTypeError, ScrapeError):
+            return await self.log_unsupported(item)
+        except Exception:
+            raise
+
+    return wrapper
+
+
+class GenericCrawler(Crawler):
+    def __init__(self, manager: Manager) -> None:
+        super().__init__(manager, ".", "Generic")
+
+    """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
+
+    @create_task_id
+    async def fetch(self, scrape_item: ScrapeItem) -> None:
+        """Determines where to send the scrape item based on the url."""
+        await self.file(scrape_item)
+
+    @log_unsupported_wrapper
+    async def file(self, scrape_item: ScrapeItem) -> None:
+        """Scrapes a file trying to guess the ext from the headers"""
+        content_type = await self.get_content_type(scrape_item.url)
+        if any(s in content_type.lower() for s in ("html", "text")):
+            return await self.try_video_from_soup(scrape_item)
+
+        filename, ext = guess_filename_and_ext(scrape_item.url, content_type)
+        if not ext:
+            msg = f"Received '{content_type}', was expecting other"
+            raise InvalidContentTypeError(message=msg)
+        fullname = Path(filename).with_suffix(ext)
+        filename, _ = get_filename_and_ext(fullname.name)
+        await self.handle_file(scrape_item.url, scrape_item, filename, ext)
+
+    async def get_content_type(self, url: URL) -> str:
+        async with self.request_limiter:
+            headers: dict = await self.client.get_head(self.domain, url)
+        content_type: str = headers.get("Content-Length", "")
+        if not content_type:
+            raise ScrapeError(422)
+        return content_type.lower()
+
+    async def try_video_from_soup(self, scrape_item: ScrapeItem) -> None:
+        async with self.request_limiter:
+            soup: BeautifulSoup = await self.client.get_soup(self.domain, scrape_item.url, origin=scrape_item)
+
+        title: str = soup.select_one("title").text  # type: ignore
+        title = title.rsplit(" - ", 1)[0].rsplit("|", 1)[0]
+
+        video = soup.select_one(VIDEO_SELECTOR)
+        if not video:
+            raise ScrapeError(422)
+
+        link_str: str = video.get("href")  # type: ignore
+        link = self.parse_url(link_str)
+        try:
+            filename, ext = get_filename_and_ext(link.name)
+        except NoExtensionError:
+            filename, ext = get_filename_and_ext(link.name + ".mp4")
+        await self.handle_file(link, scrape_item, filename, ext)
+
+    async def log_unsupported(self, scrape_item: ScrapeItem) -> None:
+        log(f"Unsupported URL: {scrape_item.url}", 30)
+        await self.manager.log_manager.write_unsupported_urls_log(
+            scrape_item.url,
+            scrape_item.parents[0] if scrape_item.parents else None,
+        )
+        self.manager.progress_manager.scrape_stats_progress.add_unsupported()
+
+
+def guess_filename_and_ext(url: URL, content_type: str) -> tuple[str, str | None]:
+    filename, ext = get_name_and_ext_from_url(url)
+    if filename and ext:
+        return filename, ext
+    return url.name, get_ext_from_content_type(content_type)
+
+
+def get_ext_from_content_type(content_type: str) -> str | None:
+    return mimetypes.guess_extension(content_type) or CONTENT_TYPE_TO_EXTENSION.get(content_type)
+
+
+def get_name_and_ext_from_url(url: URL) -> tuple[str, str | None]:
+    if not has_valid_extension(url):
+        return url.name, None
+    try:
+        filename, ext = get_filename_and_ext(url.name)
+    except NoExtensionError:
+        filename, ext = get_filename_and_ext(url.name, forum=True)
+    return filename, ext
+
+
+CONTENT_TYPE_TO_EXTENSION = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "application/pdf": ".pdf",
+    "audio/mpeg": ".mp3",
+    "audio/wav": ".wav",
+    "video/mp4": ".mp4",
+    "video/webm": ".webm",
+    "application/zip": ".zip",
+    "application/gzip": ".gz",
+    "application/x-tar": ".tar",
+    "image/svg+xml": ".svg",
+}

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -58,7 +58,8 @@ class ScrapeMapper:
             if not crawler.SUPPORTED_SITES:
                 site_crawler = crawler(self.manager)  # type: ignore
                 assert site_crawler.domain not in self.existing_crawlers
-                self.existing_crawlers[site_crawler.domain] = site_crawler
+                key = site_crawler.scrape_mapper_domain or site_crawler.domain
+                self.existing_crawlers[key] = site_crawler
                 continue
 
             for site, domains in crawler.SUPPORTED_SITES.items():


### PR DESCRIPTION
The generic crawler will:

1. Make an initial request to get the headers of the URL.
2. If the content type is `html`, it will  get the soup and try to get a video file from it
3. If the content type is `text` or `json`, it will log the URL as unsupported

For any other content type, it will try to guess the extension of the file following this logic:
1. Get the extension from the URL name,
2. Get the extension from the URL name, but assuming the URL is from a forum
3. Guess the extension from the content type in the headers


## Possible results
1. If the crawler tried to get a video from the soup but there's no video, the URL will be logged as unsupported.

2. If they crawler can't guess the extension, it will log the URL as unsupported

3. If there's any request errors during the process, it will be logged as an `ScrapeError`

4. If the crawler can successfully get an URL to download and a valid extension, it will send it to the downloader. From that point, any error will be logged as a `DownloadError`