### PR TITLE
Increase Partial File Removal Speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Changed
+
+- Speed up checking for empty files & folders by up to 2x
+- Speed up sorting files by up to 1.5x
+
 ## [6.6.1] - 2025-02-28
 
 ### Fixed

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -202,7 +202,7 @@ def parse_rich_text_by_style(text: Text, style_map: dict, default_style_map_key:
 
 def purge_dir_tree(dirname: Path) -> None:
     """Purges empty files and directories efficiently."""
-    if not dirname.exists():
+    if not dirname.is_dir():
         return
 
     # Use os.walk() to remove empty files and directories in a single pass


### PR DESCRIPTION
This speeds up checking for and removing partial and empty files/folders by up to 2 times.

In my testing, checking partials took an average of 54.4 seconds before these changes, and an average of 32.8 seconds after these changes. Both were averaged over five tests.

Sorting is also faster now but I didn't do tests for the speed increase. I estimate around a 1.2-1.5x speed increase.