### PR TITLE
perf: use async loop to keep track of available space

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -234,7 +234,7 @@ class DownloadClient:
     ) -> None:
         """Appends content to a file."""
 
-        check_free_space = partial(self.client_manager.manager.download_manager.check_free_space, media_item)
+        check_free_space = partial(self.manager.storage_manager.check_free_space, media_item)
         await check_free_space()
 
         media_item.partial_file.parent.mkdir(parents=True, exist_ok=True)

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -16,13 +16,7 @@ from dateutil import parser
 from videoprops import get_audio_properties, get_video_properties
 from yarl import URL
 
-from cyberdrop_dl.clients.errors import (
-    DownloadError,
-    InsufficientFreeSpaceError,
-    InvalidContentTypeError,
-    SlowDownloadError,
-)
-from cyberdrop_dl.config_definitions.global_settings import MIN_REQUIRED_FREE_SPACE
+from cyberdrop_dl.clients.errors import DownloadError, InvalidContentTypeError, SlowDownloadError
 from cyberdrop_dl.utils.constants import FILE_FORMATS
 from cyberdrop_dl.utils.logger import log, log_debug
 
@@ -124,8 +118,6 @@ class DownloadClient:
         self.slow_download_period = 10  # seconds
         self.download_speed_threshold = self.manager.config_manager.settings_data.runtime_options.slow_download_speed
         self.chunk_size = client_manager.speed_limiter.chunk_size
-        self.chunks_counter: int = 0
-        self.free_space_check_lock = asyncio.Lock()
         self.add_request_log_hooks()
 
     def add_request_log_hooks(self) -> None:
@@ -241,11 +233,9 @@ class DownloadClient:
         update_progress: partial,
     ) -> None:
         """Appends content to a file."""
-        check_free_space = self.client_manager.manager.download_manager.check_free_space
-        async_check_free_space = partial(asyncio.to_thread, check_free_space, media_item.download_folder)
-        async with self.free_space_check_lock:
-            if not await async_check_free_space():
-                raise InsufficientFreeSpaceError(origin=media_item)
+
+        check_free_space = partial(self.client_manager.manager.download_manager.check_free_space, media_item)
+        await check_free_space()
 
         media_item.partial_file.parent.mkdir(parents=True, exist_ok=True)
         if not media_item.partial_file.is_file():
@@ -266,16 +256,12 @@ class DownloadClient:
         async with aiofiles.open(media_item.partial_file, mode="ab") as f:  # type: ignore
             async for chunk in content.iter_chunked(self.chunk_size):
                 await self.manager.states.RUNNING.wait()
+                await check_free_space()
                 chunk_size = len(chunk)
                 await self.client_manager.speed_limiter.acquire(chunk_size)
                 await asyncio.sleep(0)
                 await f.write(chunk)
                 update_progress(chunk_size)
-                self.chunks_counter += 1
-                async with self.free_space_check_lock:
-                    if self.chunks_counter * self.chunk_size >= MIN_REQUIRED_FREE_SPACE:
-                        await async_check_free_space()
-                        self.chunks_counter = 0
 
                 if self.download_speed_threshold:
                     check_download_speed()

--- a/cyberdrop_dl/config_definitions/global_settings.py
+++ b/cyberdrop_dl/config_definitions/global_settings.py
@@ -19,6 +19,7 @@ class General(BaseModel):
     proxy: HttpURL | None = None
     required_free_space: ByteSizeSerilized = DEFAULT_REQUIRED_FREE_SPACE
     user_agent: NonEmptyStr = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
+    pause_on_insufficient_space: bool = False
 
     @field_serializer("flaresolverr", "proxy")
     def serialize(self, value: URL | str) -> str | None:

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -15,7 +15,6 @@ from cyberdrop_dl.clients.errors import (
     DownloadError,
     DurationError,
     ErrorLogMessage,
-    InsufficientFreeSpaceError,
     InvalidContentTypeError,
     RestrictedFiletypeError,
 )
@@ -129,10 +128,9 @@ class Downloader:
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
-    def check_file_can_download(self, media_item: MediaItem) -> None:
+    async def check_file_can_download(self, media_item: MediaItem) -> None:
         """Checks if the file can be downloaded."""
-        if not self.manager.download_manager.check_free_space(media_item.download_folder):
-            raise InsufficientFreeSpaceError(origin=media_item)
+        await self.manager.download_manager.check_free_space(media_item)
         if not self.manager.download_manager.check_allowed_filetype(media_item):
             raise RestrictedFiletypeError(origin=media_item)
         if not self.manager.download_manager.pre_check_duration(media_item):
@@ -181,7 +179,7 @@ class Downloader:
             await self.manager.states.RUNNING.wait()
             media_item.current_attempt = media_item.current_attempt or 1
             media_item.duration = await self.manager.db_manager.history_table.get_duration(self.domain, media_item)
-            self.check_file_can_download(media_item)
+            await self.check_file_can_download(media_item)
             downloaded = await self.client.download_file(self.manager, self.domain, media_item)
             if downloaded:
                 Path.chmod(media_item.complete_file, 0o666)

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -130,7 +130,7 @@ class Downloader:
 
     async def check_file_can_download(self, media_item: MediaItem) -> None:
         """Checks if the file can be downloaded."""
-        await self.manager.download_manager.check_free_space(media_item)
+        await self.manager.storage_manager.check_free_space(media_item)
         if not self.manager.download_manager.check_allowed_filetype(media_item):
             raise RestrictedFiletypeError(origin=media_item)
         if not self.manager.download_manager.pre_check_duration(media_item):

--- a/cyberdrop_dl/managers/download_manager.py
+++ b/cyberdrop_dl/managers/download_manager.py
@@ -2,15 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from base64 import b64encode
-from collections import defaultdict
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-import psutil
-
 from cyberdrop_dl.clients.download_client import check_file_duration
-from cyberdrop_dl.clients.errors import InsufficientFreeSpaceError
 from cyberdrop_dl.utils.constants import FILE_FORMATS
 from cyberdrop_dl.utils.logger import log_debug
 
@@ -41,80 +36,10 @@ class FileLocksVault:
             log_debug(f"Lock for {filename} released", 20)
 
 
