### PR TITLE
feat: add support for fallback URLs

### DIFF
--- a/cyberdrop_dl/utils/data_enums_classes/url_objects.py
+++ b/cyberdrop_dl/utils/data_enums_classes/url_objects.py
@@ -14,6 +14,8 @@ from cyberdrop_dl.clients.errors import MaxChildrenError
 from cyberdrop_dl.utils.utilities import sanitize_folder
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rich.progress import TaskID
 
     from cyberdrop_dl.managers.manager import Manager
@@ -49,6 +51,7 @@ class MediaItem:
     duration: float | None = field(default=None, hash=False, compare=False)
     ext: str = ""
     is_segment: bool = False
+    fallbacks: Callable[..., URL] | list[URL] | None = field(default=None, hash=False, compare=False)
 
     # exclude from __init__
     file_lock_reference_name: str | None = field(default=None, init=False)


### PR DESCRIPTION
Crawlers can pass an optinal fallback parameter to `handle_file`.  Fallback can be a list of URLs or a funtion that takes the response and the current retry as a parameter and returns a new URL.

If fallback if a function, the Funtion will be called indefinitely after every retry until it returns `None`