### PR TITLE
refactor: revalidate config after the user edits it from the UI

### DIFF
--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -244,8 +244,8 @@ class ProgramUI:
     def _open_in_text_editor(self, file_path: Path, *, reload_config: bool = True):
         try:
             open_in_text_editor(file_path)
-        except ValueError:
-            self.print_error("No default text editor found")
+        except ValueError as e:
+            self.print_error(str(e))
             return
         if reload_config:
             console.print("Revalidating config, please wait..")

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -241,13 +241,15 @@ class ProgramUI:
 
         self.manager.cache_manager.save("simp_disclaimer_shown", True)
 
-    def _open_in_text_editor(self, file_path: Path, *, reload_config: bool = False):
+    def _open_in_text_editor(self, file_path: Path, *, reload_config: bool = True):
         try:
             open_in_text_editor(file_path)
-            if reload_config:
-                self.manager.config_manager.change_config(self.manager.config_manager.loaded_config)
         except ValueError:
             self.print_error("No default text editor found")
+            return
+        if reload_config:
+            console.print("Revalidating config, please wait..")
+            self.manager.config_manager.change_config(self.manager.config_manager.loaded_config)
 
     def _process_answer(self, answer: Any, options_map: dict) -> Choice | None:
         """Checks prompt answer and executes corresponding function."""

--- a/cyberdrop_dl/ui/program_ui.py
+++ b/cyberdrop_dl/ui/program_ui.py
@@ -193,7 +193,7 @@ class ProgramUI:
         self._open_in_text_editor(config_file)
 
     def _edit_urls(self) -> None:
-        self._open_in_text_editor(self.manager.path_manager.input_file)
+        self._open_in_text_editor(self.manager.path_manager.input_file, reload_config=False)
 
     def _change_default_config(self) -> None:
         configs = self.manager.config_manager.get_configs()
@@ -241,9 +241,11 @@ class ProgramUI:
 
         self.manager.cache_manager.save("simp_disclaimer_shown", True)
 
-    def _open_in_text_editor(self, file_path: Path):
+    def _open_in_text_editor(self, file_path: Path, *, reload_config: bool = False):
         try:
             open_in_text_editor(file_path)
+            if reload_config:
+                self.manager.config_manager.change_config(self.manager.config_manager.loaded_config)
         except ValueError:
             self.print_error("No default text editor found")
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -310,7 +310,7 @@ def open_in_text_editor(file_path: Path) -> bool | None:
         subprocess.call([default_editor, file_path])
 
     elif subprocess.call(["which", "micro"], stdout=subprocess.DEVNULL) == 0:
-        subprocess.call(["micro", file_path])
+        subprocess.call(["micro", "-keymenu", "true", file_path])
 
     elif subprocess.call(["which", "nano"], stdout=subprocess.DEVNULL) == 0:
         subprocess.call(["nano", file_path])

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -300,25 +300,24 @@ def open_in_text_editor(file_path: Path) -> bool | None:
         any(var in os.environ for var in ("DISPLAY", "WAYLAND_DISPLAY")) and "SSH_CONNECTION" not in os.environ
     )
     fallback_editor = get_first_available_editor()
-    args = (file_path,)
 
     if platform.system() == "Darwin":
