### PR TITLE
fix: remove recursive requests calls and recursive locks from flaresolverr class

### DIFF
--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -265,7 +265,6 @@ class Flaresolverr:
         """Base request function to call flaresolverr."""
         if not self.enabled:
             raise DDOSGuardError(message="FlareSolverr is not configured", origin=origin)
-
         async with self.session_lock:
             if not (self.session_id or kwargs.get("session")):
                 await self._create_session()
@@ -278,7 +277,6 @@ class Flaresolverr:
         for key, value in kwargs.items():
             if isinstance(value, URL):
                 kwargs[key] = str(value)
-
         data = {"cmd": command, "maxTimeout": 60000, "session": self.session_id} | kwargs
 
         self.request_count += 1
@@ -312,7 +310,7 @@ class Flaresolverr:
     async def _destroy_session(self):
         if self.session_id:
             async with ClientSession() as client_session:
-                await self._request("sessions.destroy", client_session, session=self.session_id)
+                await self._request("sessions.destroy", client_session)
 
     async def get(
         self,

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -266,8 +266,8 @@ class Flaresolverr:
         if not self.enabled:
             raise DDOSGuardError(message="FlareSolverr is not configured", origin=origin)
 
-        if not (self.session_id or kwargs.get("session")):
-            async with self.session_lock:
+        async with self.session_lock:
+            if not (self.session_id or kwargs.get("session")):
                 await self._create_session()
         return await self._make_request(command, client_session, **kwargs)
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -266,7 +266,7 @@ class Flaresolverr:
         if not self.enabled:
             raise DDOSGuardError(message="FlareSolverr is not configured", origin=origin)
         async with self.session_lock:
-            if not (self.session_id or kwargs.get("session")):
+            if not self.session_id:
                 await self._create_session()
         return await self._make_request(command, client_session, **kwargs)
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -310,7 +310,7 @@ class Flaresolverr:
     async def _destroy_session(self):
         if self.session_id:
             async with ClientSession() as client_session:
-                await self._request("sessions.destroy", client_session, session=self.session_id)
+                await self._make_request("sessions.destroy", client_session, session=self.session_id)
                 self.session_id = None
 
     async def get(

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -266,11 +266,12 @@ class Flaresolverr:
         if not self.enabled:
             raise DDOSGuardError(message="FlareSolverr is not configured", origin=origin)
         async with self.session_lock:
-            if not self.session_id:
+            if not (self.session_id or kwargs.get("session")):
                 await self._create_session()
         return await self._make_request(command, client_session, **kwargs)
 
     async def _make_request(self, command: str, client_session: ClientSession, **kwargs):
+        client_session = kwargs.pop("session", client_session)
         headers = client_session.headers.copy()
         headers.update({"Content-Type": "application/json"})
         for key, value in kwargs.items():
@@ -310,7 +311,6 @@ class Flaresolverr:
         if self.session_id:
             async with ClientSession() as client_session:
                 await self._request("sessions.destroy", client_session)
-                self.session_id = None
 
     async def get(
         self,

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -266,9 +266,9 @@ class Flaresolverr:
         if not self.enabled:
             raise DDOSGuardError(message="FlareSolverr is not configured", origin=origin)
 
-        async with self.session_lock:
-            if not (self.session_id or kwargs.get("session")):
-                await self._create_session()
+        # async with self.session_lock:
+        if not (self.session_id or kwargs.get("session")):
+            await self._create_session()
 
         headers = client_session.headers.copy()
         headers.update({"Content-Type": "application/json"})

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -310,6 +310,7 @@ class Flaresolverr:
         if self.session_id:
             async with ClientSession() as client_session:
                 await self._request("sessions.destroy", client_session)
+                self.session_id = None
 
     async def get(
         self,

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -271,7 +271,7 @@ class Flaresolverr:
         return await self._make_request(command, client_session, **kwargs)
 
     async def _make_request(self, command: str, client_session: ClientSession, **kwargs):
-        client_session = kwargs.pop("session", client_session)
+        client_session = kwargs.pop("client_session", client_session)
         headers = client_session.headers.copy()
         headers.update({"Content-Type": "application/json"})
         for key, value in kwargs.items():
@@ -310,7 +310,8 @@ class Flaresolverr:
     async def _destroy_session(self):
         if self.session_id:
             async with ClientSession() as client_session:
-                await self._request("sessions.destroy", client_session)
+                await self._request("sessions.destroy", client_session, session=self.session_id)
+                self.session_id = None
 
     async def get(
         self,

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -271,7 +271,6 @@ class Flaresolverr:
         return await self._make_request(command, client_session, **kwargs)
 
     async def _make_request(self, command: str, client_session: ClientSession, **kwargs):
-        client_session = kwargs.pop("session", client_session)
         headers = client_session.headers.copy()
         headers.update({"Content-Type": "application/json"})
         for key, value in kwargs.items():


### PR DESCRIPTION
flaresolverr locks program currently because recursive calls to the _requests function means the child call is stuck waiting for the parent to release