### PR TITLE
Clarify exact user agent on flaresolverr mismatch

### DIFF
--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -355,7 +355,7 @@ class Flaresolverr:
             raise DDOSGuardError(message="Failed to resolve URL with flaresolverr", origin=origin)
 
         user_agent = client_session.headers["User-Agent"].strip()
-        mismatch_msg = f"Config user_agent and flaresolverr user_agent do not match: \n  Cyberdrop-DL: {user_agent}\n  Flaresolverr: {fs_resp.user_agent}"
+        mismatch_msg = f"Config user_agent and flaresolverr user_agent do not match: \n  Cyberdrop-DL: '{user_agent}'\n  Flaresolverr: '{fs_resp.user_agent}'"
         if fs_resp.soup and (
             self.client_manager.check_ddos_guard(fs_resp.soup) or self.client_manager.check_cloudflare(fs_resp.soup)
         ):


### PR DESCRIPTION
Whole error message is wrapped in `()` which can lead to situations like this:

```
Scrape Failed: https://redacted (DDoS-Guard - Config user_agent and flaresolverr user_agent do not match:
                               Cyberdrop-DL: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36)
                               Flaresolverr: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36)
```

Quoting clarifies exact strings needed for config change