### PR TITLE
Feature: Add Hyperlinks to Logged Paths

### DIFF
--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -18,6 +18,7 @@ from cyberdrop_dl.ui.progress.scraping_progress import ScrapingProgress
 from cyberdrop_dl.ui.progress.sort_progress import SortProgress
 from cyberdrop_dl.ui.progress.statistic_progress import DownloadStatsProgress, ScrapeStatsProgress
 from cyberdrop_dl.utils.logger import log, log_spacer, log_with_color
+from pathlib import Path
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -99,8 +100,15 @@ class ProgressManager:
 
         log_spacer(20)
         log("Printing Stats...\n", 20)
-        log_cyan(f"Run Stats (config: {self.manager.config_manager.loaded_config}):")
-        log_yellow(f"  Input File: {get_input(self.manager)}")
+        config_path = self.manager.path_manager.replace_config_in_path(self.manager.path_manager.config_folder / "{config}").absolute()
+        input_file = get_input(self.manager)
+        if isinstance(input_file, Path):
+            input_file_text = f"[link=file://{input_file.absolute()}]{input_file}[/link]"
+        else:
+            input_file_text = input_file
+        log_cyan(f"Run Stats (config: [link=file://{config_path}]{self.manager.config_manager.loaded_config}[/link]):", markup=True)
+        log_yellow(f"  Log Folder: [link=file://{self.manager.path_manager.log_folder.absolute()}]{self.manager.path_manager.log_folder}[/link]", markup=True)
+        log_yellow(f"  Input File: {input_file_text}", markup=True)
         log_yellow(f"  Input URLs: {self.manager.scrape_mapper.count:,}")
         log_yellow(f"  Input URL Groups: {self.manager.scrape_mapper.group_count:,}")
         log_yellow(f"  Total Runtime: {runtime}")
@@ -158,4 +166,4 @@ def get_input(manager: Manager) -> Path | str:
         return "--retry-failed"
     if manager.parsed_args.cli_only_args.retry_maintenance:
         return "--retry-maintenance"
-    return manager.config_manager.settings_data.files.input_file
+    return manager.path_manager.input_file

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -114,9 +114,10 @@ class ProgressManager:
             f"  Log Folder: [link=file://{self.manager.path_manager.log_folder.absolute()}]{self.manager.path_manager.log_folder}[/link]",
             markup=True,
         )
-        log_yellow(f"  Input File: {input_file_text}", markup=True)
+        if self.manager.scrape_mapper.using_input_file:
+            log_yellow(f"  Input File: {input_file_text}", markup=True)
+            log_yellow(f"  Input URL Groups: {self.manager.scrape_mapper.group_count:,}")
         log_yellow(f"  Input URLs: {self.manager.scrape_mapper.count:,}")
-        log_yellow(f"  Input URL Groups: {self.manager.scrape_mapper.group_count:,}")
         log_yellow(f"  Total Runtime: {runtime}")
         log_yellow(f"  Total Downloaded Data: {data_size}")
 

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -100,7 +100,7 @@ class ProgressManager:
         log_spacer(20)
         log("Printing Stats...\n", 20)
         config_path = self.manager.path_manager.config_folder / self.manager.config_manager.loaded_config
-        config_path_text = get_console_hyperlink(config_path)
+        config_path_text = get_console_hyperlink(config_path, text=self.manager.config_manager.loaded_config)
         input_file_text = get_input(self.manager)
         log_folder_text = get_console_hyperlink(self.manager.path_manager.log_folder)
         log_cyan(f"Run Stats (config: {config_path_text}):", markup=True)
@@ -168,6 +168,7 @@ def get_input(manager: Manager) -> str:
     return "--links (CLI args)"
 
 
-def get_console_hyperlink(file_path: Path) -> str:
+def get_console_hyperlink(file_path: Path, text: str = "") -> str:
     full_path = file_path.resolve()
-    return f"[link=file://{full_path}]{full_path}[/link]"
+    show_text = text or full_path
+    return f"[link=file://{full_path}]{show_text}[/link]"

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -4,6 +4,7 @@ import time
 from dataclasses import field
 from datetime import timedelta
 from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pydantic import ByteSize
@@ -18,11 +19,8 @@ from cyberdrop_dl.ui.progress.scraping_progress import ScrapingProgress
 from cyberdrop_dl.ui.progress.sort_progress import SortProgress
 from cyberdrop_dl.ui.progress.statistic_progress import DownloadStatsProgress, ScrapeStatsProgress
 from cyberdrop_dl.utils.logger import log, log_spacer, log_with_color
-from pathlib import Path
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from rich.console import RenderableType
 
     from cyberdrop_dl.managers.manager import Manager
@@ -100,14 +98,22 @@ class ProgressManager:
 
         log_spacer(20)
         log("Printing Stats...\n", 20)
