### PR TITLE
perf: queue logging to prevent blocking the async loop 

### DIFF
--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -202,17 +202,19 @@ def setup_logger(manager: Manager, config_name: str) -> None:
     queued_logger = manager.loggers.pop("main", None)
     with startup_logging():
         if manager.multiconfig and queued_logger:
-            log("Picking new config...", 20)
+            log(f"Picking new config: '{config_name}' ...", 20)
             manager.config_manager.change_config(config_name)
             log(f"Changed config to {config_name}...", 20)
-            logger.removeHandler(queued_logger.handler)
-            queued_logger.stop()
 
         try:
             file_io = manager.path_manager.main_log.open("w", encoding="utf8")
         except OSError as e:
             startup_logger.exception(str(e))
             sys.exit(1)
+        finally:
+            if queued_logger:
+                logger.removeHandler(queued_logger.handler)
+                queued_logger.stop()
 
     settings_data = manager.config_manager.settings_data
     log_level = settings_data.runtime_options.log_level

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -22,14 +22,7 @@ from cyberdrop_dl.ui.program_ui import ProgramUI
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.apprise import send_apprise_notifications
 from cyberdrop_dl.utils.dumper import Dumper
-from cyberdrop_dl.utils.logger import (
-    CustomRichHandler,
-    QueuedLogger,
-    SplitRichHandler,
-    log,
-    log_spacer,
-    log_with_color,
-)
+from cyberdrop_dl.utils.logger import LogHandler, QueuedLogger, SplitLogHandler, log, log_spacer, log_with_color
 from cyberdrop_dl.utils.sorting import Sorter
 from cyberdrop_dl.utils.updates import check_latest_pypi
 from cyberdrop_dl.utils.utilities import check_partials_and_empty_folders, send_webhook_message
@@ -131,16 +124,16 @@ def setup_startup_logger(*, first_time_setup: bool = False) -> None:
         STARTUP_LOGGER_FILE.unlink(missing_ok=True)  # Only delete file once. Subsequent calls will append to file
     destroy_startup_logger()
     startup_logger.setLevel(10)
-    console_handler = CustomRichHandler(level=10)
+    console_handler = LogHandler(level=10)
     startup_logger.addHandler(console_handler)
 
     file_io = STARTUP_LOGGER_FILE.open("a", encoding="utf8")
-    file_handler = CustomRichHandler(level=10, file=file_io, width=constants.DEFAULT_CONSOLE_WIDTH)
+    file_handler = LogHandler(level=10, file=file_io, width=constants.DEFAULT_CONSOLE_WIDTH)
     startup_logger.addHandler(file_handler)
 
 
 def destroy_startup_logger(remove_all_handlers: bool = True) -> None:
-    handlers: list[CustomRichHandler] = startup_logger.handlers  # type: ignore
+    handlers: list[LogHandler] = startup_logger.handlers  # type: ignore
     for handler in handlers[:]:  # create copy
         if not (handler.console._file or remove_all_handlers):
             continue
@@ -188,7 +181,7 @@ def setup_debug_logger(manager: Manager) -> Path | None:
             startup_logger.exception(str(e))
             sys.exit(1)
 
