### PR TITLE
feat: disable cache 

### DIFF
--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -10,8 +10,8 @@ from aiohttp_client_cache import CachedSession
 from aiohttp_client_cache.response import CachedStreamReader
 from bs4 import BeautifulSoup
 
+import cyberdrop_dl.utils.constants as constants
 from cyberdrop_dl.clients.errors import DDOSGuardError, InvalidContentTypeError
-from cyberdrop_dl.utils.constants import disable_cache
 from cyberdrop_dl.utils.logger import log_debug
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ def limiter(func: Callable) -> Any:
 
 @asynccontextmanager
 async def cache_control_manager(client_session: CachedSession, disabled: bool = False):
-    client_session.cache.disabled = disable_cache or disabled
+    client_session.cache.disabled = constants.disable_cache or disabled
     yield
     client_session.cache.disabled = False
 

--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -50,7 +50,7 @@ def limiter(func: Callable) -> Any:
 
 @asynccontextmanager
 async def cache_control_manager(client_session: CachedSession, disabled: bool = False):
-    client_session.cache.disabled = constants.disable_cache or disabled
+    client_session.cache.disabled = constants.DISABLE_CACHE or disabled
     yield
     client_session.cache.disabled = False
 

--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -11,6 +11,7 @@ from aiohttp_client_cache.response import CachedStreamReader
 from bs4 import BeautifulSoup
 
 from cyberdrop_dl.clients.errors import DDOSGuardError, InvalidContentTypeError
+from cyberdrop_dl.utils.constants import disable_cache
 from cyberdrop_dl.utils.logger import log_debug
 
 if TYPE_CHECKING:
@@ -49,7 +50,7 @@ def limiter(func: Callable) -> Any:
 
 @asynccontextmanager
 async def cache_control_manager(client_session: CachedSession, disabled: bool = False):
-    client_session.cache.disabled = disabled
+    client_session.cache.disabled = disable_cache or disabled
     yield
     client_session.cache.disabled = False
 

--- a/cyberdrop_dl/managers/cache_manager.py
+++ b/cyberdrop_dl/managers/cache_manager.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from aiohttp_client_cache import CacheBackend, SQLiteBackend
 
 from cyberdrop_dl import __version__ as current_version
-from cyberdrop_dl.scraper.filters import disable_all_cache, filter_fn
+from cyberdrop_dl.scraper.filters import filter_fn
 from cyberdrop_dl.utils import yaml
 from cyberdrop_dl.utils.data_enums_classes.supported_domains import SUPPORTED_FORUMS, SUPPORTED_WEBSITES
 
@@ -50,24 +50,20 @@ class CacheManager:
             urls_expire_after[match_host] = rate_limiting_options.file_host_cache_expire_after
         for forum in SUPPORTED_FORUMS.values():
             urls_expire_after[forum] = rate_limiting_options.forum_cache_expire_after
-
-        if self.manager.parsed_args.cli_only_args.disable_cache:
-            self.request_cache = CacheBackend(expire_after=0, filter_fn=disable_all_cache)
-        else:
-            self.request_cache = SQLiteBackend(
-                cache_name=self.manager.path_manager.cache_db,
-                autoclose=False,
-                allowed_codes=(
-                    HTTPStatus.OK,
-                    HTTPStatus.NOT_FOUND,
-                    HTTPStatus.GONE,
-                    HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS,
-                ),
-                allowed_methods=["GET"],
-                expire_after=timedelta(days=7),
-                urls_expire_after=urls_expire_after,
-                filter_fn=filter_fn,
-            )
+        self.request_cache = SQLiteBackend(
+            cache_name=self.manager.path_manager.cache_db,
+            autoclose=False,
+            allowed_codes=(
+                HTTPStatus.OK,
+                HTTPStatus.NOT_FOUND,
+                HTTPStatus.GONE,
+                HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS,
+            ),
+            allowed_methods=["GET"],
+            expire_after=timedelta(days=7),
+            urls_expire_after=urls_expire_after,
+            filter_fn=filter_fn,
+        )
 
     def get(self, key: str) -> Any:
         """Returns the value of a key in the cache."""

--- a/cyberdrop_dl/managers/cache_manager.py
+++ b/cyberdrop_dl/managers/cache_manager.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from aiohttp_client_cache import CacheBackend, SQLiteBackend
 
 from cyberdrop_dl import __version__ as current_version
-from cyberdrop_dl.scraper.filters import filter_fn
+from cyberdrop_dl.scraper.filters import disable_all_cache, filter_fn
 from cyberdrop_dl.utils import yaml
 from cyberdrop_dl.utils.data_enums_classes.supported_domains import SUPPORTED_FORUMS, SUPPORTED_WEBSITES
 
