### PR TITLE
ci/cd: update tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
 
 jobs:
   test:
-    env:
-        APPRISE_TEST_EMAIL_URL: ${{ secrets.APPRISE_TEST_EMAIL_URL }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -43,3 +41,30 @@ jobs:
       - name: Run pytest
         run: |
           poetry run pytest -v --cov --ignore=tests/test_apprise.py
+
+  test_apprise:
+    env:
+      APPRISE_TEST_EMAIL_URL: ${{ secrets.APPRISE_TEST_EMAIL_URL }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          export PATH="$HOME/.poetry/bin:$PATH"
+
+      - name: Install dependencies
+        run: |
+          poetry install
+
+      - name: Run pytest
+        run: |
+          poetry run pytest -v --cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          poetry run pytest -v --cov
+          poetry run pytest --cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          poetry run pytest -v --cov
+          poetry run pytest -v --cov --ignore=tests/test_apprise.py


### PR DESCRIPTION
### Changes

- Do not tests apprise notifications on every python version. They will only be tested once on their own runner using Ubuntu and python 3.11
- Fix relative path of apprise tests file in CI
- Update expected log messages for using discord instead of an email
- Include the name of the tests in the notifications
- Do not run apprise tests in verbose mode. The webhook URL was being logged. I'm not sure if this is enough to prevent that.

The apprise log messages for discord do not include if an attachment was successful or not, so i had to also refactor the apprise module itself to:

- Include failed attachment in logs (the log message comes from CDL, not apprise)
- Exit on apprise validation errors