-class StorageManager:
-    """Runs an infinite loop to keep an updated value of the available space on all storage devices."""
-
-    def __init__(self, manager: Manager):
-        self.manager = manager
-        # all=True is required to make sure it works on most platforms. See: https://github.com/giampaolo/psutil/issues/2191
-        # We query all of them initially but we only check on a loop the ones that we need (self.used_mounts)
-        self.partitions = psutil.disk_partitions(all=True)
-        self.mounts = [Path(p.mountpoint) for p in self.partitions]
-        self.used_mounts: set[Path] = set()
-        self.mounts_free_space: dict[Path, int] = {}
-        self.total_data_written: int = 0
-        self._mount_addition_locks: dict[Path, asyncio.Lock] = defaultdict(asyncio.Lock)
-        self._period = 2  # seconds
-        self._checking_loop = asyncio.create_task(self.free_space_check_loop())
-        self._required_free_space = manager.config_manager.global_settings_data.general.required_free_space
-
-    def get_mount_point(self, folder: Path) -> Path | None:
-        possible_mountpoints = [mount for mount in self.mounts if mount in folder.parents or mount == folder]
-        if not possible_mountpoints:
-            return  # Path does not exists, ex: disconnected USB drive
-
-        return max(possible_mountpoints, key=lambda path: len(path.parts))
-
-    async def has_free_space(self, folder: Path | None = None) -> bool:
-        """Checks if there is enough free space on the drive to continue operating."""
-        if not folder:
-            folder = self.manager.path_manager.download_folder
-
-        mount = self.get_mount_point(folder)
-        if not mount:
-            return False
-
-        async with self._mount_addition_locks[mount]:
-            if not self.mounts_free_space.get(mount):
-                # Manually query this mount now. Next time it will be part of the loop
-                result = await asyncio.to_thread(psutil.disk_usage, str(mount))
-                self.mounts_free_space[mount] = result.free
-                self.used_mounts.add(mount)
-
-        return self.mounts_free_space[mount] > self._required_free_space
-
-    async def free_space_check_loop(self) -> None:
-        """Queries free space of all used mounts and updates internal dict"""
-
-        last_check = -1
-        await self.manager.states.RUNNING.wait()
-        while True:
-            # We could also update the values every 512MB of data written (MIN_REQUIRED_FREE_SPACE)
-            # if self.data_writen // MIN_REQUIRED_FREE_SPACE <= last_check:
-            #    continue
-            # But every second is more accurate
-            last_check += 1
-            used_mounts = sorted(self.used_mounts)
-            tasks = [asyncio.to_thread(psutil.disk_usage, str(mount)) for mount in used_mounts]
-            results = await asyncio.gather(*tasks)
-            for mount, result in zip(used_mounts, results, strict=True):
-                self.mounts_free_space[mount] = result.free
-
-            await asyncio.sleep(self._period)
-
-    async def close(self) -> None:
-        self._checking_loop.cancel()
-        try:
-            await self._checking_loop
-        except asyncio.CancelledError:
-            pass
-
-
 class DownloadManager:
     def __init__(self, manager: Manager) -> None:
         self.manager = manager
         self._download_instances: dict = {}
