### PR TITLE
fix: `File is being used by another process` error if a validation error raises when running multiple configs

### DIFF
--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -31,8 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 startup_logger = logging.getLogger("cyberdrop_dl_startup")
-STARTUP_LOGGER_FILE = Path().cwd().joinpath("startup.log")
-STARTUP_LOGGER_CONSOLE = None
+STARTUP_LOGGER_FILE = Path.cwd().joinpath("startup.log")
 
 
 def startup() -> Manager:
@@ -41,7 +40,8 @@ def startup() -> Manager:
     This will also run the UI for the program
     After this function returns, the manager will be ready to use and scraping / downloading can begin.
     """
-    setup_startup_logger()
+
+    setup_startup_logger(first_time_setup=True)
     try:
         manager = Manager()
         manager.startup()
@@ -99,11 +99,8 @@ async def runtime(manager: Manager) -> None:
 async def post_runtime(manager: Manager) -> None:
     """Actions to complete after main runtime, and before ui shutdown."""
     log_spacer(20, log_to_console=False)
-    log_with_color(
-        f"Running Post-Download Processes For Config: {manager.config_manager.loaded_config}",
-        "green",
-        20,
-    )
+    msg = f"Running Post-Download Processes For Config: {manager.config_manager.loaded_config}"
+    log_with_color(msg, "green", 20)
     # checking and removing dupes
     if not (manager.multiconfig and manager.config_manager.settings_data.sorting.sort_downloads):
         await manager.hash_manager.hash_client.cleanup_dupes_after_download()
@@ -117,51 +114,41 @@ async def post_runtime(manager: Manager) -> None:
         await manager.log_manager.update_last_forum_post()
 
 
-def setup_startup_logger() -> None:
-    global STARTUP_LOGGER_CONSOLE
+def setup_startup_logger(*, first_time_setup: bool = False) -> None:
+    if first_time_setup:
+        STARTUP_LOGGER_FILE.unlink(missing_ok=True)  # Only delete file once. Subsequent calls will append to file
+    destroy_startup_logger()
     startup_logger.setLevel(10)
-    STARTUP_LOGGER_FILE.unlink(missing_ok=True)
-    STARTUP_LOGGER_CONSOLE = RedactedConsole(
-        file=STARTUP_LOGGER_FILE.open("w", encoding="utf8"),
-        width=constants.DEFAULT_CONSOLE_WIDTH,
-    )
-    rich_file_handler = RichHandler(
-        **constants.RICH_HANDLER_CONFIG,
-        console=STARTUP_LOGGER_CONSOLE,
-        level=10,
-    )
-    add_custom_log_render(rich_file_handler)
-    rich_handler = RichHandler(**(constants.RICH_HANDLER_CONFIG | {"show_time": False}), level=10)
-    startup_logger.addHandler(rich_file_handler)
-    startup_logger.addHandler(rich_handler)
+    file_io = STARTUP_LOGGER_FILE.open("a", encoding="utf8")
+    file_console = RedactedConsole(file=file_io, width=constants.DEFAULT_CONSOLE_WIDTH)
+    file_handler = RichHandler(**constants.RICH_HANDLER_CONFIG, console=file_console, level=10)
+    console_handler = RichHandler(**(constants.RICH_HANDLER_CONFIG | {"show_time": False}), level=10)
+    add_custom_log_render(file_handler)
+    startup_logger.addHandler(file_handler)
+    startup_logger.addHandler(console_handler)
 
 
 def setup_debug_logger(manager: Manager) -> Path | None:
     if not env.DEBUG_VAR:
-        return None
+        return
 
     logger_debug = logging.getLogger("cyberdrop_dl_debug")
-    manager.config_manager.settings_data.runtime_options.log_level = 10
-    logger_debug.setLevel(manager.config_manager.settings_data.runtime_options.log_level)
+    log_level = 10
+    manager.config_manager.settings_data.runtime_options.log_level = log_level
+    logger_debug.setLevel(log_level)
     debug_log_file_path = Path(__file__).parents[1] / "cyberdrop_dl_debug.log"
     if env.DEBUG_LOG_FOLDER:
         date = datetime.now().strftime("%Y%m%d_%H%M%S")
         debug_log_file_path = Path(env.DEBUG_LOG_FOLDER) / f"cyberdrop_dl_debug_{date}.log"
 
-    rich_file_handler_debug = RichHandler(
-        **constants.RICH_HANDLER_DEBUG_CONFIG,
-        console=Console(
-            file=debug_log_file_path.open("w", encoding="utf8"),
-            width=manager.config_manager.settings_data.logs.log_line_width,
-        ),
-        level=manager.config_manager.settings_data.runtime_options.log_level,
-    )
-
-    add_custom_log_render(rich_file_handler_debug)
-    logger_debug.addHandler(rich_file_handler_debug)
+    file_io = debug_log_file_path.open("w", encoding="utf8")
+    file_console = Console(file=file_io, width=manager.config_manager.settings_data.logs.log_line_width)
+    file_handler_debug = RichHandler(**constants.RICH_HANDLER_DEBUG_CONFIG, console=file_console, level=log_level)
+    add_custom_log_render(file_handler_debug)
+    logger_debug.addHandler(file_handler_debug)
 
     # aiosqlite_log = logging.getLogger("aiosqlite")
-    # aiosqlite_log.setLevel(manager.config_manager.settings_data.runtime_options.log_level)
+    # aiosqlite_log.setLevel(log_level)
     # aiosqlite_log.addHandler(file_handler_debug)
 
     return debug_log_file_path.resolve()
@@ -169,6 +156,7 @@ def setup_debug_logger(manager: Manager) -> Path | None:
 
 def setup_logger(manager: Manager, config_name: str) -> None:
     logger = logging.getLogger("cyberdrop_dl")
+    setup_startup_logger()  # To log any possible errors while changing configs ex: validation errors
     if manager.multiconfig:
         if len(logger.handlers) > 0:
             log("Picking new config...", 20)
@@ -179,28 +167,36 @@ def setup_logger(manager: Manager, config_name: str) -> None:
             logger.removeHandler(logger.handlers[0])
             old_file_handler.close()
 
-    logger.setLevel(manager.config_manager.settings_data.runtime_options.log_level)
+    destroy_startup_logger()  # Delete startup file if empty
+    log_level = manager.config_manager.settings_data.runtime_options.log_level
+    console_log_level = manager.config_manager.settings_data.runtime_options.console_log_level
+    logger.setLevel(log_level)
 
-    rich_file_handler = RichHandler(
-        **constants.RICH_HANDLER_CONFIG,
-        console=RedactedConsole(
-            file=manager.path_manager.main_log.open("w", encoding="utf8"),
-            width=manager.config_manager.settings_data.logs.log_line_width,
-        ),
-        level=manager.config_manager.settings_data.runtime_options.log_level,
-    )
-    add_custom_log_render(rich_file_handler)
     if not manager.parsed_args.cli_only_args.fullscreen_ui:
-        constants.CONSOLE_LEVEL = manager.config_manager.settings_data.runtime_options.console_log_level
+        constants.CONSOLE_LEVEL = console_log_level
 
-    rich_handler = RichHandler(
-        **(constants.RICH_HANDLER_CONFIG | {"show_time": False}),
-        console=Console(),
-        level=constants.CONSOLE_LEVEL,
-    )
+    file_io = manager.path_manager.main_log.open("w", encoding="utf8")
+    file_console = RedactedConsole(file=file_io, width=manager.config_manager.settings_data.logs.log_line_width)
+    file_handler = RichHandler(**constants.RICH_HANDLER_CONFIG, console=file_console, level=log_level)
+    console_handler = RichHandler(**(constants.RICH_HANDLER_CONFIG | {"show_time": False}), level=console_log_level)
+    add_custom_log_render(file_handler)
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
 
-    logger.addHandler(rich_file_handler)
-    logger.addHandler(rich_handler)
+
+def destroy_startup_logger(remove_all_handlers: bool = True) -> None:
+    handlers: list[RichHandler] = startup_logger.handlers  # type: ignore
+    for handler in handlers:
+        if not (handler.console._file or remove_all_handlers):
+            continue
+        if handler.console._file:
+            handler.console._file.close()
+        startup_logger.removeHandler(handler)
+        handler.close()
+
+    if STARTUP_LOGGER_FILE.is_file() and STARTUP_LOGGER_FILE.stat().st_size >= 0:
+        return
+    STARTUP_LOGGER_FILE.unlink(missing_ok=True)
 
 
 def ui_error_handling_wrapper(func: Callable) -> Callable:
@@ -234,9 +230,7 @@ async def director(manager: Manager) -> None:
     if manager.multiconfig:
         configs_to_run = manager.config_manager.get_configs()
 
-    if STARTUP_LOGGER_FILE.is_file() and STARTUP_LOGGER_FILE.stat().st_size == 0:
-        STARTUP_LOGGER_CONSOLE.file.close()
-        STARTUP_LOGGER_FILE.unlink()
+    destroy_startup_logger()  # Delete startup file created while initializing the manager (if empty)
 
     start_time = manager.start_time
     while configs_to_run:

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -1,6 +1,7 @@
 import re
 from enum import Enum, IntEnum, StrEnum, auto
 from pathlib import Path
+from typing import Any
 
 from rich.text import Text
 
@@ -10,7 +11,7 @@ MAX_NAME_LENGTHS = {"FILE": 95, "FOLDER": 60}
 DEFAULT_CONSOLE_WIDTH = 240
 CSV_DELIMITER = ","
 LOG_OUTPUT_TEXT = Text("")
-RICH_HANDLER_CONFIG = {"show_time": True, "rich_tracebacks": True, "tracebacks_show_locals": False}
+RICH_HANDLER_CONFIG: dict[str, Any] = {"show_time": True, "rich_tracebacks": True, "tracebacks_show_locals": False}
 RICH_HANDLER_DEBUG_CONFIG = {
     "show_time": True,
     "rich_tracebacks": True,


### PR DESCRIPTION
Changes the startup logger behavior by creating and immediately destroying all of its handlers.

It will create the startup logger before any critical section of code where we may not have the manager ready.

It will destroy the startup logger after each of these sections but only delete the startup log file if the file is empty.

These sections are:
- The setup of the manager itself
- Calls to `manager.config_manager.change_config`

Also refactors some of the logic for the main and debug loggers