### PR TITLE
perf: use generators for input item URLs

### DIFF
--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -159,7 +159,7 @@ class ScrapeMapper:
                 for url in urls:
                     if not url:
                         continue
-                    item = self.create_item_from_link(url)
+                    item = ScrapeItem(url=url)
                     if group_name:
                         item.add_to_parent_title(group_name)
                         item.part_of_album = True
@@ -168,7 +168,7 @@ class ScrapeMapper:
             return
 
         for url in self.manager.parsed_args.cli_only_args.links:
-            yield self.create_item_from_link(url)  # type: ignore
+            yield ScrapeItem(url=url)  # type: ignore
 
     async def load_failed_links(self) -> AsyncGenerator[ScrapeItem]:
         """Loads failed links from database."""
@@ -199,9 +199,6 @@ class ScrapeMapper:
             scrape_item.url = URL(scrape_item.url)
         if self.filter_items(scrape_item):
             await self.send_to_crawler(scrape_item)
-
-    def create_item_from_link(self, link: URL) -> ScrapeItem:
-        return ScrapeItem(url=link)
 
     def create_item_from_entry(self, entry: Sequence) -> ScrapeItem:
         url = URL(entry[0])

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -131,12 +131,11 @@ class ScrapeMapper:
             async for line in f:
                 assert isinstance(line, str)
 
-                if line.startswith(("---", "===")):
+                if line.startswith(("---", "===")):  # New group begins here
                     current_group_name = line.replace("---", "").replace("===", "").strip()
-                    if current_group_name and current_group_name not in self.groups:
-                        self.groups.add(current_group_name)
 
                 if current_group_name:
+                    self.groups.add(current_group_name)
                     yield (current_group_name, regex_links(line))
                     continue
 


### PR DESCRIPTION
Process URLs as soon as the come. Do not wait for all of them to be parsed. This is specially useful when using retry options.

Drawback: We only know the total URL count at the end of the run