-        self.storage_manager = StorageManager(manager)
         self.file_locks = FileLocksVault()
 
         self.download_limits = {
@@ -141,11 +66,6 @@ class DownloadManager:
         """Returns a basic auth token."""
         token = b64encode(f"{username}:{password}".encode()).decode("ascii")
         return f"Basic {token}"
-
-    async def check_free_space(self, media_item: MediaItem) -> None:
-        """Checks if there is enough free space on the drive to continue operating."""
-        if not await self.storage_manager.has_free_space(media_item.download_folder):
-            raise InsufficientFreeSpaceError(origin=media_item)
 
     def check_allowed_filetype(self, media_item: MediaItem) -> bool:
         """Checks if the file type is allowed to download."""

--- a/cyberdrop_dl/managers/download_manager.py
+++ b/cyberdrop_dl/managers/download_manager.py
@@ -2,17 +2,20 @@ from __future__ import annotations
 
 import asyncio
 from base64 import b64encode
+from collections import defaultdict
 from contextlib import asynccontextmanager
-from shutil import disk_usage
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import psutil
+
 from cyberdrop_dl.clients.download_client import check_file_duration
+from cyberdrop_dl.clients.errors import InsufficientFreeSpaceError
 from cyberdrop_dl.utils.constants import FILE_FORMATS
 from cyberdrop_dl.utils.logger import log_debug
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
-    from pathlib import Path
 
     from cyberdrop_dl.managers.manager import Manager
     from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem
@@ -38,11 +41,80 @@ class FileLocksVault:
             log_debug(f"Lock for {filename} released", 20)
 
 
+class StorageManager:
+    """Runs an infinite loop to keep an updated value of the available space on all storage devices."""
+
+    def __init__(self, manager: Manager):
+        self.manager = manager
+        # all=True is required to make sure it works on most platforms. See: https://github.com/giampaolo/psutil/issues/2191
+        # We query all of them initially but we only check on a loop the ones that we need (self.used_mounts)
+        self.partitions = psutil.disk_partitions(all=True)
+        self.mounts = [Path(p.mountpoint) for p in self.partitions]
+        self.used_mounts: set[Path] = set()
+        self.mounts_free_space: dict[Path, int] = {}
+        self.total_data_written: int = 0
+        self._mount_addition_locks: dict[Path, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._period = 2  # seconds
+        self._checking_loop = asyncio.create_task(self.free_space_check_loop())
+        self._required_free_space = manager.config_manager.global_settings_data.general.required_free_space
+
+    def get_mount_point(self, folder: Path) -> Path | None:
+        possible_mountpoints = [mount for mount in self.mounts if mount in folder.parents or mount == folder]
+        if not possible_mountpoints:
+            return  # Path does not exists, ex: disconnected USB drive
+
+        return max(possible_mountpoints, key=lambda path: len(path.parts))
+
+    async def has_free_space(self, folder: Path | None = None) -> bool:
+        """Checks if there is enough free space on the drive to continue operating."""
+        if not folder:
+            folder = self.manager.path_manager.download_folder
+
+        mount = self.get_mount_point(folder)
+        if not mount:
+            return False
+
+        async with self._mount_addition_locks[mount]:
+            if not self.mounts_free_space.get(mount):
+                # Manually query this mount now. Next time it will be part of the loop
+                result = await asyncio.to_thread(psutil.disk_usage, str(mount))
+                self.mounts_free_space[mount] = result.free
+                self.used_mounts.add(mount)
+
+        return self.mounts_free_space[mount] > self._required_free_space
+
+    async def free_space_check_loop(self) -> None:
+        """Queries free space of all used mounts and updates internal dict"""
+
+        last_check = -1
+        await self.manager.states.RUNNING.wait()
+        while True:
+            # We could also update the values every 512MB of data written (MIN_REQUIRED_FREE_SPACE)
+            # if self.data_writen // MIN_REQUIRED_FREE_SPACE <= last_check:
+            #    continue
+            # But every second is more accurate
+            last_check += 1
+            used_mounts = sorted(self.used_mounts)
+            tasks = [asyncio.to_thread(psutil.disk_usage, str(mount)) for mount in used_mounts]
+            results = await asyncio.gather(*tasks)
+            for mount, result in zip(used_mounts, results, strict=True):
+                self.mounts_free_space[mount] = result.free
+
+            await asyncio.sleep(self._period)
+
+    async def close(self) -> None:
+        self._checking_loop.cancel()
+        try:
+            await self._checking_loop
+        except asyncio.CancelledError:
+            pass
+
+
 class DownloadManager:
     def __init__(self, manager: Manager) -> None:
         self.manager = manager
         self._download_instances: dict = {}
-
+        self.storage_manager = StorageManager(manager)
         self.file_locks = FileLocksVault()
 
         self.download_limits = {
@@ -70,20 +142,10 @@ class DownloadManager:
         token = b64encode(f"{username}:{password}".encode()).decode("ascii")
         return f"Basic {token}"
 
-    def check_free_space(self, folder: Path | None = None) -> bool:
+    async def check_free_space(self, media_item: MediaItem) -> None:
         """Checks if there is enough free space on the drive to continue operating."""
-        if not folder:
-            folder = self.manager.path_manager.download_folder
-
-        folder = folder.resolve()
-        while not folder.is_dir() and folder.parents:
-            folder = folder.parent
-
-        # check if we reached an anchor (root) that does not exists, ex: disconnected USB drive
-        if not folder.is_dir():
-            return False
-        free_space = disk_usage(folder).free
-        return free_space >= self.manager.config_manager.global_settings_data.general.required_free_space
+        if not await self.storage_manager.has_free_space(media_item.download_folder):
+            raise InsufficientFreeSpaceError(origin=media_item)
 
     def check_allowed_filetype(self, media_item: MediaItem) -> bool:
         """Checks if the file type is allowed to download."""

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -130,12 +130,15 @@ class Manager:
             self.client_manager = ClientManager(self)
         if not isinstance(self.storage_manager, StorageManager):
             self.storage_manager = StorageManager(self)
+
+        elif self.states.RUNNING.is_set():
+            await self.storage_manager.reset()  # Reset total downloaded data if running multiple configs
+
         if not isinstance(self.download_manager, DownloadManager):
             self.download_manager = DownloadManager(self)
         if not isinstance(self.real_debrid_manager, RealDebridManager):
             self.real_debrid_manager = RealDebridManager(self)
 
-        await self.storage_manager.reset()  # Reset total downloaded data if running multiple configs
         await self.async_db_hash_startup()
 
         constants.MAX_NAME_LENGTHS["FILE"] = self.config_manager.global_settings_data.general.max_file_name_length

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -134,6 +134,8 @@ class Manager:
             self.download_manager = DownloadManager(self)
         if not isinstance(self.real_debrid_manager, RealDebridManager):
             self.real_debrid_manager = RealDebridManager(self)
+
+        self.storage_manager.reset()  # Reset total downloaded data if running multiple configs
         await self.async_db_hash_startup()
 
         constants.MAX_NAME_LENGTHS["FILE"] = self.config_manager.global_settings_data.general.max_file_name_length

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -20,6 +20,7 @@ from cyberdrop_dl.managers.log_manager import LogManager
 from cyberdrop_dl.managers.path_manager import PathManager
 from cyberdrop_dl.managers.progress_manager import ProgressManager
 from cyberdrop_dl.managers.realdebrid_manager import RealDebridManager
+from cyberdrop_dl.managers.storage_manager import StorageManager
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.args import ParsedArgs
 from cyberdrop_dl.utils.logger import QueuedLogger, log
@@ -49,6 +50,7 @@ class Manager:
         self.log_manager: LogManager = field(init=False)
         self.db_manager: DBManager = field(init=False)
         self.client_manager: ClientManager = field(init=False)
+        self.storage_manager: StorageManager = field(init=False)
 
         self.download_manager: DownloadManager = field(init=False)
         self.progress_manager: ProgressManager = field(init=False)
@@ -126,6 +128,8 @@ class Manager:
 
         if not isinstance(self.client_manager, ClientManager):
             self.client_manager = ClientManager(self)
+        if not isinstance(self.storage_manager, StorageManager):
+            self.storage_manager = StorageManager(self)
         if not isinstance(self.download_manager, DownloadManager):
             self.download_manager = DownloadManager(self)
         if not isinstance(self.real_debrid_manager, RealDebridManager):
@@ -251,9 +255,11 @@ class Manager:
         self.states.RUNNING.clear()
         if not isinstance(self.client_manager, Field):
             await self.client_manager.close()
+
         await self.async_db_close()
         await self.cache_manager.close()
-        await self.download_manager.storage_manager.close()
+        await self.storage_manager.close()
+
         self.cache_manager.close_sync()
         while self.loggers:
             _, queued_logger = self.loggers.popitem()

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -248,10 +248,12 @@ class Manager:
 
     async def close(self) -> None:
         """Closes the manager."""
+        self.states.RUNNING.clear()
         if not isinstance(self.client_manager, Field):
             await self.client_manager.close()
         await self.async_db_close()
         await self.cache_manager.close()
+        await self.download_manager.storage_manager.close()
         self.cache_manager.close_sync()
         while self.loggers:
             _, queued_logger = self.loggers.popitem()

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -135,7 +135,7 @@ class Manager:
         if not isinstance(self.real_debrid_manager, RealDebridManager):
             self.real_debrid_manager = RealDebridManager(self)
 
-        self.storage_manager.reset()  # Reset total downloaded data if running multiple configs
+        await self.storage_manager.reset()  # Reset total downloaded data if running multiple configs
         await self.async_db_hash_startup()
 
         constants.MAX_NAME_LENGTHS["FILE"] = self.config_manager.global_settings_data.general.max_file_name_length

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -5,7 +5,7 @@ import json
 import platform
 from dataclasses import Field, field
 from time import perf_counter
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from cyberdrop_dl import __version__
 from cyberdrop_dl.config_definitions import ConfigSettings, GlobalSettings
@@ -21,6 +21,7 @@ from cyberdrop_dl.managers.path_manager import PathManager
 from cyberdrop_dl.managers.progress_manager import ProgressManager
 from cyberdrop_dl.managers.realdebrid_manager import RealDebridManager
 from cyberdrop_dl.managers.storage_manager import StorageManager
+from cyberdrop_dl.ui.textual import TextualUI
 from cyberdrop_dl.utils import constants
 from cyberdrop_dl.utils.args import ParsedArgs
 from cyberdrop_dl.utils.logger import QueuedLogger, log
@@ -56,6 +57,7 @@ class Manager:
         self.progress_manager: ProgressManager = field(init=False)
         self.live_manager: LiveManager = field(init=False)
         self.textual_log_queue: queue.Queue = field(init=False)
+        self._textual_ui: TextualUI = field(init=False)
 
         self._loaded_args_config: bool = False
         self._made_portable: bool = False
@@ -101,6 +103,19 @@ class Manager:
         if self.config_manager.loaded_config.casefold() == "all" or self.parsed_args.cli_only_args.multiconfig:
             self.multiconfig = True
         self.set_constants()
+
+    def notify(
+        self,
+        msg: str,
+        title: str = "",
+        severity: Literal["information", "warning", "error"] = "information",
+        timeout: float | None = None,
+    ):
+        """Wrapper around textual.app.notify
+
+        Does nothing if CDL is not using textual (`--no-textual-ui`)"""
+        if isinstance(self._textual_ui, TextualUI):
+            self._textual_ui.notify(msg, title=title, severity=severity, timeout=timeout)
 
     def adjust_for_simpcity(self) -> None:
         """Adjusts settings for SimpCity update."""

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -72,11 +72,17 @@ class ProgressManager:
 
     def pause_or_resume(self):
         if self.manager.states.RUNNING.is_set():
-            self.manager.states.RUNNING.clear()
-            self.activity.update(self.activity_task_id, description="Paused")
+            self.pause()
         else:
-            self.manager.states.RUNNING.set()
-            self.activity.update(self.activity_task_id, description="Running Cyberdrop-DL")
+            self.resume()
+
+    def pause(self):
+        self.manager.states.RUNNING.clear()
+        self.activity.update(self.activity_task_id, description="Paused")
+
+    def resume(self):
+        self.manager.states.RUNNING.set()
+        self.activity.update(self.activity_task_id, description="Running Cyberdrop-DL")
 
     def startup(self) -> None:
         """Startup process for the progress manager."""

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -133,7 +133,7 @@ class ProgressManager:
             return
         end_time = time.perf_counter()
         runtime = timedelta(seconds=int(end_time - start_time))
-        data_size = ByteSize(self.file_progress.downloaded_data).human_readable(decimal=True)
+        total_data_written = ByteSize(self.manager.storage_manager.total_data_written).human_readable(decimal=True)
 
         log_spacer(20)
         log("Printing Stats...\n", 20)
@@ -148,7 +148,7 @@ class ProgressManager:
         log_yellow(f"  Input URL Groups: {self.manager.scrape_mapper.group_count:,}")
         log_concat("  Log Folder: ", log_folder_text, style="yellow")
         log_yellow(f"  Total Runtime: {runtime}")
-        log_yellow(f"  Total Downloaded Data: {data_size}")
+        log_yellow(f"  Total Downloaded Data: {total_data_written}")
 
         log_spacer(20, "")
         log_cyan("Download Stats:")

--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -76,9 +76,10 @@ class ProgressManager:
         else:
             self.resume()
 
-    def pause(self):
+    def pause(self, msg: str = ""):
         self.manager.states.RUNNING.clear()
-        self.activity.update(self.activity_task_id, description="Paused")
+        suffix = f" [{msg}]" if msg else ""
+        self.activity.update(self.activity_task_id, description=f"Paused{suffix}")
 
     def resume(self):
         self.manager.states.RUNNING.set()

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from types import MappingProxyType
+from typing import TYPE_CHECKING, NamedTuple
 
 import psutil
 
@@ -20,76 +22,65 @@ class StorageManager:
 
     def __init__(self, manager: Manager):
         self.manager = manager
-        # all=True is required to make sure it works on most platforms. See: https://github.com/giampaolo/psutil/issues/2191
-        # We query all of them initially but we only check on a loop the ones that we need (self.used_mounts)
-        self.partitions = psutil.disk_partitions(all=True)
-        self.partitions_map = {Path(p.mountpoint): p for p in self.partitions}
-        self.mounts = sorted(self.partitions_map.keys())
-        self.used_mounts: set[Path] = set()
-        self.mounts_free_space: dict[Path, int] = {}
         self.total_data_written: int = 0
-        self.pause_if_no_free_space = True
+        self._used_mounts: set[Path] = set()
+        self._free_space: dict[Path, int] = {}
+        self._pause_if_no_free_space = True
         self._mount_addition_locks: dict[Path, asyncio.Lock] = defaultdict(asyncio.Lock)
-        self._period: int = 2  # seconds
-        self._log_period: int = 10  # loops, AKA log every 20 (2x10) seconds,
-        self._loop = asyncio.create_task(self.free_space_check_loop())
         self._updated = asyncio.Event()
-
-    def get_mount_point(self, folder: Path) -> Path | None:
-        possible_mountpoints = [mount for mount in self.mounts if mount in folder.parents or mount == folder]
-        if not possible_mountpoints:
-            return  # Path does not exists, ex: disconnected USB drive
-
-        return max(possible_mountpoints, key=lambda path: len(path.parts))
+        self._period: int = 2  # how often the check_free_space_loop will run (in seconds)
+        self._log_period: int = 10  # log storage details every <x> loops, AKA log every 20 (2x10) seconds,
+        self._loop = asyncio.create_task(self._check_free_space_loop())
 
     def get_used_mounts_stats(self) -> dict:
         data = {}
-        for mount in self.used_mounts:
-            data[mount] = self.partitions_map[mount]._asdict()
-            data[mount]["free_space"] = self.mounts_free_space[mount]
+        for mount in self._used_mounts:
+            data[mount] = get_available_partitions()[mount]._asdict()
+            data[mount]["free_space"] = self._free_space[mount]
         return data
 
-    async def has_sufficient_space(self, media_item: MediaItem) -> bool:
-        """Checks if there is enough free space to download this item"""
-
-        if isinstance(media_item.mount_point, Path):
-            mount = media_item.mount_point
-        else:
-            mount = self.get_mount_point(media_item.download_folder)
-            if mount:
-                media_item.mount_point = mount
-            else:
-                return False
-
-        return await self.has_sufficient_space_mount(mount)
-
-    async def has_sufficient_space_mount(self, mount: Path) -> bool:
-        """Checks if there is enough free space in this mount point"""
-
-        assert mount in self.mounts
-        async with self._mount_addition_locks[mount]:
-            if not self.mounts_free_space.get(mount):
-                # Manually query this mount now. Next time it will be part of the loop
-                result = await asyncio.to_thread(psutil.disk_usage, str(mount))
-                self.mounts_free_space[mount] = result.free
-                self.used_mounts.add(mount)
-
-        return (
-            self.mounts_free_space[mount] > self.manager.config_manager.global_settings_data.general.required_free_space
-        )
-
     async def check_free_space(self, media_item: MediaItem, no_pause: bool = False) -> None:
-        """Checks if there is enough free space on the drive to continue operating."""
+        """Checks if there is enough free space on download this item"""
 
-        if not await self.has_sufficient_space(media_item):
-            if self.pause_if_no_free_space and not no_pause:
+        if not await self._has_sufficient_space(media_item.download_folder):
+            if self._pause_if_no_free_space and not no_pause:
                 self.manager.states.RUNNING.clear()
                 await self.manager.states.RUNNING.wait()
                 return await self.check_free_space(media_item, no_pause=True)
             raise InsufficientFreeSpaceError(origin=media_item)
 
-    async def free_space_check_loop(self) -> None:
-        """Queries free space of all used mounts and updates internal dict"""
+    async def reset(self):
+        await self._updated.wait()  # Make sure a query is not running right now
+        self.total_data_written = 0
+        self._used_mounts = set()
+        self._free_space = {}
+
+    async def close(self) -> None:
+        await self.reset()
+        self._loop.cancel()
+        try:
+            await self._loop
+        except asyncio.CancelledError:
+            pass
+
+    async def _has_sufficient_space(self, folder: Path) -> bool:
+        """Checks if there is enough free space to download to this folder"""
+
+        mount = get_mount_point(folder)
+        if not mount:
+            return False
+
+        async with self._mount_addition_locks[mount]:
+            if mount not in self._free_space:
+                # Manually query this mount now. Next time it will be part of the loop
+                result = await asyncio.to_thread(psutil.disk_usage, str(mount))
+                self._free_space[mount] = result.free
+                self._used_mounts.add(mount)
+
+        return self._free_space[mount] > self.manager.config_manager.global_settings_data.general.required_free_space
+
+    async def _check_free_space_loop(self) -> None:
+        """Infinite loop to get free space of all used mounts and update internal dict"""
 
         last_check = -1
         while True:
@@ -100,27 +91,37 @@ class StorageManager:
             await self.manager.states.RUNNING.wait()
             self._updated.clear()
             last_check += 1
-            if self.used_mounts:
-                used_mounts = sorted(self.used_mounts)
+            if self._used_mounts:
+                used_mounts = sorted(self._used_mounts)
                 tasks = [asyncio.to_thread(psutil.disk_usage, str(mount)) for mount in used_mounts]
                 results = await asyncio.gather(*tasks)
                 for mount, result in zip(used_mounts, results, strict=True):
-                    self.mounts_free_space[mount] = result.free
+                    self._free_space[mount] = result.free
                 if last_check % self._log_period == 0:
                     log_debug({"Storage status": self.get_used_mounts_stats()})
             self._updated.set()
             await asyncio.sleep(self._period)
 
-    async def reset(self):
-        await self._updated.wait()  # Make sure a query is not running right now
-        self.total_data_written = 0
-        self.used_mounts = set()
-        self.mounts_free_space = {}
 
-    async def close(self) -> None:
-        await self.reset()
-        self._loop.cancel()
-        try:
-            await self._loop
-        except asyncio.CancelledError:
-            pass
+def get_mount_point(folder: Path) -> Path | None:
+    mounts = get_available_mountpoints()
+    possible_mountpoints = [mount for mount in mounts if mount in folder.parents or mount == folder]
+    if not possible_mountpoints:
+        return  # Path does not exists, ex: disconnected USB drive
+
+    return max(possible_mountpoints, key=lambda path: len(path.parts))
+
+
+@lru_cache
+def get_available_partitions() -> MappingProxyType[Path, NamedTuple]:
+    """NOTE: This function is cached which means it always returns the partitions available at startup"""
+
+    # all=True is required to make sure it works on most platforms. See: https://github.com/giampaolo/psutil/issues/2191
+    partitions = psutil.disk_partitions(all=True)
+    return MappingProxyType({Path(p.mountpoint): p for p in partitions})
+
+
+@lru_cache
+def get_available_mountpoints() -> tuple[Path, ...]:
+    """NOTE: This function is cached which means it always returns the mounts available at startup"""
+    return tuple(sorted(get_available_partitions().keys()))

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -56,7 +56,8 @@ class StorageManager:
             raise InsufficientFreeSpaceError(origin=media_item)
 
     async def reset(self):
-        await self._updated.wait()  # Make sure a query is not running right now
+        # This is causing lock ups
+        # await self._updated.wait()  # Make sure a query is not running right now
         self.total_data_written = 0
         self._used_mounts = set()
         self._free_space = {}

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import psutil
 
 from cyberdrop_dl.clients.errors import InsufficientFreeSpaceError
+from cyberdrop_dl.utils.logger import log_debug
 
 if TYPE_CHECKING:
     from cyberdrop_dl.managers.manager import Manager
@@ -22,13 +23,15 @@ class StorageManager:
         # all=True is required to make sure it works on most platforms. See: https://github.com/giampaolo/psutil/issues/2191
         # We query all of them initially but we only check on a loop the ones that we need (self.used_mounts)
         self.partitions = psutil.disk_partitions(all=True)
-        self.mounts = [Path(p.mountpoint) for p in self.partitions]
+        self.partitions_map = {Path(p.mountpoint): p for p in self.partitions}
+        self.mounts = sorted(self.partitions_map.keys())
         self.used_mounts: set[Path] = set()
         self.mounts_free_space: dict[Path, int] = {}
         self.total_data_written: int = 0
         self._mount_addition_locks: dict[Path, asyncio.Lock] = defaultdict(asyncio.Lock)
-        self._period = 2  # seconds
-        self._checking_loop = asyncio.create_task(self.free_space_check_loop())
+        self._period: int = 2  # seconds
+        self._log_period: int = 10  # loops, AKA log every 20 (2x10) seconds,
+        self._loop = asyncio.create_task(self.free_space_check_loop())
         self._updated = asyncio.Event()
 
     def get_mount_point(self, folder: Path) -> Path | None:
@@ -39,9 +42,10 @@ class StorageManager:
         return max(possible_mountpoints, key=lambda path: len(path.parts))
 
     async def has_free_space(self, folder: Path | None = None) -> bool:
-        """Checks if there is enough free space on the drive to continue operating."""
-        if not folder:
-            folder = self.manager.path_manager.download_folder
+        """Checks if there is enough free space on the drive to continue operating.
+
+        if `folder` is `None`, checks config's `download_folder`"""
+        folder = folder or self.manager.path_manager.download_folder
 
         mount = self.get_mount_point(folder)
         if not mount:
@@ -76,8 +80,20 @@ class StorageManager:
                 results = await asyncio.gather(*tasks)
                 for mount, result in zip(used_mounts, results, strict=True):
                     self.mounts_free_space[mount] = result.free
+                if last_check % self._log_period:
+                    msg = f"Storage status: {self.get_used_mount_stats()}"
+                    log_debug(msg)
             self._updated.set()
             await asyncio.sleep(self._period)
+
+    def get_used_mount_stats(self) -> dict:
+        data = {}
+        for mount, partition in self.partitions_map.items():
+            if mount not in self.used_mounts:
+                continue
+            data[mount] = partition._asdict()
+            data["free_space"] = self.mounts_free_space[mount]
+        return data
 
     async def check_free_space(self, media_item: MediaItem) -> None:
         """Checks if there is enough free space on the drive to continue operating."""
@@ -85,15 +101,15 @@ class StorageManager:
             raise InsufficientFreeSpaceError(origin=media_item)
 
     async def reset(self):
-        await self._updated.wait()
+        await self._updated.wait()  # Make sure a query is not running right now
         self.total_data_written = 0
         self.used_mounts = set()
         self.mounts_free_space = {}
 
     async def close(self) -> None:
         await self.reset()
-        self._checking_loop.cancel()
+        self._loop.cancel()
         try:
-            await self._checking_loop
+            await self._loop
         except asyncio.CancelledError:
             pass

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -103,12 +103,24 @@ class StorageManager:
             await asyncio.sleep(self._period)
 
 
+@lru_cache
 def get_mount_point(folder: Path) -> Path | None:
+    # Cached for performance.
+    # It's not an expensive operation nor IO blocking, but it's very common for multiple files to share the same download folder
+    # ex: HLS downloads could have over a thousand segments. All of them will go to the same folder
     mounts = get_available_mountpoints()
     possible_mountpoints = [mount for mount in mounts if mount in folder.parents or mount == folder]
     if not possible_mountpoints:
-        return  # Path does not exists, ex: disconnected USB drive
+        # Mount point for this path does not exists
+        # This will only happend on Windows (ex: an USB drive (`D:`) that is not currently available (AKA disconnected)
+        # On Unix there always at least 1 mountpoint, root (`/`)
+        return
 
+    # Get the closest mountpoint to the desired path
+    # Example:
+    # mount_a = /home/user/  -> points to an internal SSD
+    # mount_b = /home/user/USB -> points to an external USB drive
+    # If folder is `/home/user/USB/videos`, the correct mountpoint is mount_b
     return max(possible_mountpoints, key=lambda path: len(path.parts))
 
 

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -35,10 +35,11 @@ class StorageManager:
         self._loop = asyncio.create_task(self._check_free_space_loop())
 
     def get_used_mounts_stats(self) -> dict:
-        data = {}
+        mounts = {}
         for mount in self._used_mounts:
-            data[mount] = get_available_partitions()[mount]._asdict()
-            data[mount]["free_space"] = self._free_space[mount]
+            data = get_available_partitions()[mount]._asdict() | {"free_space": self._free_space[mount]}
+            data.pop("mountpoint", None)
+            mounts[str(mount)] = data
         return data
 
     async def check_free_space(self, media_item: MediaItem) -> None:

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import psutil
+
+from cyberdrop_dl.clients.errors import InsufficientFreeSpaceError
+
+if TYPE_CHECKING:
+    from cyberdrop_dl.managers.manager import Manager
+    from cyberdrop_dl.utils.data_enums_classes.url_objects import MediaItem
+
+
+class StorageManager:
+    """Runs an infinite loop to keep an updated value of the available space on all storage devices."""
+
+    def __init__(self, manager: Manager):
+        self.manager = manager
+        # all=True is required to make sure it works on most platforms. See: https://github.com/giampaolo/psutil/issues/2191
+        # We query all of them initially but we only check on a loop the ones that we need (self.used_mounts)
+        self.partitions = psutil.disk_partitions(all=True)
+        self.mounts = [Path(p.mountpoint) for p in self.partitions]
+        self.used_mounts: set[Path] = set()
+        self.mounts_free_space: dict[Path, int] = {}
+        self.total_data_written: int = 0
+        self._mount_addition_locks: dict[Path, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._period = 2  # seconds
+        self._checking_loop = asyncio.create_task(self.free_space_check_loop())
+
+    def get_mount_point(self, folder: Path) -> Path | None:
+        possible_mountpoints = [mount for mount in self.mounts if mount in folder.parents or mount == folder]
+        if not possible_mountpoints:
+            return  # Path does not exists, ex: disconnected USB drive
+
+        return max(possible_mountpoints, key=lambda path: len(path.parts))
+
+    async def has_free_space(self, folder: Path | None = None) -> bool:
+        """Checks if there is enough free space on the drive to continue operating."""
+        if not folder:
+            folder = self.manager.path_manager.download_folder
+
+        mount = self.get_mount_point(folder)
+        if not mount:
+            return False
+
+        async with self._mount_addition_locks[mount]:
+            if not self.mounts_free_space.get(mount):
+                # Manually query this mount now. Next time it will be part of the loop
+                result = await asyncio.to_thread(psutil.disk_usage, str(mount))
+                self.mounts_free_space[mount] = result.free
+                self.used_mounts.add(mount)
+
+        return (
+            self.mounts_free_space[mount] > self.manager.config_manager.global_settings_data.general.required_free_space
+        )
+
+    async def free_space_check_loop(self) -> None:
+        """Queries free space of all used mounts and updates internal dict"""
+
+        last_check = -1
+        await self.manager.states.RUNNING.wait()
+        while True:
+            # We could also update the values every 512MB of data written (MIN_REQUIRED_FREE_SPACE)
+            # if self.data_writen // MIN_REQUIRED_FREE_SPACE <= last_check:
+            #    continue
+            # But every second is more accurate
+            last_check += 1
+            used_mounts = sorted(self.used_mounts)
+            tasks = [asyncio.to_thread(psutil.disk_usage, str(mount)) for mount in used_mounts]
+            results = await asyncio.gather(*tasks)
+            for mount, result in zip(used_mounts, results, strict=True):
+                self.mounts_free_space[mount] = result.free
+
+            await asyncio.sleep(self._period)
+
+    async def check_free_space(self, media_item: MediaItem) -> None:
+        """Checks if there is enough free space on the drive to continue operating."""
+        if not await self.has_free_space(media_item.download_folder):
+            raise InsufficientFreeSpaceError(origin=media_item)
+
+    async def close(self) -> None:
+        self.used_mounts = set()
+        self._checking_loop.cancel()
+        try:
+            await self._checking_loop
+        except asyncio.CancelledError:
+            pass

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -81,8 +81,7 @@ class StorageManager:
                 for mount, result in zip(used_mounts, results, strict=True):
                     self.mounts_free_space[mount] = result.free
                 if last_check % self._log_period:
-                    msg = f"Storage status: {self.get_used_mount_stats()}"
-                    log_debug(msg)
+                    log_debug({"Storage status": self.get_used_mount_stats()})
             self._updated.set()
             await asyncio.sleep(self._period)
 
@@ -92,7 +91,7 @@ class StorageManager:
             if mount not in self.used_mounts:
                 continue
             data[mount] = partition._asdict()
-            data["free_space"] = self.mounts_free_space[mount]
+            data[mount]["free_space"] = self.mounts_free_space[mount]
         return data
 
     async def check_free_space(self, media_item: MediaItem) -> None:

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -59,7 +59,7 @@ class StorageManager:
         if not await self._has_sufficient_space(media_item.download_folder):
             if self.manager.config_manager.global_settings_data.general.pause_on_insufficient_space:
                 if not self._paused_datetime:
-                    self.manager.progress_manager.pause()
+                    self.manager.progress_manager.pause("Insufficient Free Space")
                     self.manager.notify(
                         title="Insufficient Free Space",
                         msg="Clean up storage space and click resume to continue",

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
 from types import MappingProxyType
@@ -57,6 +57,7 @@ class StorageManager:
 
         await self.manager.states.RUNNING.wait()
         if not await self._has_sufficient_space(media_item.download_folder):
+            """ Needs textual UI
             if self.manager.config_manager.global_settings_data.general.pause_on_insufficient_space:
                 if not self._paused_datetime:
                     self.manager.progress_manager.pause("Insufficient Free Space")
@@ -68,6 +69,7 @@ class StorageManager:
                     self._paused_datetime = datetime.now()
                 if (datetime.now() - self._paused_datetime) < self._timedelta_period:
                     return await self.check_free_space(media_item)
+            """
             raise InsufficientFreeSpaceError(origin=media_item)
 
     async def reset(self):

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -49,6 +49,11 @@ class StorageManager:
             if self.manager.config_manager.global_settings_data.general.pause_on_insufficient_space:
                 if not self._paused_datetime:
                     self.manager.progress_manager.pause()
+                    self.manager.notify(
+                        title="Insufficient Free Space",
+                        msg="Clean up storage space and click resume to continue",
+                        severity="warning",
+                    )
                     self._paused_datetime = datetime.now()
                 if (datetime.now() - self._paused_datetime) < self._timedelta_period:
                     return await self.check_free_space(media_item)

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -27,7 +27,6 @@ class StorageManager:
         self._paused_datetime = None
         self._used_mounts: set[Path] = set()
         self._free_space: dict[Path, int] = {}
-        self._pause_if_no_free_space = False
         self._mount_addition_locks: dict[Path, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._updated = asyncio.Event()
         self._period: int = 2  # how often the check_free_space_loop will run (in seconds)
@@ -47,7 +46,7 @@ class StorageManager:
 
         await self.manager.states.RUNNING.wait()
         if not await self._has_sufficient_space(media_item.download_folder):
-            if self._pause_if_no_free_space:
+            if self.manager.config_manager.global_settings_data.general.pause_on_insufficient_space:
                 if not self._paused_datetime:
                     self.manager.progress_manager.pause()
                     self._paused_datetime = datetime.now()

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -108,11 +108,12 @@ def get_mount_point(folder: Path) -> Path | None:
     # Cached for performance.
     # It's not an expensive operation nor IO blocking, but it's very common for multiple files to share the same download folder
     # ex: HLS downloads could have over a thousand segments. All of them will go to the same folder
+    assert folder.is_absolute()
     mounts = get_available_mountpoints()
     possible_mountpoints = [mount for mount in mounts if mount in folder.parents or mount == folder]
     if not possible_mountpoints:
         # Mount point for this path does not exists
-        # This will only happend on Windows (ex: an USB drive (`D:`) that is not currently available (AKA disconnected)
+        # This will only happend on Windows, ex: an USB drive (`D:`) that is not currently available (AKA disconnected)
         # On Unix there always at least 1 mountpoint, root (`/`)
         return
 

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -81,17 +81,15 @@ class StorageManager:
                 results = await asyncio.gather(*tasks)
                 for mount, result in zip(used_mounts, results, strict=True):
                     self.mounts_free_space[mount] = result.free
-                if last_check % self._log_period:
+                if last_check % self._log_period == 0:
                     log_debug({"Storage status": self.get_used_mount_stats()})
             self._updated.set()
             await asyncio.sleep(self._period)
 
     def get_used_mount_stats(self) -> dict:
         data = {}
-        for mount, partition in self.partitions_map.items():
-            if mount not in self.used_mounts:
-                continue
-            data[mount] = partition._asdict()
+        for mount in self.used_mounts:
+            data[mount] = self.partitions_map[mount]._asdict()
             data[mount]["free_space"] = self.mounts_free_space[mount]
         return data
 

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -43,10 +43,6 @@ class FileProgress(DequeProgress):
         self._progress = Progress(*use_columns)
         super().__init__("Downloads", visible_tasks_limit)
 
-    @property
-    def downloaded_data(self):
-        return self.manager.download_manager.storage_manager.total_data_written
-
     def get_queue_length(self) -> int:
         """Returns the number of tasks in the downloader queue."""
         total = 0

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -66,7 +66,7 @@ class FileProgress(DequeProgress):
 
     def advance_file(self, task_id: TaskID, amount: int) -> None:
         """Advances the progress of the given task by the given amount."""
-        self.manager.download_manager.storage_manager.total_data_written += amount
+        self.manager.storage_manager.total_data_written += amount
         self._progress.advance(task_id, amount)
 
     def get_speed(self, task_id: TaskID) -> float:

--- a/cyberdrop_dl/ui/progress/file_progress.py
+++ b/cyberdrop_dl/ui/progress/file_progress.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pydantic import ByteSize
 from rich.markup import escape
 from rich.progress import (
     BarColumn,
@@ -42,8 +41,11 @@ class FileProgress(DequeProgress):
         if manager.parsed_args.cli_only_args.portrait:
             use_columns = vertical_columns
         self._progress = Progress(*use_columns)
-        self.downloaded_data = ByteSize(0)
         super().__init__("Downloads", visible_tasks_limit)
+
+    @property
+    def downloaded_data(self):
+        return self.manager.download_manager.storage_manager.total_data_written
 
     def get_queue_length(self) -> int:
         """Returns the number of tasks in the downloader queue."""
@@ -68,7 +70,7 @@ class FileProgress(DequeProgress):
 
     def advance_file(self, task_id: TaskID, amount: int) -> None:
         """Advances the progress of the given task by the given amount."""
-        self.downloaded_data += amount
+        self.manager.download_manager.storage_manager.total_data_written += amount
         self._progress.advance(task_id, amount)
 
     def get_speed(self, task_id: TaskID) -> float:

--- a/cyberdrop_dl/ui/textual.py
+++ b/cyberdrop_dl/ui/textual.py
@@ -55,6 +55,7 @@ class TextualUI(App[int]):
         self.manager = manager
         self.queue: queue.Queue[Text] = manager.textual_log_queue
         self.auto_scroll = True
+        manager._textual_ui = self
 
     def compose(self) -> ComposeResult:
         def create_footer():

--- a/cyberdrop_dl/utils/args.py
+++ b/cyberdrop_dl/utils/args.py
@@ -73,20 +73,20 @@ class CommandLineOnlyArgs(BaseModel):
     completed_before: date | None = Field(None, description="only download completed downloads at or before this date")
     config: str | None = Field(None, description="name of config to load")
     config_file: Path | None = Field(None, description="path to the CDL settings.yaml file to load")
+    disable_cache: bool = Field(False, description="Temporarily disable the requests cache")
     download: bool = Field(False, description="skips UI, start download immediatly")
+    download_dropbox_folders_as_zip: bool = Field(False, description="download Dropbox folder without api key as zip")
+    download_tiktok_audios: bool = Field(False, description="download TikTok audios")
     max_items_retry: int = Field(0, description="max number of links to retry")
     no_textual_ui: bool = Field(False, description="Disable textual UI (TUI with mouse support)")
+    portrait: bool = Field(is_terminal_in_portrait(), description="show UI in a portrait layout")
+    print_stats: bool = Field(True, description="Show stats report at the end of a run")
     retry_all: bool = Field(False, description="retry all downloads")
     retry_failed: bool = Field(False, description="retry failed downloads")
     retry_maintenance: bool = Field(
         False, description="retry download of maintenance files (bunkr). Requires files to be hashed"
     )
-    download_dropbox_folders_as_zip: bool = Field(False, description="download Dropbox folder without api key as zip")
-    download_tiktok_audios: bool = Field(False, description="download TikTok audios")
-    print_stats: bool = Field(True, description="Show stats report at the end of a run")
     ui: UIOptions = Field(UIOptions.FULLSCREEN, description="DISABLED, ACTIVITY, SIMPLE or FULLSCREEN")
-    portrait: bool = Field(is_terminal_in_portrait(), description="show UI in a portrait layout")
-    disable_cache: bool = Field(False, description="Temporarily disable the requests cache")
 
     @property
     def retry_any(self) -> bool:

--- a/cyberdrop_dl/utils/args.py
+++ b/cyberdrop_dl/utils/args.py
@@ -75,6 +75,7 @@ class CommandLineOnlyArgs(BaseModel):
     config_file: Path | None = Field(None, description="path to the CDL settings.yaml file to load")
     download: bool = Field(False, description="skips UI, start download immediatly")
     max_items_retry: int = Field(0, description="max number of links to retry")
+    no_textual_ui: bool = Field(False, description="Disable textual UI (TUI with mouse support)")
     retry_all: bool = Field(False, description="retry all downloads")
     retry_failed: bool = Field(False, description="retry failed downloads")
     retry_maintenance: bool = Field(
@@ -86,7 +87,6 @@ class CommandLineOnlyArgs(BaseModel):
     ui: UIOptions = Field(UIOptions.FULLSCREEN, description="DISABLED, ACTIVITY, SIMPLE or FULLSCREEN")
     portrait: bool = Field(is_terminal_in_portrait(), description="show UI in a portrait layout")
     disable_cache: bool = Field(False, description="Temporarily disable the requests cache")
-    textual_ui: bool = Field(True, description="Enable/Disable textual UI (TUI with mouse support)")
 
     @property
     def retry_any(self) -> bool:

--- a/cyberdrop_dl/utils/data_enums_classes/url_objects.py
+++ b/cyberdrop_dl/utils/data_enums_classes/url_objects.py
@@ -53,7 +53,6 @@ class MediaItem:
     task_id: TaskID | None = field(default=None, init=False, hash=False, compare=False)
     hash: str | None = field(default=None, init=False, hash=False, compare=False)
     downloaded: bool = field(default=False, init=False, hash=False, compare=False)
-    mount_point: Path = field(init=False, hash=False, compare=False)
 
     # slots for __post_init__
     referer: URL = field(init=False)

--- a/cyberdrop_dl/utils/data_enums_classes/url_objects.py
+++ b/cyberdrop_dl/utils/data_enums_classes/url_objects.py
@@ -53,6 +53,7 @@ class MediaItem:
     task_id: TaskID | None = field(default=None, init=False, hash=False, compare=False)
     hash: str | None = field(default=None, init=False, hash=False, compare=False)
     downloaded: bool = field(default=False, init=False, hash=False, compare=False)
+    mount_point: Path = field(init=False, hash=False, compare=False)
 
     # slots for __post_init__
     referer: URL = field(init=False)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1573,6 +1573,30 @@ files = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.0.0"
+description = "Cross-platform lib for process and system monitoring in Python.  NOTE: the syntax of this script MUST be kept compatible with Python 2.7."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25"},
+    {file = "psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993"},
+    {file = "psutil-7.0.0-cp36-cp36m-win32.whl", hash = "sha256:84df4eb63e16849689f76b1ffcb36db7b8de703d1bc1fe41773db487621b6c17"},
+    {file = "psutil-7.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:1e744154a6580bc968a0195fd25e80432d3afec619daf145b9e5ba16cc1d688e"},
+    {file = "psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99"},
+    {file = "psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553"},
+    {file = "psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black (==24.10.0)", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest", "pytest-cov", "pytest-xdist", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
+test = ["pytest", "pytest-xdist", "setuptools"]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "packaging (>=24.2)",
     "pillow (>=11.1.0,<12.0.0)",
     "platformdirs (>=4.3.6,<5.0.0)",
+    "psutil (>=7.0.0,<8.0.0)",
     "pydantic (>=2.10.6,<3.0.0)",
     "pywin32>=308 ; sys_platform == 'win32'",
     "pyyaml (>=6.0.2,<7.0.0)",


### PR DESCRIPTION
### Context

- The changes from #831 work but using a global lock blocks all downloads until the query for free space is ready, even if they will go to a different drive. 

- The internal chunk counter is reset after a single query so, if 2 downloads start at almost the same time, the original issue can still occur.

- We can take advantage of #814 by skipping querying free space for every file and just query the mount point they are using/will use and reuse the result of the query for every file that uses the same mount point.

### Changes

This PR adds a helper class that runs a loop every 2 seconds to get the free space of every mount point in the system and keeps a dict with the values. This means we can check the available free space after every chunk written to disk by just querying the internal dict with the mount point of the current file, without blocking.

Loop only queries mount points that were used/are being used by some file in the current run.

This uses a new dependency ([psutil](https://github.com/giampaolo/psutil/tree/master)) to get the mountpoint of all available storage devices in the system

### TODO:
- [X] ~~Right now the mount point is computed after every written chunk. I will add the mount point as as an attribute of the `MediaItem` class~~ Added a global cache instead
- [X] Needs #822 (uses the manager asyncio events to start/stop the loop)