@@ -52,7 +52,7 @@ class CacheManager:
             urls_expire_after[forum] = rate_limiting_options.forum_cache_expire_after
 
         if self.manager.parsed_args.cli_only_args.disable_cache:
-            self.request_cache = CacheBackend(expire_after=0)
+            self.request_cache = CacheBackend(expire_after=0, filter_fn=disable_all_cache)
         else:
             self.request_cache = SQLiteBackend(
                 cache_name=self.manager.path_manager.cache_db,

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -80,6 +80,7 @@ class Manager:
         self.adjust_for_simpcity()
         if self.config_manager.loaded_config.casefold() == "all" or self.parsed_args.cli_only_args.multiconfig:
             self.multiconfig = True
+        self.set_constants()
 
     def adjust_for_simpcity(self) -> None:
         """Adjusts settings for SimpCity update."""
@@ -244,6 +245,12 @@ class Manager:
             return
         for config in all_configs:
             self.config_manager.change_config(config)
+
+    def set_constants(self):
+        """
+        rewrite constants after config/arg manager have loaded
+        """
+        constants.disable_cache = self.parsed_args.cli_only_args.disable_cache
 
 
 def get_system_information() -> str:

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -250,7 +250,7 @@ class Manager:
         """
         rewrite constants after config/arg manager have loaded
         """
-        constants.disable_cache = self.parsed_args.cli_only_args.disable_cache
+        constants.DISABLE_CACHE = self.parsed_args.cli_only_args.disable_cache
 
 
 def get_system_information() -> str:

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -67,15 +67,15 @@ class RedditCrawler(Crawler):
         async with CachedSession(
             cache=self.manager.cache_manager.request_cache, trace_configs=self.trace_configs
         ) as session:
-            await cache_control_manager(session)
-            reddit = self.new_reddit_conn(session)
-            if any(part in scrape_item.url.parts for part in ("user", "u")):
-                return await self.user(scrape_item, reddit)
-            if any(part in scrape_item.url.parts for part in ("comments", "r")):
-                return await self.subreddit(scrape_item, reddit)
-            if "redd.it" in scrape_item.url.host:
-                return await self.media(scrape_item, reddit)
-            raise ValueError
+            async with cache_control_manager(session):
+                reddit = self.new_reddit_conn(session)
+                if any(part in scrape_item.url.parts for part in ("user", "u")):
+                    return await self.user(scrape_item, reddit)
+                if any(part in scrape_item.url.parts for part in ("comments", "r")):
+                    return await self.subreddit(scrape_item, reddit)
+                if "redd.it" in scrape_item.url.host:
+                    return await self.media(scrape_item, reddit)
+                raise ValueError
 
     @error_handling_wrapper
     async def user(self, scrape_item: ScrapeItem, reddit: Reddit) -> None:

--- a/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/reddit_crawler.py
@@ -12,6 +12,7 @@ from asyncpraw import Reddit
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import LoginError, NoExtensionError, ScrapeError
+from cyberdrop_dl.clients.scraper_client import cache_control_manager
 from cyberdrop_dl.scraper.crawler import Crawler, create_task_id
 from cyberdrop_dl.utils.data_enums_classes.url_objects import FILE_HOST_ALBUM, FILE_HOST_PROFILE, ScrapeItem
 from cyberdrop_dl.utils.logger import log, log_debug
@@ -66,6 +67,7 @@ class RedditCrawler(Crawler):
         async with CachedSession(
             cache=self.manager.cache_manager.request_cache, trace_configs=self.trace_configs
         ) as session:
+            await cache_control_manager(session)
             reddit = self.new_reddit_conn(session)
             if any(part in scrape_item.url.parts for part in ("user", "u")):
                 return await self.user(scrape_item, reddit)

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import NoExtensionError
-from cyberdrop_dl.utils.constants import FILE_FORMATS, DISABLE_CACHE
+from cyberdrop_dl.utils.constants import DISABLE_CACHE, FILE_FORMATS
 from cyberdrop_dl.utils.utilities import get_filename_and_ext
 
 if TYPE_CHECKING:

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -163,8 +163,3 @@ async def filter_fn(response: ClientResponse) -> bool:
     cache_response, reason = await filter_fn(response) if filter_fn else False, "No caching manager for host"
     del reason
     return cache_response
-
-
-def disable_all_cache(response: ClientResponse):
-    """Disables all writing/reading of the cache"""
-    return False

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -163,3 +163,8 @@ async def filter_fn(response: ClientResponse) -> bool:
     cache_response, reason = await filter_fn(response) if filter_fn else False, "No caching manager for host"
     del reason
     return cache_response
+
+
+def disable_all_cache(response: ClientResponse):
+    """Disables all writing/reading of the cache"""
+    return False

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -8,7 +8,8 @@ from bs4 import BeautifulSoup
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import NoExtensionError
-from cyberdrop_dl.utils.constants import DISABLE_CACHE, FILE_FORMATS
+from cyberdrop_dl.utils.constants import FILE_FORMATS
+import cyberdrop_dl.utils.constants as constants
 from cyberdrop_dl.utils.utilities import get_filename_and_ext
 
 if TYPE_CHECKING:
@@ -98,7 +99,7 @@ async def get_return_value(url: URL | str) -> bool | None:
 
 async def filter_fn(response: ClientResponse) -> bool:
     """Filter function for aiohttp_client_cache"""
-    if DISABLE_CACHE:
+    if constants.DISABLE_CACHE:
         return False
     HTTP_404_LIKE_STATUS = {HTTPStatus.NOT_FOUND, HTTPStatus.GONE, HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS}
 

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -7,9 +7,9 @@ import arrow
 from bs4 import BeautifulSoup
 from yarl import URL
 
+import cyberdrop_dl.utils.constants as constants
 from cyberdrop_dl.clients.errors import NoExtensionError
 from cyberdrop_dl.utils.constants import FILE_FORMATS
-import cyberdrop_dl.utils.constants as constants
 from cyberdrop_dl.utils.utilities import get_filename_and_ext
 
 if TYPE_CHECKING:

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import NoExtensionError
-from cyberdrop_dl.utils.constants import FILE_FORMATS
+from cyberdrop_dl.utils.constants import FILE_FORMATS, DISABLE_CACHE
 from cyberdrop_dl.utils.utilities import get_filename_and_ext
 
 if TYPE_CHECKING:
@@ -98,6 +98,8 @@ async def get_return_value(url: URL | str) -> bool | None:
 
 async def filter_fn(response: ClientResponse) -> bool:
     """Filter function for aiohttp_client_cache"""
+    if DISABLE_CACHE:
+        return False
     HTTP_404_LIKE_STATUS = {HTTPStatus.NOT_FOUND, HTTPStatus.GONE, HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS}
 
     if response.status in HTTP_404_LIKE_STATUS:

--- a/cyberdrop_dl/utils/args.py
+++ b/cyberdrop_dl/utils/args.py
@@ -58,6 +58,7 @@ class CommandLineOnlyArgs(BaseModel):
     print_stats: bool = Field(True, description="Show stats report at the end of a run")
     ui: UIOptions = Field(UIOptions.FULLSCREEN, description="DISABLED, ACTIVITY, SIMPLE or FULLSCREEN")
     portrait: bool = Field(False, description="show UI in a portrait layout")
+    disable_cache: bool = Field(False, description="Temporarily disable the requests cache")
 
     @property
     def retry_any(self) -> bool:

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -143,3 +143,4 @@ FILE_FORMATS = {
 
 
 MEDIA_EXTENSIONS = FILE_FORMATS["Audio"] | FILE_FORMATS["Videos"] | FILE_FORMATS["Images"]
+disable_cache = None

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -143,4 +143,4 @@ FILE_FORMATS = {
 
 
 MEDIA_EXTENSIONS = FILE_FORMATS["Audio"] | FILE_FORMATS["Videos"] | FILE_FORMATS["Images"]
-disable_cache = None
+DISABLE_CACHE = None

--- a/docs/reference/cli-arguments.md
+++ b/docs/reference/cli-arguments.md
@@ -139,6 +139,22 @@ Retry download of maintenance files (bunkr). Requires files to be hashed
 
 ***
 
+### `disable-cache`  
+
+| Type       | Default | Action       |
+| ---------- | ------- | ------------ |
+| `BoolFlag` | `False` | `store_true` |
+
+Disables the use of the requests cache for the current run only
+all config settings or arguments relating to the cache expiry such as file_host_cache_expire_after will be ignored
+
+{% hint style="info" %}
+This does not affect the original cache
+{% endhint %}
+
+
+***
+
 ## Overview
 
 Bool arguments like options within `Download Options`, `Ignore Options`, `Runtime Options`, etc. can be prefixed with `--no-` to negate them. Ex: `--no-auto-dedupe` will disable auto dedupe, overriding whatever the config option was set to.


### PR DESCRIPTION
https://github.com/jbsparrow/CyberDropDownloader/issues/544
This add an option to disable the main file cache for the current  run, by using a throwaway in memory cache

The cache would be erased after the current run, and setting the expired_after value to zero means no value will be saved to the cache

Orginally I wanted to change the cache_control_manager function, but it doesn't have access to the manager class


