### PR TITLE
fix: handle OS errors on startup (log files)

### DIFF
--- a/cyberdrop_dl/env.py
+++ b/cyberdrop_dl/env.py
@@ -2,9 +2,9 @@ import os
 from hashlib import sha256
 
 RUNNING_IN_IDE = os.getenv("PYCHARM_HOSTED") or os.getenv("TERM_PROGRAM") == "vscode"
-KEY = os.getenv("ENABLESIMPCITY")
-if KEY:
-    KEY = sha256(KEY.encode("utf-8")).hexdigest()
+ENABLE_DEBUG_CRAWLERS = os.getenv("CDL_ENABLE_DEBUG_CRAWLERS")
+if ENABLE_DEBUG_CRAWLERS:
+    ENABLE_DEBUG_CRAWLERS = sha256(ENABLE_DEBUG_CRAWLERS.encode("utf-8")).hexdigest()
 
 DEBUG_LOG_FOLDER = os.getenv("CDL_DEBUG_LOG_FOLDER")
 PROFILING = os.getenv("CDL_PROFILING")

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -119,13 +119,14 @@ def setup_startup_logger(*, first_time_setup: bool = False) -> None:
         STARTUP_LOGGER_FILE.unlink(missing_ok=True)  # Only delete file once. Subsequent calls will append to file
     destroy_startup_logger()
     startup_logger.setLevel(10)
+    console_handler = RichHandler(**(constants.RICH_HANDLER_CONFIG | {"show_time": False}), level=10)
+    startup_logger.addHandler(console_handler)
+
     file_io = STARTUP_LOGGER_FILE.open("a", encoding="utf8")
     file_console = RedactedConsole(file=file_io, width=constants.DEFAULT_CONSOLE_WIDTH)
     file_handler = RichHandler(**constants.RICH_HANDLER_CONFIG, console=file_console, level=10)
-    console_handler = RichHandler(**(constants.RICH_HANDLER_CONFIG | {"show_time": False}), level=10)
     add_custom_log_render(file_handler)
     startup_logger.addHandler(file_handler)
-    startup_logger.addHandler(console_handler)
 
 
 def destroy_startup_logger(remove_all_handlers: bool = True) -> None:

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -161,11 +161,18 @@ def setup_debug_logger(manager: Manager) -> Path | None:
     manager.config_manager.settings_data.runtime_options.log_level = log_level
     logger_debug.setLevel(log_level)
     debug_log_file_path = Path(__file__).parents[1] / "cyberdrop_dl_debug.log"
-    if env.DEBUG_LOG_FOLDER:
-        date = datetime.now().strftime("%Y%m%d_%H%M%S")
-        debug_log_file_path = Path(env.DEBUG_LOG_FOLDER) / f"cyberdrop_dl_debug_{date}.log"
+    with startup_logging():
+        if env.DEBUG_LOG_FOLDER:
+            debug_log_folder = Path(env.DEBUG_LOG_FOLDER)
+            if not debug_log_folder.is_dir():
+                msg = "Value of env var 'CDL_DEBUG_LOG_FOLDER' is invalid."
+                msg += f" Folder '{debug_log_folder}' does not exists"
+                startup_logger.error(msg)
+                sys.exit(1)
+            date = datetime.now().strftime("%Y%m%d_%H%M%S")
+            debug_log_file_path = debug_log_folder / f"cyberdrop_dl_debug_{date}.log"
+        file_io = debug_log_file_path.open("w", encoding="utf8")
 
-    file_io = debug_log_file_path.open("w", encoding="utf8")
     file_console = Console(file=file_io, width=manager.config_manager.settings_data.logs.log_line_width)
     file_handler_debug = RichHandler(**constants.RICH_HANDLER_DEBUG_CONFIG, console=file_console, level=log_level)
     add_custom_log_render(file_handler_debug)
@@ -191,6 +198,8 @@ def setup_logger(manager: Manager, config_name: str) -> None:
                 logger.removeHandler(logger.handlers[0])
                 old_file_handler.close()
 
+        file_io = manager.path_manager.main_log.open("w", encoding="utf8")
+
     log_level = manager.config_manager.settings_data.runtime_options.log_level
     console_log_level = manager.config_manager.settings_data.runtime_options.console_log_level
     logger.setLevel(log_level)
