### PR TITLE
ci/cd: run tests with matrix in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+    env:
+        APPRISE_TEST_EMAIL_URL: ${{ secrets.APPRISE_TEST_EMAIL_URL }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.11, 3.12, 3.13]
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          export PATH="$HOME/.poetry/bin:$PATH"
+
+
+      - name: Install dependencies
+        run: |
+          poetry install
+
+      - name: Run pytest
+        run: |
+          poetry run pytest -v --cov

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -290,13 +290,12 @@ async def director(manager: Manager) -> None:
         start_time = perf_counter()
 
 
-def main():
-    profiling: bool = False
+def main(*, profiling: bool = False, ask: bool = True):
     if not (profiling or env.PROFILING):
         return actual_main()
     from cyberdrop_dl.profiling import profile
 
-    profile(actual_main)
+    profile(actual_main, ask)
 
 
 def actual_main() -> None:

--- a/cyberdrop_dl/profiling.py
+++ b/cyberdrop_dl/profiling.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def profile(func: Callable) -> None:
+def profile(func: Callable, ask: bool) -> None:
     @contextmanager
     def temp_dir_context():
         with TemporaryDirectory() as temp_dir:
@@ -28,7 +28,8 @@ def profile(func: Callable) -> None:
                 yield
             finally:
                 destroy_profile(*profile)
-                input("Press any key to finish and delete the profile folder: ")
+                if ask:
+                    input("Press any key to finish and delete the profile folder: ")
 
     with temp_dir_context(), cProfile.Profile() as cdl_profile:
         with contextlib.suppress(SystemExit):
@@ -64,6 +65,7 @@ def destroy_profile(old_cwd: Path, temp_dir_path: Path) -> None:
     if env.PROFILING == "use_date":
         suffix += f"_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
     new_log_file = Path(f"cyberdrop_dl_debug_{suffix}.log").resolve()
-    shutil.move(old_log_file, new_log_file)
+    if old_log_file.is_file():
+        shutil.move(old_log_file, new_log_file)
     print(f"Profile AppData folder: {temp_dir_path}")
     print(f"Debug log file: {new_log_file}")

--- a/cyberdrop_dl/utils/args.py
+++ b/cyberdrop_dl/utils/args.py
@@ -205,7 +205,7 @@ class CustomHelpFormatter(RawDescriptionHelpFormatter):
 
     def format_help(self):
         help_text = super().format_help()
-        if env.RUNNING_IN_IDE:
+        if env.RUNNING_IN_IDE and CLI_ARGUMENTS_MD.is_file():
             cli_overview, *_ = help_text.partition(CDL_EPILOG)
             current_text = CLI_ARGUMENTS_MD.read_text(encoding="utf8")
             new_text, *_ = current_text.partition("```shell")