-    file_handler_debug = SplitRichHandler(
+    file_handler_debug = SplitLogHandler(
         level=log_level, file=file_io, width=manager.config_manager.settings_data.logs.log_line_width, debug=True
     )
     queued_logger = QueuedLogger.new(file_handler_debug)
@@ -232,10 +225,10 @@ def setup_logger(manager: Manager, config_name: str) -> None:
         constants.CONSOLE_LEVEL = manager.config_manager.settings_data.runtime_options.console_log_level
 
     console_log_level = constants.CONSOLE_LEVEL
-    console_handler = CustomRichHandler(level=console_log_level)
+    console_handler = LogHandler(level=console_log_level)
     logger.addHandler(console_handler)
 
-    file_handler = SplitRichHandler(
+    file_handler = SplitLogHandler(
         level=log_level, file=file_io, width=manager.config_manager.settings_data.logs.log_line_width
     )
     queued_logger = QueuedLogger.new(file_handler)

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -203,18 +203,18 @@ def setup_logger(manager: Manager, config_name: str) -> None:
     with startup_logging():
         if manager.multiconfig and queued_logger:
             log(f"Picking new config: '{config_name}' ...", 20)
-            manager.config_manager.change_config(config_name)
-            log(f"Changed config to {config_name}...", 20)
+            try:
+                manager.config_manager.change_config(config_name)
+                log(f"Changed config to {config_name}...", 20)
+            finally:
+                logger.removeHandler(queued_logger.handler)
+                queued_logger.stop()
 
         try:
             file_io = manager.path_manager.main_log.open("w", encoding="utf8")
         except OSError as e:
             startup_logger.exception(str(e))
             sys.exit(1)
-        finally:
-            if queued_logger:
-                logger.removeHandler(queued_logger.handler)
-                queued_logger.stop()
 
     settings_data = manager.config_manager.settings_data
     log_level = settings_data.runtime_options.log_level

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -53,10 +53,6 @@ def startup() -> Manager:
         if not manager.parsed_args.cli_only_args.download:
             ProgramUI(manager)
 
-    except InvalidYamlError as e:
-        startup_logger.error(e.message)
-        sys.exit(1)
-
     except ValidationError as e:
         sources = {
             "GlobalSettings": manager.config_manager.global_settings,
@@ -68,21 +64,7 @@ def startup() -> Manager:
         handle_validation_error(e, file=file)
         sys.exit(1)
 
-    except KeyboardInterrupt:
-        startup_logger.info("Exiting...")
-        sys.exit(0)
-
-    except browser_cookie3.BrowserCookieError:
-        startup_logger.exception("")
-        sys.exit(1)
-
-    except Exception:
-        msg = "An error occurred, please report this to the developer with your logs file:"
-        startup_logger.exception(msg)
-        sys.exit(1)
-
-    else:
-        return manager
+    return manager
 
 
 async def runtime(manager: Manager) -> None:
@@ -149,11 +131,35 @@ def destroy_startup_logger(remove_all_handlers: bool = True) -> None:
 
 @contextlib.contextmanager
 def startup_logging(*, first_time_setup: bool = False) -> Generator:
+    exit_code = 1
     try:
         setup_startup_logger(first_time_setup=first_time_setup)
         yield
+
+    except InvalidYamlError as e:
+        startup_logger.error(e.message)
+
+    except browser_cookie3.BrowserCookieError:
+        startup_logger.exception("")
+
+    except OSError as e:
+        startup_logger.exception(str(e))
+
+    except KeyboardInterrupt:
+        startup_logger.info("Exiting...")
+        exit_code = 0
+
+    except Exception:
+        msg = "An error occurred, please report this to the developer with your logs file:"
+        startup_logger.exception(msg)
+
+    else:
+        return
+
     finally:
         destroy_startup_logger()
+
+    sys.exit(exit_code)
 
 
 def setup_debug_logger(manager: Manager) -> Path | None:
@@ -176,11 +182,8 @@ def setup_debug_logger(manager: Manager) -> Path | None:
                 sys.exit(1)
             date = datetime.now().strftime("%Y%m%d_%H%M%S")
             debug_log_file_path = debug_log_folder / f"cyberdrop_dl_debug_{date}.log"
-        try:
-            file_io = debug_log_file_path.open("w", encoding="utf8")
-        except OSError as e:
-            startup_logger.exception(str(e))
-            sys.exit(1)
+
+        file_io = debug_log_file_path.open("w", encoding="utf8")
 
     file_handler = LogHandler(level=log_level, file=file_io, width=settings_data.logs.log_line_width, debug=True)
     queued_logger = QueuedLogger.new(manager, file_handler, "debug")
@@ -210,11 +213,7 @@ def setup_logger(manager: Manager, config_name: str) -> None:
                 logger.removeHandler(queued_logger.handler)
                 queued_logger.stop()
 
-        try:
-            file_io = manager.path_manager.main_log.open("w", encoding="utf8")
-        except OSError as e:
-            startup_logger.exception(str(e))
-            sys.exit(1)
+        file_io = manager.path_manager.main_log.open("w", encoding="utf8")
 
     settings_data = manager.config_manager.settings_data
     log_level = settings_data.runtime_options.log_level

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -186,7 +186,7 @@ def setup_debug_logger(manager: Manager) -> Path | None:
         file_io = debug_log_file_path.open("w", encoding="utf8")
 
     file_handler = LogHandler(level=log_level, file=file_io, width=settings_data.logs.log_line_width, debug=True)
-    queued_logger = QueuedLogger.new(manager, file_handler, "debug")
+    queued_logger = QueuedLogger(manager, file_handler, "debug")
     debug_logger.addHandler(queued_logger.handler)
 
     aiohttp_client_cache_logger = logging.getLogger("aiohttp_client_cache")
@@ -226,7 +226,7 @@ def setup_logger(manager: Manager, config_name: str) -> None:
     logger.addHandler(console_handler)
 
     file_handler = LogHandler(level=log_level, file=file_io, width=settings_data.logs.log_line_width)
-    queued_logger = QueuedLogger.new(manager, file_handler, "main")
+    queued_logger = QueuedLogger(manager, file_handler)
     logger.addHandler(queued_logger.handler)
 
 

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -236,8 +236,10 @@ class Manager:
         await self.async_db_close()
         await self.cache_manager.close()
         self.cache_manager.close_sync()
-        for queued_logger in self.loggers.values():
+        while self.loggers:
+            _, queued_logger = self.loggers.popitem()
             queued_logger.stop()
+
         self.cache_manager: CacheManager = field(init=False)
         self.hash_manager: HashManager = field(init=False)
 

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -21,7 +21,7 @@ from cyberdrop_dl.managers.progress_manager import ProgressManager
 from cyberdrop_dl.managers.realdebrid_manager import RealDebridManager
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.args import ParsedArgs
-from cyberdrop_dl.utils.logger import log
+from cyberdrop_dl.utils.logger import QueuedLogger, log
 from cyberdrop_dl.utils.transfer import transfer_v5_db_to_v6
 
 if TYPE_CHECKING:
@@ -58,6 +58,7 @@ class Manager:
         self.start_time: float = perf_counter()
         self.downloaded_data: int = 0
         self.multiconfig: bool = False
+        self.loggers: dict[str, QueuedLogger] = {}
 
     def startup(self) -> None:
         """Startup process for the manager."""
@@ -235,6 +236,8 @@ class Manager:
         await self.async_db_close()
         await self.cache_manager.close()
         self.cache_manager.close_sync()
+        for queued_logger in self.loggers.values():
+            queued_logger.stop()
         self.cache_manager: CacheManager = field(init=False)
         self.hash_manager: HashManager = field(init=False)
 

--- a/cyberdrop_dl/utils/constants.py
+++ b/cyberdrop_dl/utils/constants.py
@@ -11,10 +11,8 @@ MAX_NAME_LENGTHS = {"FILE": 95, "FOLDER": 60}
 DEFAULT_CONSOLE_WIDTH = 240
 CSV_DELIMITER = ","
 LOG_OUTPUT_TEXT = Text("")
-RICH_HANDLER_CONFIG: dict[str, Any] = {"show_time": True, "rich_tracebacks": True, "tracebacks_show_locals": False}
-RICH_HANDLER_DEBUG_CONFIG = {
-    "show_time": True,
-    "rich_tracebacks": True,
+RICH_HANDLER_CONFIG: dict[str, Any] = {"rich_tracebacks": True, "tracebacks_show_locals": False}
+RICH_HANDLER_DEBUG_CONFIG = RICH_HANDLER_CONFIG | {
     "tracebacks_show_locals": True,
     "locals_max_string": DEFAULT_CONSOLE_WIDTH,
     "tracebacks_extra_lines": 2,

--- a/cyberdrop_dl/utils/logger.py
+++ b/cyberdrop_dl/utils/logger.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import json
 import logging
 import queue
@@ -10,14 +9,12 @@ from pathlib import Path
 from typing import IO, TYPE_CHECKING
 
 from rich._log_render import LogRender
-from rich._null_file import NullFile
 from rich.console import Console, Group
 from rich.containers import Lines, Renderables
 from rich.logging import RichHandler
 from rich.measure import Measurement
 from rich.padding import Padding
 from rich.text import Text, TextType
-from rich.traceback import Traceback
 
 from cyberdrop_dl import env
 from cyberdrop_dl.utils import constants
@@ -57,70 +54,25 @@ class LogHandler(RichHandler):
             self._log_render = NoPaddingLogRender(show_level=True)
 
 
-class SplitLogHandler(LogHandler):
-    """Custom class to split the creation of the log renderable and its emition"""
+class BareQueueHandler(QueueHandler):
+    """Sends the log record to the queue as is.
 
-    def get_log_renderable(self, record: logging.LogRecord) -> ConsoleRenderable:
-        message = self.format(record)
-        traceback = None
-        if self.rich_tracebacks and record.exc_info and record.exc_info != (None, None, None):
-            exc_type, exc_value, exc_traceback = record.exc_info
-            assert exc_type is not None
-            assert exc_value is not None
-            traceback = Traceback.from_exception(
-                exc_type,
-                exc_value,
-                exc_traceback,
-                width=self.tracebacks_width,
-                code_width=self.tracebacks_code_width,
-                extra_lines=self.tracebacks_extra_lines,
-                theme=self.tracebacks_theme,
-                word_wrap=self.tracebacks_word_wrap,
-                show_locals=self.tracebacks_show_locals,
-                locals_max_length=self.locals_max_length,
-                locals_max_string=self.locals_max_string,
-                suppress=self.tracebacks_suppress,
-                max_frames=self.tracebacks_max_frames,
-            )
-            message = record.getMessage()
-            if self.formatter:
-                record.message = record.getMessage()
-                formatter = self.formatter
-                if hasattr(formatter, "usesTime") and formatter.usesTime():
-                    record.asctime = formatter.formatTime(record, formatter.datefmt)
-                message = formatter.formatMessage(record)
+    The base class formats the record by merging the message and arguments.
+    It also removes all other attributes of the record, just in case they have not pickleable objects.
 
-        message_renderable = self.render_message(record, message)
-        return self.render(record=record, traceback=traceback, message_renderable=message_renderable)
+    This made tracebacks render improperly because when the rich handler picks the log record from the queue, it has no traceback.
+    The original traceback was being formatted as normal text and included as part of the message.
 
-    def emit(self, record: logging.LogRecord):
-        if isinstance(self.console.file, NullFile):
-            self.handleError(record)
-            return
-        try:
-            self.console.print(record.log_renderable)  # type: ignore
-        except Exception:
-            self.handleError(record)
-
-
-class RichQueueHandler(QueueHandler):
-    """Computes entire log renderable and adds it to the log record as a property before sending it to the queue"""
-
-    def __init__(self, queue, log_handler: SplitLogHandler) -> None:
-        super().__init__(queue)
-        self.get_log_renderable = log_handler.get_log_renderable
+    Having not pickleable objects is only an issue in multi-processing operations (multiprocessing.Queue)
+    """
 
     def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
-        record = copy.copy(record)
-        record.log_renderable = self.get_log_renderable(record)
-        # Remove all other attributes in case they are not pickleable.
-        record.args = record.exc_info = record.exc_text = record.stack_info = None
         return record
 
 
 @dataclass
 class QueuedLogger:
-    handler: RichQueueHandler
+    handler: BareQueueHandler
     listener: QueueListener
 
     def stop(self) -> None:
@@ -129,9 +81,9 @@ class QueuedLogger:
         self.handler.close()
 
     @classmethod
-    def new(cls, split_handler: SplitLogHandler) -> QueuedLogger:
+    def new(cls, split_handler: LogHandler) -> QueuedLogger:
         log_queue = queue.Queue()
-        handler = RichQueueHandler(log_queue, log_handler=split_handler)
+        handler = BareQueueHandler(log_queue)
         listener = QueueListener(log_queue, split_handler, respect_handler_level=True)
         listener.start()
         return QueuedLogger(handler, listener)
@@ -196,8 +148,7 @@ class NoPaddingLogRender(LogRender):
                 continue
             padded_lines.append(Padding(renderable, (0, 0, 0, self.cdl_padding), expand=False))
 
-        output = Group(output, *padded_lines)
-        return output
+        return Group(output, *padded_lines)
 
 
 def get_renderable_length(renderable) -> int:

--- a/cyberdrop_dl/utils/logger.py
+++ b/cyberdrop_dl/utils/logger.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
     from rich.console import ConsoleRenderable
 
+    from cyberdrop_dl.managers.manager import Manager
+
 
 EXCLUDE_PATH_LOGGING_FROM = "logger.py", "base.py", "session.py", "cache_control.py"
 
@@ -81,12 +83,15 @@ class QueuedLogger:
         self.handler.close()
 
     @classmethod
-    def new(cls, split_handler: LogHandler) -> QueuedLogger:
+    def new(cls, manager: Manager, split_handler: LogHandler, name: str = "main") -> QueuedLogger:
+        assert name not in manager.loggers, f"A logger with the name '{name}' already exists"
         log_queue = queue.Queue()
         handler = BareQueueHandler(log_queue)
         listener = QueueListener(log_queue, split_handler, respect_handler_level=True)
         listener.start()
-        return QueuedLogger(handler, listener)
+        queued_logger = QueuedLogger(handler, listener)
+        manager.loggers[name] = queued_logger
+        return queued_logger
 
 
 class NoPaddingLogRender(LogRender):


### PR DESCRIPTION
Replaces normal logging with a queued logging than delegates the writing of the log messages to a different thread.

This have the benefits of not blocking the loop with the file IO while still being able to use the main `log` function anywhere, without `await`.