-        config_path = self.manager.path_manager.replace_config_in_path(self.manager.path_manager.config_folder / "{config}").absolute()
+        config_path = self.manager.path_manager.replace_config_in_path(
+            self.manager.path_manager.config_folder / "{config}"
+        ).absolute()
         input_file = get_input(self.manager)
         if isinstance(input_file, Path):
             input_file_text = f"[link=file://{input_file.absolute()}]{input_file}[/link]"
         else:
             input_file_text = input_file
-        log_cyan(f"Run Stats (config: [link=file://{config_path}]{self.manager.config_manager.loaded_config}[/link]):", markup=True)
-        log_yellow(f"  Log Folder: [link=file://{self.manager.path_manager.log_folder.absolute()}]{self.manager.path_manager.log_folder}[/link]", markup=True)
+        log_cyan(
+            f"Run Stats (config: [link=file://{config_path}]{self.manager.config_manager.loaded_config}[/link]):",
+            markup=True,
+        )
+        log_yellow(
+            f"  Log Folder: [link=file://{self.manager.path_manager.log_folder.absolute()}]{self.manager.path_manager.log_folder}[/link]",
+            markup=True,
+        )
         log_yellow(f"  Input File: {input_file_text}", markup=True)
         log_yellow(f"  Input URLs: {self.manager.scrape_mapper.count:,}")
         log_yellow(f"  Input URL Groups: {self.manager.scrape_mapper.group_count:,}")

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -169,4 +169,5 @@ def get_input(manager: Manager) -> str:
 
 
 def get_console_hyperlink(file_path: Path) -> str:
-    return f"[link=file://{file_path.resolve()}]{file_path}[/link]"
+    full_path = file_path.resolve()
+    return f"[link=file://{full_path}]{full_path}[/link]"

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -42,7 +42,7 @@ class ScrapeMapper:
         self.no_crawler_downloader = Downloader(self.manager, "no_crawler")
         self.jdownloader = JDownloader(self.manager)
         self.jdownloader_whitelist = self.manager.config_manager.settings_data.runtime_options.jdownloader_whitelist
-        self.using_input_file = True
+        self.using_input_file = False
         self.group_count = 0
         self.count = 0
 
@@ -151,10 +151,10 @@ class ScrapeMapper:
 
         links = {"": []}
         if not self.manager.parsed_args.cli_only_args.links:
+            self.using_input_file = True
             links = await self.parse_input_file_groups()
 
         else:
-            self.using_input_file = False
             links[""].extend(self.manager.parsed_args.cli_only_args.links)
 
         links = {k: list(filter(None, v)) for k, v in links.items()}

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -42,8 +42,9 @@ class ScrapeMapper:
         self.no_crawler_downloader = Downloader(self.manager, "no_crawler")
         self.jdownloader = JDownloader(self.manager)
         self.jdownloader_whitelist = self.manager.config_manager.settings_data.runtime_options.jdownloader_whitelist
-        self.count = 0
+        self.using_input_file = True
         self.group_count = 0
+        self.count = 0
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
@@ -153,6 +154,7 @@ class ScrapeMapper:
             links = await self.parse_input_file_groups()
 
         else:
+            self.using_input_file = False
             links[""].extend(self.manager.parsed_args.cli_only_args.links)
 
         links = {k: list(filter(None, v)) for k, v in links.items()}

--- a/cyberdrop_dl/utils/logger.py
+++ b/cyberdrop_dl/utils/logger.py
@@ -141,10 +141,12 @@ def log_debug(message: Exception | str, level: int = 10, **kwargs) -> None:
         logger_debug.log(level, message.encode("ascii", "ignore").decode("ascii"), **kwargs)
 
 
-def log_with_color(message: str, style: str, level: int, show_in_stats: bool = True, **kwargs) -> None:
+def log_with_color(message: str, style: str, level: int, show_in_stats: bool = True, markup: bool = False, **kwargs) -> None:
     """Simple logging function with color."""
     log(message, level, **kwargs)
     text = Text(message, style=style)
+    if markup:
+        text = Text.from_markup(message, style=style)
     if constants.CONSOLE_LEVEL >= 50:
         console.print(text)
     if show_in_stats:

--- a/cyberdrop_dl/utils/logger.py
+++ b/cyberdrop_dl/utils/logger.py
@@ -141,7 +141,9 @@ def log_debug(message: Exception | str, level: int = 10, **kwargs) -> None:
         logger_debug.log(level, message.encode("ascii", "ignore").decode("ascii"), **kwargs)
 
 
-def log_with_color(message: str, style: str, level: int, show_in_stats: bool = True, markup: bool = False, **kwargs) -> None:
+def log_with_color(
+    message: str, style: str, level: int, show_in_stats: bool = True, markup: bool = False, **kwargs
+) -> None:
     """Simple logging function with color."""
     log(message, level, **kwargs)
     text = Text(message, style=style)


### PR DESCRIPTION
Added hyperlinks to paths that are logged to the terminal. If the user's terminal supports it, the path will be embedded as a hyperlink and the user can click on it to open the file/folder.

Also added the log folder to the end of run output because many people have trouble finding it.

Also hides the 'Input File' and 'Input URL Groups' runtime stats if the user isn't using the input file. Closes #718 