### PR TITLE
refactor: simplify error message logging

### DIFF
--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -49,6 +49,11 @@ class CDLBaseError(Exception):
             self.status = status
             super().__init__(self.status)
 
+    def __str__(self):
+        if self.ui_message == self.message:
+            return self.message
+        return f"{self.ui_message} - {self.message}"
+
 
 class InvalidContentTypeError(CDLBaseError):
     def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:

--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import singledispatch
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from yaml import YAMLError
 from yarl import URL
@@ -50,9 +50,13 @@ class CDLBaseError(Exception):
             super().__init__(self.status)
 
     def __str__(self):
-        if self.ui_message == self.message:
-            return self.message
-        return f"{self.ui_message} - {self.message}"
+        return self.format(self.ui_message, self.message)
+
+    @classmethod
+    def format(cls, ui_message: str, message: str) -> str:
+        if ui_message == message:
+            return message
+        return f"{ui_message} - {message}"
 
 
 class InvalidContentTypeError(CDLBaseError):
@@ -231,3 +235,9 @@ def get_origin(origin: ScrapeItem | Path | MediaItem | URL | None = None) -> Pat
     if origin and not isinstance(origin, URL | Path):
         return origin.parents[0] if origin.parents else None
     return origin
+
+
+class ErrorLogMessage(NamedTuple):
+    ui_msg: str
+    main_log_msg: str
+    csv_log_msg: str

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -15,6 +15,7 @@ from cyberdrop_dl.clients.errors import (
     DownloadError,
     DurationError,
     InsufficientFreeSpaceError,
+    InvalidContentTypeError,
     RestrictedFiletypeError,
 )
 from cyberdrop_dl.utils.constants import CustomHTTPStatus
@@ -189,7 +190,7 @@ class Downloader:
             self.manager.progress_manager.download_progress.add_skipped()
             self.attempt_task_removal(media_item)
 
-        except (DownloadError, ClientResponseError):
+        except (DownloadError, ClientResponseError, InvalidContentTypeError):
             raise
 
         except (

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -14,6 +14,7 @@ from filedate import File
 from cyberdrop_dl.clients.errors import (
     DownloadError,
     DurationError,
+    ErrorLogMessage,
     InsufficientFreeSpaceError,
     InvalidContentTypeError,
     RestrictedFiletypeError,
@@ -215,12 +216,12 @@ class Downloader:
             message = str(e)
             raise DownloadError(ui_message, message, retry=True) from e
 
-    async def write_download_error(self, media_item: MediaItem, log_msg: str, ui_msg: str, exc_info=None) -> None:
+    async def write_download_error(self, media_item: MediaItem, error_log_msg: ErrorLogMessage, exc_info=None) -> None:
         self.attempt_task_removal(media_item)
-        full_message = f"{self.log_prefix} Failed: {media_item.url} ({log_msg}) \n -> Referer: {media_item.referer}"
+        full_message = f"{self.log_prefix} Failed: {media_item.url} ({error_log_msg.main_log_msg}) \n -> Referer: {media_item.referer}"
         log(full_message, 40, exc_info=exc_info)  # type: ignore
-        await self.manager.log_manager.write_download_error_log(media_item, log_msg)  # type: ignore
-        self.manager.progress_manager.download_stats_progress.add_failure(ui_msg)
+        await self.manager.log_manager.write_download_error_log(media_item, error_log_msg.csv_log_msg)  # type: ignore
+        self.manager.progress_manager.download_stats_progress.add_failure(error_log_msg.ui_msg)
         self.manager.progress_manager.download_progress.add_failed()
 
     @staticmethod

--- a/cyberdrop_dl/managers/log_manager.py
+++ b/cyberdrop_dl/managers/log_manager.py
@@ -62,7 +62,7 @@ class LogManager:
             self.download_error_log, url=media_item.url, error=error_message, referer=media_item.referer, origin=origin
         )
 
-    async def write_scrape_error_log(self, url: URL, error_message: str, origin: URL | None = None) -> None:
+    async def write_scrape_error_log(self, url: URL, error_message: str, origin: URL | Path | None = None) -> None:
         """Writes to the scrape error log."""
         await self.write_to_csv(self.scrape_error_log, url=url, error=error_message, origin=origin)
 


### PR DESCRIPTION
- Handle error formatting inside CDL custom error
- Create a custom class to hold the 3 possible messages when an error raises (UI, main log and CSV log messages)
- Do not retry `InvalidContentType` errors