### PR TITLE
refactor: move `parse_url` to utils

### DIFF
--- a/cyberdrop_dl/config_definitions/custom/converters.py
+++ b/cyberdrop_dl/config_definitions/custom/converters.py
@@ -6,8 +6,11 @@ import re
 from datetime import timedelta
 from pathlib import Path
 
+import yarl
 from pydantic import AnyUrl, ByteSize, TypeAdapter
-from yarl import URL
+
+from cyberdrop_dl.clients.errors import InvalidURLError
+from cyberdrop_dl.utils.utilities import parse_url
 
 DATE_PATTERN_REGEX = r"(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days|week|weeks|month|months|year|years)"
 DATE_PATTERN = re.compile(DATE_PATTERN_REGEX, re.IGNORECASE)
@@ -21,8 +24,11 @@ def convert_byte_size_to_str(value: ByteSize) -> str:
     return value.human_readable(decimal=True)
 
 
-def convert_to_yarl(value: AnyUrl) -> URL:
-    return URL(str(value))
+def convert_to_yarl(value: AnyUrl | str, *args, **kwargs) -> yarl.URL:
+    try:
+        return parse_url(str(value), *args, **kwargs)
+    except (InvalidURLError, TypeError) as e:
+        raise ValueError(str(e)) from e
 
 
 def change_path_suffix(value: Path, suffix: str) -> Path:

--- a/cyberdrop_dl/config_definitions/custom/types.py
+++ b/cyberdrop_dl/config_definitions/custom/types.py
@@ -12,7 +12,6 @@ from pydantic import (
     BeforeValidator,
     ByteSize,
     ConfigDict,
-    HttpUrl,
     NonNegativeInt,
     PlainSerializer,
     PlainValidator,
@@ -22,39 +21,32 @@ from pydantic import (
     model_serializer,
     model_validator,
 )
+from pydantic import HttpUrl as PydanticHttpUrl
 
 from .converters import change_path_suffix, convert_byte_size_to_str, convert_to_yarl
 from .validators import parse_apprise_url, parse_falsy_as_none, parse_list
 
+# ~~~~~ Strings ~~~~~~~
 StrSerializer = PlainSerializer(str, return_type=str, when_used="json-unless-none")
-
-
-ByteSizeSerilized = Annotated[ByteSize, PlainSerializer(convert_byte_size_to_str, return_type=str)]
-HttpURL = Annotated[HttpUrl, AfterValidator(convert_to_yarl), StrSerializer]
-ListNonNegativeInt = Annotated[list[NonNegativeInt], BeforeValidator(parse_list)]
-
 NonEmptyStr = Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)]
 NonEmptyStrOrNone = Annotated[NonEmptyStr | None, BeforeValidator(parse_falsy_as_none)]
 ListNonEmptyStr = Annotated[list[NonEmptyStr], BeforeValidator(parse_list)]
 
+# ~~~~~ Paths ~~~~~~~
 PathOrNone = Annotated[Path | None, BeforeValidator(parse_falsy_as_none)]
 LogPath = Annotated[Path, AfterValidator(partial(change_path_suffix, suffix=".csv"))]
 MainLogPath = Annotated[LogPath, AfterValidator(partial(change_path_suffix, suffix=".log"))]
 
+# ~~~~~ URLs ~~~~~~~
+URLSerilized = Annotated[yarl.URL, StrSerializer]
+HttpStr = Annotated[URLSerilized, PlainValidator(str)]  # URL in type hints, str at runtime
+HttpStrURL = Annotated[HttpStr, AfterValidator(convert_to_yarl)]  # URL with str validation
+HttpUrl = Annotated[URLSerilized, PlainValidator(PydanticHttpUrl)]  # URL in type hints, pydantic.HttpUrl at runtime
+HttpURL = Annotated[HttpUrl, AfterValidator(convert_to_yarl)]  # URL with pydantic.HttpUrl validation
 
-YarlURLSerilized = Annotated[yarl.URL, StrSerializer]
-
-# A yarl.URL in type hints that is actually a str at runtime, to use as base for custom URL parsers
-CustomHttpStrURL = Annotated[YarlURLSerilized, PlainValidator(str)]
-
-# A yarl.URL in type hints that is actually a pydantic.HttpUrl at runtime
-CustomHttpURL = Annotated[YarlURLSerilized, PlainValidator(HttpUrl)]
-
-# An actual yarl.URL in type hints and runtime but uses str for validation.
-ParsedHttpStrURL = Annotated[CustomHttpStrURL, AfterValidator(convert_to_yarl)]
-
-# An actual yarl.URL in type hints and runtime but uses pydantic.HttpUrl for validation.
-ParsedHttpURL = Annotated[CustomHttpURL, AfterValidator(convert_to_yarl)]
+# ~~~~~ Others ~~~~~~~
+ByteSizeSerilized = Annotated[ByteSize, PlainSerializer(convert_byte_size_to_str, return_type=str)]
+ListNonNegativeInt = Annotated[list[NonNegativeInt], BeforeValidator(parse_list)]
 
 
 class AliasModel(BaseModel):
@@ -67,7 +59,7 @@ class FrozenModel(BaseModel):
 
 class AppriseURLModel(FrozenModel):
     url: Secret[AnyUrl]
-    tags: set[str]
+    tags: set[str] = set()
 
     @model_serializer()
     def serialize(self, info: SerializationInfo):
@@ -85,3 +77,7 @@ class AppriseURLModel(FrozenModel):
 
 class HttpAppriseURL(AppriseURLModel):
     url: Secret[HttpURL]
