### PR TITLE
refactor: fallback to `Last-Modified` for file date

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -217,7 +217,7 @@ class DownloadClient:
                 media_item.partial_file.unlink()
 
             if not media_item.datetime and (last_modified := get_last_modified(resp.headers)):
-                msg = f"Unable to parse upload date for {media_item.url}, using `Last-Modified` value from server as file datetime"
+                msg = f"Unable to parse upload date for {media_item.url}, using `Last-Modified` header as file datetime"
                 log(msg, 30)
                 media_item.datetime = last_modified
 

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import calendar
 import copy
 import itertools
 import time
@@ -11,6 +12,7 @@ from typing import TYPE_CHECKING
 import aiofiles
 import aiohttp
 from aiohttp import ClientSession
+from dateutil import parser
 from videoprops import get_audio_properties, get_video_properties
 from yarl import URL
 
@@ -214,6 +216,8 @@ class DownloadClient:
             if resp.status != HTTPStatus.PARTIAL_CONTENT and media_item.partial_file.is_file():
                 media_item.partial_file.unlink()
 
+            if not media_item.datetime:
+                add_last_modified(media_item, resp.headers)
             media_item.task_id = self.manager.progress_manager.file_progress.add_task(
                 domain=domain,
                 filename=media_item.filename,
@@ -501,6 +505,19 @@ def get_content_type(ext: str, headers: CIMultiDictProxy) -> str | None:
         raise InvalidContentTypeError(message=msg)
 
     return content_type
+
+
+def get_last_modified(headers: CIMultiDictProxy) -> int | None:
+    if date_str := headers.get("Last-Modified"):
+        parsed_date = parser.parse(date_str)
+        return calendar.timegm(parsed_date.timetuple())
+
+
+def add_last_modified(media_item: MediaItem, headers: CIMultiDictProxy) -> None:
+    if date := get_last_modified(headers):
+        msg = f"Unable to parse upload date for {media_item.url}, using `Last-Modified` value from server as file datetime"
+        log(msg, 30)
+        media_item.datetime = date
 
 
 def is_html_or_text(content_type: str) -> bool:

--- a/cyberdrop_dl/crawlers/google_drive.py
+++ b/cyberdrop_dl/crawlers/google_drive.py
@@ -32,13 +32,11 @@
 
 from __future__ import annotations
 
-import calendar
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 from aiolimiter import AsyncLimiter
-from dateutil import parser
 from yarl import URL
 
 from cyberdrop_dl.clients.errors import DownloadError, ScrapeError
@@ -143,8 +141,6 @@ class GoogleDriveCrawler(Crawler):
         scrape_item.url = canonical_url
 
         filename = get_filename_from_headers(headers) or link.name
-        date = get_datetime_from_headers(headers)
-        scrape_item.possible_datetime = date
         filename, ext = self.get_filename_and_ext(filename)
         await self.handle_file(canonical_url, scrape_item, filename, ext, debrid_link=link)
 
@@ -253,13 +249,6 @@ def get_filename_from_headers(headers: dict) -> str | None:
     if match:
         matches = match.groups()
         return matches[0] or matches[1]
-
-
-def get_datetime_from_headers(headers: dict) -> int | None:
-    date_str = headers.get("Last-Modified")
-    if date_str:
-        parsed_date = parser.parse(date_str)
-        return calendar.timegm(parsed_date.timetuple())
 
 
 def get_canonical_url(item_id: str, folder: bool = False) -> URL:


### PR DESCRIPTION
Use server's `Last-Modified` value as the file date if we didn't get a date while scraping.

If `Last-Modified` is no available either, current datetime will be used