### PR TITLE
refactor: single file progress for hls downloads

### DIFF
--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -167,11 +167,7 @@ class Crawler(ABC):
             self.manager.progress_manager.download_progress.add_skipped()
             return
 
-        if not m3u8_content:
-            self.manager.task_group.create_task(self.downloader.run(media_item))
-            return
-
-        self.manager.task_group.create_task(self.downloader.download_hls(media_item, m3u8_content))
+        self.manager.task_group.create_task(self.downloader.run(media_item, m3u8_content))
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-<<<<<<< HEAD
-import re
-=======
 import contextlib
->>>>>>> bd88c7a8 (refactor: count the actual number of segments)
 from dataclasses import field
 from functools import wraps
 from pathlib import Path
@@ -338,8 +334,8 @@ async def set_file_datetime(media_item: MediaItem, file_path: Path | None = None
         file_path = file_path or media_item.complete_file
 
     def set_date():
-            file = File(str(file_path))
-            file.set(*(media_item.datetime,) * 3)  # type: ignore
+        file = File(str(file_path))
+        file.set(*(media_item.datetime,) * 3)  # type: ignore
 
     await asyncio.to_thread(set_date)
 

--- a/cyberdrop_dl/managers/download_manager.py
+++ b/cyberdrop_dl/managers/download_manager.py
@@ -24,7 +24,7 @@ class FileLocksVault:
         self._locked_files: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     @asynccontextmanager
-    async def get_lock(self, media_item: MediaItem) -> AsyncGenerator:
+    async def get_lock(self, media_item: MediaItem) -> AsyncGenerator[None, None]:
         """Get filelock for the media_item. Creates one if none exists"""
         if not media_item.file_lock_reference_name:
             media_item.file_lock_reference_name = media_item.filename

--- a/cyberdrop_dl/managers/download_manager.py
+++ b/cyberdrop_dl/managers/download_manager.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-from cyberdrop_dl.clients.download_client import check_file_duration
 from cyberdrop_dl.utils.constants import FILE_FORMATS
 from cyberdrop_dl.utils.logger import log_debug
 
@@ -84,10 +83,3 @@ class DownloadManager:
         if media_item.ext.lower() in FILE_FORMATS["Audio"] and ignore_options.exclude_audio:
             return False
         return not (ignore_options.exclude_other and media_item.ext.lower() not in valid_extensions)
-
-    def pre_check_duration(self, media_item: MediaItem) -> bool:
-        """Checks if the download is above the maximum runtime."""
-        if not media_item.duration:
-            return True
-
-        return check_file_duration(media_item, self.manager)

--- a/cyberdrop_dl/managers/download_manager.py
+++ b/cyberdrop_dl/managers/download_manager.py
@@ -24,8 +24,13 @@ class FileLocksVault:
         self._locked_files: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     @asynccontextmanager
-    async def get_lock(self, filename: str) -> AsyncGenerator:
-        """Get filelock for the provided filename. Creates one if none exists"""
+    async def get_lock(self, media_item: MediaItem) -> AsyncGenerator:
+        """Get filelock for the media_item. Creates one if none exists"""
+        if not media_item.file_lock_reference_name:
+            media_item.file_lock_reference_name = media_item.filename
+
+        filename = media_item.file_lock_reference_name
+
         log_debug(f"Checking lock for '{filename}'", 20)
         if filename not in self._locked_files:
             log_debug(f"Lock for '{filename}' does not exists", 20)

--- a/cyberdrop_dl/managers/download_manager.py
+++ b/cyberdrop_dl/managers/download_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from base64 import b64encode
+from collections import defaultdict
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -20,7 +21,7 @@ class FileLocksVault:
     """Is this necessary? No. But I want it."""
 
     def __init__(self) -> None:
-        self._locked_files: dict[str, asyncio.Lock] = {}
+        self._locked_files: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     @asynccontextmanager
     async def get_lock(self, filename: str) -> AsyncGenerator:
@@ -29,7 +30,6 @@ class FileLocksVault:
         if filename not in self._locked_files:
             log_debug(f"Lock for '{filename}' does not exists", 20)
 
-        self._locked_files[filename] = self._locked_files.get(filename, asyncio.Lock())
         async with self._locked_files[filename]:
             log_debug(f"Lock for '{filename}' acquired", 20)
             yield

--- a/cyberdrop_dl/managers/path_manager.py
+++ b/cyberdrop_dl/managers/path_manager.py
@@ -141,6 +141,10 @@ class PathManager:
         if self.manager.config_manager.settings_data.files.save_pages_html:
             self.pages_folder.mkdir(parents=True, exist_ok=True)
 
+        self.download_folder.mkdir(parents=True, exist_ok=True)
+        if self.manager.config_manager.settings_data.sorting.sort_downloads:
+            self.sorted_folder.mkdir(parents=True, exist_ok=True)
+
     def add_completed(self, media_item: MediaItem) -> None:
         if media_item.is_segment:
             return


### PR DESCRIPTION
- Unify downloader's limiter, queue and locks in a single method (related to #556)
- Process all hls segments as a single file