+
+
+# DEPRECATED
+# HttpURL = Annotated[HttpUrl, AfterValidator(convert_to_yarl), StrSerializer]

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -13,12 +13,11 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 from aiolimiter import AsyncLimiter
 from yarl import URL
 
-from cyberdrop_dl.clients.errors import InvalidURLError
 from cyberdrop_dl.downloader.downloader import Downloader
 from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem, ScrapeItem
 from cyberdrop_dl.utils.database.tables.history_table import get_db_path
 from cyberdrop_dl.utils.logger import log
-from cyberdrop_dl.utils.utilities import get_download_path, get_filename_and_ext, remove_file_id
+from cyberdrop_dl.utils.utilities import get_download_path, get_filename_and_ext, parse_url, remove_file_id
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable
@@ -276,22 +275,8 @@ class Crawler(ABC):
         scrape_item.add_to_parent_title(title)
 
     def parse_url(self, link_str: str, relative_to: URL | None = None, *, trim: bool = True) -> URL:
-        try:
-            assert link_str
-            assert isinstance(link_str, str)
-            link_str = clean_link_str(link_str)
-            encoded = "%" in link_str
-            base = relative_to or self.primary_base_domain
-            new_url = URL(link_str, encoded=encoded)
-        except (AssertionError, AttributeError, ValueError, TypeError) as e:
-            raise InvalidURLError(str(e), url=link_str) from e
-        if not new_url.absolute:
-            new_url = base.join(new_url)
-        if not new_url.scheme:
-            new_url = new_url.with_scheme(base.scheme or "https")
-        if not trim:
-            return new_url
-        return remove_trailing_slash(new_url)
+        base = relative_to or self.primary_base_domain
+        return parse_url(link_str, base, trim=trim)
 
     def update_cookies(self, cookies: dict, url: URL | None = None) -> None:
         """Update cookies for the provided URL
@@ -318,12 +303,6 @@ class Crawler(ABC):
             page_url = self.parse_url(page_url_str)
 
 
-def remove_trailing_slash(url: URL) -> URL:
-    if url.name or url.path == "/":
-        return url
-    return url.parent.with_fragment(url.fragment).with_query(url.query)
-
-
 def create_task_id(func: Callable) -> Callable:
     """Wrapper handles task_id creation and removal for ScrapeItems"""
 
@@ -348,11 +327,3 @@ def create_task_id(func: Callable) -> Callable:
 def pre_check_scrape_item(scrape_item: ScrapeItem) -> None:
     if scrape_item.url.path == "/":
         raise ValueError
-
-
-def clean_link_str(link_str: str) -> str:
-    if "?" in link_str:
-        parts, query = link_str.split("?", 1)
-        query = query.replace("+", "%20")
-        return f"{parts}?{query}"
-    return link_str

--- a/cyberdrop_dl/crawlers/xenforo/xenforo.py
+++ b/cyberdrop_dl/crawlers/xenforo/xenforo.py
@@ -13,11 +13,11 @@ from bs4 import BeautifulSoup
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import InvalidURLError, LoginError, ScrapeError
-from cyberdrop_dl.crawlers.crawler import Crawler, create_task_id, remove_trailing_slash
+from cyberdrop_dl.crawlers.crawler import Crawler, create_task_id
 from cyberdrop_dl.scraper.filters import set_return_value
 from cyberdrop_dl.utils.data_enums_classes.url_objects import FORUM, FORUM_POST, ScrapeItem
 from cyberdrop_dl.utils.logger import log, log_debug
-from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
+from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext, remove_trailing_slash
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Sequence

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -58,18 +58,6 @@ def is_in_domain_list(scrape_item: ScrapeItem, domain_list: Sequence[str]) -> bo
     return any(domain in scrape_item.url.host for domain in domain_list)  # type: ignore
 
 
-def remove_trailing_slash(url: URL) -> URL:
-    if not str(url).endswith("/"):
-        return url
-
-    url_trimmed = url.with_path(url.path[:-1])
-    if url.query_string:
-        query = url.query_string[:-1]
-        url_trimmed = url.with_query(query)
-
-    return url_trimmed
-
-
 def has_valid_extension(url: URL, forum: bool = False) -> bool:
     """Checks if the URL has a valid extension."""
     try:

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -13,18 +13,12 @@ from yarl import URL
 from cyberdrop_dl.clients.errors import JDownloaderError, NoExtensionError
 from cyberdrop_dl.crawlers import CRAWLERS
 from cyberdrop_dl.downloader.downloader import Downloader
-from cyberdrop_dl.scraper.filters import (
-    has_valid_extension,
-    is_in_domain_list,
-    is_outside_date_range,
-    is_valid_url,
-    remove_trailing_slash,
-)
+from cyberdrop_dl.scraper.filters import has_valid_extension, is_in_domain_list, is_outside_date_range, is_valid_url
 from cyberdrop_dl.scraper.jdownloader import JDownloader
 from cyberdrop_dl.utils.constants import BLOCKED_DOMAINS, REGEX_LINKS
 from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem, ScrapeItem
 from cyberdrop_dl.utils.logger import log
-from cyberdrop_dl.utils.utilities import get_download_path, get_filename_and_ext
+from cyberdrop_dl.utils.utilities import get_download_path, get_filename_and_ext, remove_trailing_slash
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Sequence


### PR DESCRIPTION
To be able to use it without the context of a crawler.