### PR TITLE
refactor: mock manager

### DIFF
--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -331,14 +331,12 @@ def show_supported_sites():
     from rich import print
     from rich.table import Table
 
-    from cyberdrop_dl.managers.mock_manager import MockManager
-    from cyberdrop_dl.scraper import scrape_mapper
+    from cyberdrop_dl.scraper.scrape_mapper import gen_crawlers_info
 
-    crawlers = scrape_mapper.gen_crawlers_info(scrape_mapper.get_crawlers(MockManager()))
     table = Table(title="Cyberdrop-DL Supported Sites")
     for column in ("Site", "Crawler", "Primary Base Domain"):
         table.add_column(column, no_wrap=True)
-    for crawler in crawlers:
+    for crawler in gen_crawlers_info():
         table.add_row(crawler.site, crawler.name, str(crawler.primary_base_domain))
     print(table)
     sys.exit(0)

--- a/cyberdrop_dl/managers/mock_manager.py
+++ b/cyberdrop_dl/managers/mock_manager.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-root_manager = None
+MOCK_MANAGER = None
 
 
 class Mock(Any):
@@ -9,8 +9,8 @@ class Mock(Any):
         self._mock_name = name
 
     def __getattribute__(self, name: str) -> Any:
-        if name == "manager" and root_manager is not None:
-            return root_manager
+        if name == "manager" and MOCK_MANAGER is not None:
+            return MOCK_MANAGER
         try:
             return super().__getattribute__(name)
         except AttributeError:
@@ -34,8 +34,11 @@ class MockCacheManager(Mock):
 
 class MockManager(Mock):
     def __init__(self):
-        global root_manager
-        assert root_manager is None, "A global MockManager already exists. Only 1 should be created"
+        global MOCK_MANAGER
+        assert MOCK_MANAGER is None, "A global MockManager already exists. Only 1 should be created"
         super().__init__("manager")
         self.cache_manager = MockCacheManager()
-        root_manager = self
+        MOCK_MANAGER = self
+
+
+MOCK_MANAGER = MockManager()

--- a/cyberdrop_dl/managers/mock_manager.py
+++ b/cyberdrop_dl/managers/mock_manager.py
@@ -1,14 +1,27 @@
+from __future__ import annotations
+
 from typing import Any
 
 MOCK_MANAGER = None
 
 
+class MockCallable:
+    def __init__(self, return_obj: Any = None) -> None:
+        self.return_obj = return_obj
+
+    def __getitem__(self, parameters: Any) -> object: ...
+    def __or__(self, other: Any) -> MockCallable: ...
+    def __ror__(self, other: Any) -> MockCallable: ...
+    def __call__(self, *args, **kwargs):
+        return self.return_obj
+
+
 class Mock(Any):
-    def __init__(self, name: str):
+    def __init__(self, name: str, /) -> None:
         self._nested_attrs: dict[str, Mock] = {}
         self._mock_name = name
 
-    def __getattribute__(self, name: str) -> Any:
+    def __getattribute__(self, name: str, /) -> Any:
         if name == "manager" and MOCK_MANAGER is not None:
             return MOCK_MANAGER
         try:
@@ -18,18 +31,11 @@ class Mock(Any):
                 raise  # Avoid infinite recursion
             return self._nested_attrs.get(name, Mock(name))
 
-    def __call__(self, *_, **__):
-        return self
-
 
 class MockCacheManager(Mock):
-    def __init__(self):
+    def __init__(self) -> None:
+        self.get = self.save = MockCallable()
         super().__init__("cache_manager")
-
-    def __getattribute__(self, name: str):
-        if name in ("get", "save"):
-            return lambda _: None
-        return super().__getattribute__(name)
 
 
 class MockManager(Mock):

--- a/cyberdrop_dl/managers/mock_manager.py
+++ b/cyberdrop_dl/managers/mock_manager.py
@@ -23,18 +23,19 @@ class Mock(Any):
 
 
 class MockCacheManager(Mock):
-    def __getattribute__(self, name: str):
-        if name == "get":
-            return self.get
-        return super().__getattribute__(name)
+    def __init__(self):
+        super().__init__("cache_manager")
 
-    def get(self, _: str = "") -> None:
-        return None
+    def __getattribute__(self, name: str):
+        if name in ("get", "save"):
+            return lambda _: None
+        return super().__getattribute__(name)
 
 
 class MockManager(Mock):
     def __init__(self):
         global root_manager
+        assert root_manager is None, "A global MockManager already exists. Only 1 should be created"
         super().__init__("manager")
-        self.cache_manager = MockCacheManager
+        self.cache_manager = MockCacheManager()
         root_manager = self

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -333,10 +333,16 @@ def create_item_from_entry(entry: Sequence) -> ScrapeItem:
     return item
 
 
-def get_crawlers(manager: Manager) -> dict[str, Crawler]:
-    """Retuns a mapping with an instance of all scrapers.
+def get_crawlers(manager: Manager | None = None) -> dict[str, Crawler]:
+    """Retuns a mapping with an instance of all crawlers.
 
-    Crawlers are only created on the first calls. Future calls always return a reference to the same crawlers"""
+    Crawlers are only created on the first calls. Future calls always return a reference to the same crawlers
+
+    If manager is `None`, the `MOCK_MANAGER` will be used, which means the crawlers won't be able to actually run"""
+
+    from cyberdrop_dl.managers.mock_manager import MOCK_MANAGER
+
+    manager = manager or MOCK_MANAGER
     global existing_crawlers
     if not existing_crawlers:
         for crawler in CRAWLERS:
@@ -355,14 +361,16 @@ def get_crawlers(manager: Manager) -> dict[str, Crawler]:
     return existing_crawlers
 
 
-def gen_crawlers_info(crawlers: dict[str, Crawler]):
+def gen_crawlers_info():
+    """Yields information about every crawler as a NamedTuple"""
+
     class CrawlerInfo(NamedTuple):
         site: str
         name: str
         primary_base_domain: URL
         crawler: Crawler
 
-    for name, crawler in sorted(crawlers.items()):
+    for name, crawler in sorted(get_crawlers().items()):
         if name == ".":
             continue
         yield CrawlerInfo(name, type(crawler).__name__.removesuffix("Crawler"), crawler.primary_base_domain, crawler)


### PR DESCRIPTION
- Generalize `MockManager` so we can use it for other simulated functions in future
- Simplify some functions calls
- Make sure only 1 instance of a `MockManager` is ever created