### PR TITLE
fix: jsonl timestamp serializer

### DIFF
--- a/cyberdrop_dl/utils/dumper.py
+++ b/cyberdrop_dl/utils/dumper.py
@@ -36,7 +36,7 @@ class Dumper:
 def convert_to_dict(media_item: MediaItem) -> dict:
     date = media_item.datetime
     item = asdict(media_item)
-    if date:
+    if date and isinstance(date, int):
         item["datetime"] = datetime.datetime.fromtimestamp(date)
     for key, new_key in KEYS_TO_REPLACE.items():
         item[new_key] = item[key]


### PR DESCRIPTION
The actual error comes from some crawler that is saving the date as a string instead of a timestamp. This just prevent CDL from crashing

- Fixes #774 