### PR TITLE
Revert "fix: always deep scrape albums (bunkr)"

### DIFF
--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -288,7 +288,6 @@ class BunkrrCrawler(Crawler):
 
     def deep_scrape(self, url: URL) -> bool:
         assert url.host
-        return True  # Always deepscrape albums, see GH-848
         return any(part in url.host.split(".") for part in ("burger",)) or self.manager.config_manager.deep_scrape
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""


### PR DESCRIPTION
- Proper fix is #853 
- Reverts jbsparrow/CyberDropDownloader#851