### PR TITLE
fix: media_item task removal

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -216,14 +216,18 @@ class DownloadClient:
                 log(msg, 30)
                 media_item.datetime = last_modified
 
-            media_item.task_id = self.manager.progress_manager.file_progress.add_task(
-                domain=domain,
-                filename=media_item.filename,
-                expected_size=media_item.filesize + resume_point,
-            )
+            task_id = media_item.task_id
+            if task_id is None:
+                task_id = self.manager.progress_manager.file_progress.add_task(
+                    domain=domain,
+                    filename=media_item.filename,
+                    expected_size=media_item.filesize + resume_point,
+                )
+                media_item.set_task_id(task_id)
+
             if media_item.partial_file.is_file():
                 resume_point = media_item.partial_file.stat().st_size
-                self.manager.progress_manager.file_progress.advance_file(media_item.task_id, resume_point)
+                self.manager.progress_manager.file_progress.advance_file(task_id, resume_point)
 
             await save_content(resp.content)
             return True

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import re
 from dataclasses import field
 from functools import wraps
@@ -233,9 +232,12 @@ class Downloader:
     def attempt_task_removal(self, media_item: MediaItem) -> None:
         """Attempts to remove the task from the progress bar."""
         if media_item.task_id is not None:
-            with contextlib.suppress(ValueError):
+            try:
                 self.manager.progress_manager.file_progress.remove_task(media_item.task_id)
-        media_item.task_id = None
+            except ValueError:
+                pass
+
+            media_item.set_task_id(None)
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 


### PR DESCRIPTION
`task_id` has to always be an int at runtime after a8d7dc1a8625bbfb5d5b4bee0ef7636163a945bd

Also added a reference to a possible parent `media_item` to use the same `task_id` across multiple items (related to #857)