@@ -198,7 +207,6 @@ def setup_logger(manager: Manager, config_name: str) -> None:
     if not manager.parsed_args.cli_only_args.fullscreen_ui:
         constants.CONSOLE_LEVEL = console_log_level
 
-    file_io = manager.path_manager.main_log.open("w", encoding="utf8")
     file_console = RedactedConsole(file=file_io, width=manager.config_manager.settings_data.logs.log_line_width)
     file_handler = RichHandler(**constants.RICH_HANDLER_CONFIG, console=file_console, level=log_level)
     console_handler = RichHandler(**(constants.RICH_HANDLER_CONFIG | {"show_time": False}), level=console_log_level)

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -171,7 +171,11 @@ def setup_debug_logger(manager: Manager) -> Path | None:
                 sys.exit(1)
             date = datetime.now().strftime("%Y%m%d_%H%M%S")
             debug_log_file_path = debug_log_folder / f"cyberdrop_dl_debug_{date}.log"
-        file_io = debug_log_file_path.open("w", encoding="utf8")
+        try:
+            file_io = debug_log_file_path.open("w", encoding="utf8")
+        except OSError as e:
+            startup_logger.exception(str(e))
+            sys.exit(1)
 
     file_console = Console(file=file_io, width=manager.config_manager.settings_data.logs.log_line_width)
     file_handler_debug = RichHandler(**constants.RICH_HANDLER_DEBUG_CONFIG, console=file_console, level=log_level)
@@ -198,7 +202,11 @@ def setup_logger(manager: Manager, config_name: str) -> None:
                 logger.removeHandler(logger.handlers[0])
                 old_file_handler.close()
 
-        file_io = manager.path_manager.main_log.open("w", encoding="utf8")
+        try:
+            file_io = manager.path_manager.main_log.open("w", encoding="utf8")
+        except OSError as e:
+            startup_logger.exception(str(e))
+            sys.exit(1)
 
     log_level = manager.config_manager.settings_data.runtime_options.log_level
     console_log_level = manager.config_manager.settings_data.runtime_options.console_log_level

--- a/cyberdrop_dl/profiling.py
+++ b/cyberdrop_dl/profiling.py
@@ -53,7 +53,7 @@ def setup_profile(temp_dir: Path | str) -> tuple[Path, Path]:
 
     os.chdir(temp_dir_path)
     print(f"Using {temp_dir_path} as temp AppData dir")
-    env.DEBUG_LOG_FILE_FOLDER = temp_dir_path
+    env.DEBUG_LOG_FOLDER = temp_dir_path
     return old_cwd, temp_dir_path
 
 

--- a/cyberdrop_dl/scraper/__init__.py
+++ b/cyberdrop_dl/scraper/__init__.py
@@ -67,12 +67,8 @@ if TYPE_CHECKING:
     from cyberdrop_dl.scraper.crawler import Crawler
 
 ALL_CRAWLERS: set[type[Crawler]] = {crawler for name, crawler in globals().items() if name.endswith("Crawler")}
-DISABLED_CRAWLERS = {SimpCityCrawler}
-DEBUG_CRAWLERS = {BunkrAlbumsIOCrawler}
-CRAWLERS = ALL_CRAWLERS - DISABLED_CRAWLERS - DEBUG_CRAWLERS
+DEBUG_CRAWLERS = {SimpCityCrawler, BunkrAlbumsIOCrawler}
+CRAWLERS = ALL_CRAWLERS - DEBUG_CRAWLERS
 
-if env.RUNNING_IN_IDE:
+if env.ENABLE_DEBUG_CRAWLERS == "d396ab8c85fcb1fecd22c8d9b58acf944a44e6d35014e9dd39e42c9a64091eda":
     CRAWLERS.update(DEBUG_CRAWLERS)
-
-if env.KEY == "d396ab8c85fcb1fecd22c8d9b58acf944a44e6d35014e9dd39e42c9a64091eda":
-    CRAWLERS.update(DISABLED_CRAWLERS)


### PR DESCRIPTION
- Rename some env variables
- Check that the value of `CDL_DEBUG_LOG_FOLDER` exists, is a folder and CDL has permissions to write to it (if supplied)
- Check that CDL has permissions to write to the main log file
- An error on any of the previous cases will be logged to the startup log file