--- a/poetry.lock
+++ b/poetry.lock
@@ -840,20 +840,20 @@ files = [
 
 [[package]]
 name = "jeepney"
-version = "0.8.0"
+version = "0.9.0"
 description = "Low-level, pure Python DBus protocol wrapper."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 markers = "\"bsd\" in sys_platform or sys_platform == \"linux\""
 files = [
-    {file = "jeepney-0.8.0-py3-none-any.whl", hash = "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755"},
-    {file = "jeepney-0.8.0.tar.gz", hash = "sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"},
+    {file = "jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"},
+    {file = "jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"},
 ]
 
 [package.extras]
 test = ["async-timeout", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
-trio = ["async_generator", "trio"]
+trio = ["trio"]
 
 [[package]]
 name = "lz4"
@@ -1124,7 +1124,7 @@ version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "test"]
+groups = ["main", "dev", "test"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -2433,4 +2433,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4"
-content-hash = "8672605afcff235b74fe5a5716dd563bc3e7520d12c93c7d546642f9cdfe0851"
+content-hash = "c14586d18c677cfe8f662ef358e7e3fc8a6837ac3dc1b5c1c7be0558430cc758"

--- a/poetry.lock
+++ b/poetry.lock
@@ -356,6 +356,18 @@ pycryptodomex = "*"
 shadowcopy = {version = "*", markers = "python_version >= \"3.7\" and platform_system == \"Windows\""}
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
+    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -377,6 +389,18 @@ groups = ["dev"]
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
 ]
 
 [[package]]
@@ -502,7 +526,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "test"]
+groups = ["main", "dev", "test"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -1233,7 +1257,7 @@ version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
-groups = ["test"]
+groups = ["dev", "test"]
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -1619,6 +1643,25 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyproject-api"
+version = "1.9.0"
+description = "API to interact with the python pyproject.toml based projects"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pyproject_api-1.9.0-py3-none-any.whl", hash = "sha256:326df9d68dea22d9d98b5243c46e3ca3161b07a1b9b18e213d1e24fd0e605766"},
+    {file = "pyproject_api-1.9.0.tar.gz", hash = "sha256:7e8a9854b2dfb49454fae421cb86af43efbb2b2454e5646ffb7623540321ae6e"},
+]
+
+[package.dependencies]
+packaging = ">=24.2"
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx-autodoc-typehints (>=3)"]
+testing = ["covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)", "setuptools (>=75.8)"]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
@@ -1997,6 +2040,32 @@ files = [
     {file = "tornado-6.4.2-cp38-abi3-win_amd64.whl", hash = "sha256:908b71bf3ff37d81073356a5fadcc660eb10c1476ee6e2725588626ce7e5ca38"},
     {file = "tornado-6.4.2.tar.gz", hash = "sha256:92bad5b4746e9879fd7bf1eb21dce4e3fc5128d71601f80005afa39237ad620b"},
 ]
+
+[[package]]
+name = "tox"
+version = "4.24.1"
+description = "tox is a generic virtualenv management and test command line tool"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "tox-4.24.1-py3-none-any.whl", hash = "sha256:57ba7df7d199002c6df8c2db9e6484f3de6ca8f42013c083ea2d4d1e5c6bdc75"},
+    {file = "tox-4.24.1.tar.gz", hash = "sha256:083a720adbc6166fff0b7d1df9d154f9d00bfccb9403b8abf6bc0ee435d6a62e"},
+]
+
+[package.dependencies]
+cachetools = ">=5.5"
+chardet = ">=5.2"
+colorama = ">=0.4.6"
+filelock = ">=3.16.1"
+packaging = ">=24.2"
+platformdirs = ">=4.3.6"
+pluggy = ">=1.5"
+pyproject-api = ">=1.8"
+virtualenv = ">=20.27.1"
+
+[package.extras]
+test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.3)", "pytest-mock (>=3.14)"]
 
 [[package]]
 name = "types-python-dateutil"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ requires-poetry = ">=2.0"
 pre-commit = ">=4.0.1,<5"
 ruff = "0.9.6"
 snakeviz = "^2.2.2"
+tox = "^4.24.1"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=8.3.4,<9"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+import sys
+
+import pytest
+
+from cyberdrop_dl.main import main
+
+
+def test_help(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    # This is just to test that cyberdrop is able to run in the current python version
+    monkeypatch.setattr(sys, "argv", ["pytest", "--help"])
+    main(profiling=True, ask=False)
+    captured = capsys.readouterr()
+    output = captured.out
+    assert "Bulk asynchronous downloader for multiple file hosts" in output

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,6 @@ envlist = py311, py312, py313
 [testenv]
 allowlist_externals = poetry
 commands_pre =
-    poetry install --no-root --sync
+    poetry sync --no-root
 commands =
     poetry run pytest tests/ -v --cov --import-mode importlib

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py311, py312, py313
+
+[testenv]
+allowlist_externals = poetry
+commands_pre =
+    poetry install --no-root --sync
+commands =
+    poetry run pytest tests/ -v --cov --import-mode importlib


### PR DESCRIPTION
- Add a GH workflow to run CDL on pushes to master with ubuntu, windows and macOS, python 3.11 to 3.13
- Add tox config to be able to replicate the behavior of the action locally
- Add a basic test to just run `--help`

@jbsparrow you have to set a secret on the repo for the Apprise tests to work. The name should be `APPRISE_TEST_EMAIL_URL`

Its values does not have to be an email, it can be anything that supports attachments, like a discord webhook, but it should be in the apprise format