### PR TITLE
refactor: disable textual UI

### DIFF
--- a/cyberdrop_dl/managers/live_manager.py
+++ b/cyberdrop_dl/managers/live_manager.py
@@ -23,7 +23,7 @@ class LiveManager:
         self.ui_setting = self.manager.parsed_args.cli_only_args.ui
         self.fullscreen = f = self.manager.parsed_args.cli_only_args.fullscreen_ui
         self.refresh_rate = rate = self.manager.config_manager.global_settings_data.ui_options.refresh_rate
-        self.use_textual = manager.parsed_args.cli_only_args.textual_ui and self.fullscreen
+        self.use_textual = False  # manager.parsed_args.cli_only_args.textual_ui and self.fullscreen
         self.auto_refresh = a = not self.use_textual
         self.live = Live(refresh_per_second=rate, console=console, transient=True, screen=f, auto_refresh=a)
 


### PR DESCRIPTION
Disable textual UI for the next release.

UI freezes a lot if there are multiple input URLs that use the request cache. There's a blocking operation somewhere. I need to debug with a profile before releasing it.