### PR TITLE
[FEAT] Remove unsupported browsers from import menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.8.1] - 2025-04-10
+
+### Added
+- The import cookies menu will now only display the browsers that the user's OS supports for cookie extraction
+
 ## [6.8.0] - 2025-04-05
 
 ### Added

--- a/cyberdrop_dl/ui/prompts/user_prompts.py
+++ b/cyberdrop_dl/ui/prompts/user_prompts.py
@@ -223,11 +223,23 @@ def extract_cookies(manager: Manager, *, dry_run: bool = False) -> None:
 def browser_prompt() -> str:
     """Asks the user to select browser(s) for cookie extraction."""
     unsupported_browsers = {
-        "Windows": {"safari"},
-        "Linux": {"safari", "edge"},
-        "Darwin": {"edge"},
+        "Windows": {
+            "arc",
+            "brave",
+            "chrome",
+            "chromium",
+            "edge",
+            "lynx",
+            "opera",
+            "opera_gx",
+            "safari",
+            "vivaldi",
+            "w3m",
+        },
+        "Linux": {"arc", "opera_gx", "safari"},
+        "Darwin": {"lynx", "w3m"},
     }.get(system(), set())
-    choices = [Choice(browser, browser.capitalize()) for browser in BROWSERS if browser not in unsupported_browsers]
+    choices = [Choice(browser, browser.capitalize() if browser != 'opera_gx' else 'Opera GX') for browser in BROWSERS if browser not in unsupported_browsers]
     return basic_prompts.ask_checkbox(choices, message="Select the browser(s) for extraction:")
 
 

--- a/cyberdrop_dl/ui/prompts/user_prompts.py
+++ b/cyberdrop_dl/ui/prompts/user_prompts.py
@@ -239,7 +239,11 @@ def browser_prompt() -> str:
         "Linux": {"arc", "opera_gx", "safari"},
         "Darwin": {"lynx", "w3m"},
     }.get(system(), set())
-    choices = [Choice(browser, browser.capitalize() if browser != 'opera_gx' else 'Opera GX') for browser in BROWSERS if browser not in unsupported_browsers]
+    choices = [
+        Choice(browser, browser.capitalize() if browser != "opera_gx" else "Opera GX")
+        for browser in BROWSERS
+        if browser not in unsupported_browsers
+    ]
     return basic_prompts.ask_checkbox(choices, message="Select the browser(s) for extraction:")
 
 


### PR DESCRIPTION
Only show the user browsers that are supported for import on their operating system.

Also change 'opera_gx' to display 'Opera GX'