### PR TITLE
Fix crash when default Notepad is missing on Windows

### DIFF
--- a/cyberdrop_dl/crawlers/thisvid.py
+++ b/cyberdrop_dl/crawlers/thisvid.py
@@ -134,13 +134,14 @@ class ThisVidCrawler(Crawler):
 
 
 def get_video_info(flashvars: str) -> Video:
-    if (match_id := VIDEO_INFO_PATTTERN.search(flashvars)) and (
-        match_res := VIDEO_RESOLUTION_PATTERN.search(flashvars)
-    ):
-        id, license_code, url = match_id.groups()
+    if match_id := VIDEO_INFO_PATTTERN.search(flashvars):
+        video_id, license_code, url = match_id.groups()
         real_url = kvs_get_real_url(url, license_code)
-        resolution = match_res.group(1)
-        return Video(id, real_url, resolution)
+        if match_res := VIDEO_RESOLUTION_PATTERN.search(flashvars):
+            resolution = match_res.group(1)
+        else:
+            resolution = "Unknown"
+        return Video(video_id, real_url, resolution)
     raise ScrapeError(404)
 
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -387,7 +387,7 @@ def open_in_text_editor(file_path: Path) -> None:
         if platform.system() == "windows":
             error_msg += (
                 "Please install one of the following editors or add it to your PATH:\n"
-                "Notepad / Notepad++ / VSCode / Sublime Text / Atom."
+                "Notepad / Notepad++ / VSCode / Sublime Text."
             )
         error_msg += "\nYou can set the env var $EDITOR to point to your preferred editor."
         raise ValueError(error_msg)

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -359,7 +359,12 @@ def open_in_text_editor(file_path: Path) -> bool | None:
         cmd = "open", "-a", "TextEdit", file_path
 
     elif platform.system() == "Windows":
-        cmd = "notepad.exe", file_path
+        try:
+            os.startfile(file_path)
+        except OSError:
+            cmd = ("cmd", "/c", "start", "", str(file_path))
+        else:
+            return True
 
     elif using_desktop_enviroment and not using_ssh and set_default_app_if_none(file_path):
         cmd = "xdg-open", file_path


### PR DESCRIPTION
I noticed that on Windows, if Notepad.exe is uninstalled (or you’ve reassigned the `.txt` file association to another editor), running the `.bat` file and selecting **Edit URLs.txt** causes a `FileNotFoundError`.
I’ve attached log here: [startup.log](https://github.com/user-attachments/files/19924675/startup.log)

Currently, even when a user has chosen a different default program for `.txt` files, the script still invokes `notepad.exe` and fails if it’s missing.

Since the fix was straightforward, I didn’t file a separate issue and instead opened this pull request directly. I hope that’s okay?
Thanks!