### PR TITLE
fix: downloader stalling and creating empty files

### DIFF
--- a/cyberdrop_dl/crawlers/__init__.py
+++ b/cyberdrop_dl/crawlers/__init__.py
@@ -89,7 +89,7 @@ from .youjizz import YouJizzCrawler
 
 ALL_CRAWLERS: set[type[Crawler]] = {crawler for name, crawler in globals().items() if name.endswith("Crawler")}
 ALL_CRAWLERS = ALL_CRAWLERS - {Crawler}
-DEBUG_CRAWLERS = {SimpCityCrawler, BunkrAlbumsIOCrawler}
+DEBUG_CRAWLERS = {SimpCityCrawler, BunkrAlbumsIOCrawler, MissAVCrawler}
 CRAWLERS = ALL_CRAWLERS - DEBUG_CRAWLERS
 
 if env.ENABLE_DEBUG_CRAWLERS == "d396ab8c85fcb1fecd22c8d9b58acf944a44e6d35014e9dd39e42c9a64091eda":

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -155,12 +155,11 @@ class Crawler(ABC):
             self.manager.progress_manager.download_progress.add_skipped()
             return
 
-        if m3u8_content:
-            task = self.downloader.download_hls(media_item, m3u8_content)
-        else:
-            task = self.downloader.run(media_item)
+        if not m3u8_content:
+            self.manager.task_group.create_task(self.downloader.run(media_item))
+            return
 
-        self.manager.task_group.create_task(task)
+        self.manager.task_group.create_task(self.downloader.download_hls(media_item, m3u8_content))
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -201,8 +201,9 @@ class ClientManager:
 
         check_etag()
         if HTTPStatus.OK <= status < HTTPStatus.BAD_REQUEST:
-            # check DDosGuard even on successful pages
-            return await check_ddos_guard()
+            # We need to check DDosGuard even on successful pages, but it was causing the response content to be empty
+            # await check_ddos_guard()
+            return
 
         await check_json_status()
         await check_ddos_guard()

--- a/cyberdrop_dl/utils/data_enums_classes/url_objects.py
+++ b/cyberdrop_dl/utils/data_enums_classes/url_objects.py
@@ -57,7 +57,7 @@ class MediaItem:
     current_attempt: int = field(default=0, init=False, hash=False, compare=False)
     partial_file: Path | None = field(default=None, init=False)
     complete_file: Path = field(default=None, init=False)  # type: ignore
-    task_id: TaskID | None = field(default=None, init=False, hash=False, compare=False)
+    task_id: TaskID = field(init=False, hash=False, compare=False)
     hash: str | None = field(default=None, init=False, hash=False, compare=False)
     downloaded: bool = field(default=False, init=False, hash=False, compare=False)
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -78,7 +78,7 @@ def error_handling_wrapper(func: Callable) -> Callable:
             exc_info = e
             error_log_msg = ErrorLogMessage.from_unknown_exc(e)
 
-        if getattr(item, "is_segment", False):
+        if (skip := getattr(item, "is_segment", None)) and skip is not None:
             return
 
         link_to_show = link_to_show or link


### PR DESCRIPTION
## Context

The bug was introduced by 03407c3623c23b41a42bba85219d3e89090f7113 in here:

https://github.com/jbsparrow/CyberDropDownloader/blob/03407c3623c23b41a42bba85219d3e89090f7113/cyberdrop_dl/managers/client_manager.py#L203-L205

To check `DDos-Guard` errors, we need to create a soup, which means we need to await the response's `read()` method to get the content.

However, we do not keep a reference to that soup. If the check was successful (no `DDoS-Guard` detected), we create a new soup inside `ScrapeClient`,  which requires awaiting `read()` again.

Calling `read()` multiple times on a `CachedResponse` will silently return nothing after the first call. This is an upstream issue in `aiohttp_client_cache`. They fixed it a long time ago (2024-11-07) but the fix was not included until version v13.0, which was released just few days ago (2025-04-08).

## Solution

Instead of bumping the minimum version, i reverted back to the old behavior (not checking successful responses) cause i don't have time to properly test it. We can bump the version in the next release.

See:
- https://github.com/requests-cache/aiohttp-client-cache/issues/289
- https://github.com/requests-cache/aiohttp-client-cache/pull/279
- [aiohttp_client_cache v13.0 changelog](https://github.com/requests-cache/aiohttp-client-cache/blob/3cb86ffb87f8ec89bc9428635ee65ec1b98e6758/HISTORY.md#0130-2025-04-08)

## Additional Changes
I also moved the `missav` crawler to `DEBUG_CRAWLERS` because the database entries will be a mess until #857 is merged and we won't be able to fix it afterwards. We can re-enable it in the next release.