-        args = "-a", "TextEdit", *args
-        subprocess.Popen(["open", *args], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        cmd = "open", "-a", "TextEdit", file_path
 
     elif platform.system() == "Windows":
-        subprocess.Popen(["notepad.exe", *args], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        cmd = "notepad.exe", file_path
 
     elif using_desktop_enviroment and set_default_app_if_none(file_path):
-        subprocess.Popen(["xdg-open", *args], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        cmd = "xdg-open", file_path
 
     elif fallback_editor:
+        cmd = fallback_editor, file_path
         if fallback_editor.stem == "micro":
-            args = "-keymenu", "true", *args
-        subprocess.call([fallback_editor, *args])
-
+            cmd = fallback_editor, "-keymenu", "true", file_path
     else:
         raise ValueError
+
+    subprocess.call([*cmd], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 def get_first_available_editor() -> Path | None:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -7,7 +7,7 @@ import platform
 import re
 import shutil
 import subprocess
-from functools import partial, wraps
+from functools import lru_cache, partial, wraps
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -320,6 +320,7 @@ def open_in_text_editor(file_path: Path) -> bool | None:
     subprocess.call([*cmd], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
+@lru_cache
 def get_first_available_editor() -> Path | None:
     for editor in TEXT_EDITORS:
         if not editor:
@@ -329,6 +330,7 @@ def get_first_available_editor() -> Path | None:
             return Path(path)
 
 
+@lru_cache
 def set_default_app_if_none(file_path: Path) -> bool:
     mimetype = xdg_mime_query("filetype", str(file_path))
     if not mimetype:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -296,10 +296,8 @@ async def send_webhook_message(manager: Manager) -> None:
 
 def open_in_text_editor(file_path: Path) -> bool | None:
     """Opens file in OS text editor."""
-    using_desktop_enviroment = (
-        any(var in os.environ for var in ("DISPLAY", "WAYLAND_DISPLAY")) and "SSH_CONNECTION" not in os.environ
-    )
-    fallback_editor = get_first_available_editor()
+    using_ssh = "SSH_CONNECTION" in os.environ
+    using_desktop_enviroment = any(var in os.environ for var in ("DISPLAY", "WAYLAND_DISPLAY"))
 
     if platform.system() == "Darwin":
         cmd = "open", "-a", "TextEdit", file_path
@@ -307,10 +305,10 @@ def open_in_text_editor(file_path: Path) -> bool | None:
     elif platform.system() == "Windows":
         cmd = "notepad.exe", file_path
 
-    elif using_desktop_enviroment and set_default_app_if_none(file_path):
+    elif using_desktop_enviroment and not using_ssh and set_default_app_if_none(file_path):
         cmd = "xdg-open", file_path
 
-    elif fallback_editor:
+    elif fallback_editor := get_first_available_editor():
         cmd = fallback_editor, file_path
         if fallback_editor.stem == "micro":
             cmd = fallback_editor, "-keymenu", "true", file_path

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem, ScrapeItem
 
 
-TEXT_EDITORS = os.environ.get("EDITOR"), "micro", "nano", "vim"  # Ordered by preference
+TEXT_EDITORS = "micro", "nano", "vim"  # Ordered by preference
 
 subprocess_get_text = partial(subprocess.run, capture_output=True, text=True, check=False)
 
@@ -298,8 +298,16 @@ def open_in_text_editor(file_path: Path) -> bool | None:
     """Opens file in OS text editor."""
     using_ssh = "SSH_CONNECTION" in os.environ
     using_desktop_enviroment = any(var in os.environ for var in ("DISPLAY", "WAYLAND_DISPLAY"))
+    custom_editor = os.environ.get("EDITOR")
 
-    if platform.system() == "Darwin":
+    if custom_editor:
+        path = shutil.which(custom_editor)
+        if not path:
+            msg = f"Editor '{custom_editor}' from env bar $EDITOR is not available"
+            raise ValueError(msg)
+        cmd = path, file_path
+
+    elif platform.system() == "Darwin":
         cmd = "open", "-a", "TextEdit", file_path
 
     elif platform.system() == "Windows":
@@ -313,16 +321,16 @@ def open_in_text_editor(file_path: Path) -> bool | None:
         if fallback_editor.stem == "micro":
             cmd = fallback_editor, "-keymenu", "true", file_path
     else:
-        raise ValueError
+        msg = "No default text editor found"
+        raise ValueError(msg)
 
+    rich.print(f"Opening '{file_path}' with '{cmd[0]}'...")
     subprocess.call([*cmd], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 @lru_cache
 def get_first_available_editor() -> Path | None:
     for editor in TEXT_EDITORS:
-        if not editor:
-            continue
         path = shutil.which(editor)
         if path:
             return Path(path)


### PR DESCRIPTION
## Changes
- Use `shutil.which` to find available text editor
- Show keyboard bindings footer when using `micro`
- Halt CDL until text editor process finishes
- Revalidate and reload config after the user edits any config file from the UI
- Use `$EDITOR` value (if available) on Windows and macOS