### PR TITLE
perf: make setting file dates async

### DIFF
--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -38,7 +38,7 @@ if sys.platform == "win32":
 
 elif sys.platform == "darwin":
     # SetFile is non standard in macOS. Only users that have xcode installed will have SetFile
-    MAC_OS_SET_FILE = shutil.which("SetFile") or None
+    MAC_OS_SET_FILE = shutil.which("SetFile")
 
 
 if TYPE_CHECKING:
@@ -256,23 +256,22 @@ class Downloader:
                     # Windows dates are 64bits, split into 2 32bits unsigned ints (dwHighDateTime , dwLowDateTime)
                     # XOR to get the date as bytes, then shift to get the first 32 bits (dwHighDateTime)
                     ctime = wintypes.FILETIME(timestamp & 0xFFFFFFFF, timestamp >> 32)
-                    access_mode = win32con.GENERIC_WRITE
-                    sharing_mode = win32con.FILE_SHARE_READ | win32con.FILE_SHARE_WRITE | win32con.FILE_SHARE_DELETE
+                    access_mode = 256  # FILE_WRITE_ATTRIBUTES
+                    sharing_mode = 0  # Exclusive access
                     security_mode = None  # Use default security attributes
                     creation_disposition = win32con.OPEN_EXISTING
-                    flags = (
-                        win32con.FILE_ATTRIBUTE_NORMAL,
-                        win32con.FILE_FLAG_BACKUP_SEMANTICS,  # (allows folder access)
-                    )
-                    temp_file = None
+
+                    # FILE_FLAG_BACKUP_SEMANTICS allows access to directories
+                    flags = win32con.FILE_ATTRIBUTE_NORMAL | win32con.FILE_FLAG_BACKUP_SEMANTICS
+                    template_file = None
 
                     params = (
                         access_mode,
                         sharing_mode,
                         security_mode,
                         creation_disposition,
-                        flags[0] | flags[1],
-                        temp_file,
+                        flags,
+                        template_file,
                     )
 
                     handle = windll.kernel32.CreateFileW(complete_file, *params)

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -289,9 +289,10 @@ class Downloader:
             elif sys.platform == "darwin" and MAC_OS_SET_FILE:
                 date_string = datetime.fromtimestamp(media_item.datetime).strftime("%m/%d/%Y %H:%M:%S")
                 cmd = ["-d", date_string, complete_file]
-                await asyncio.subprocess.create_subprocess_exec(
+                process = await asyncio.subprocess.create_subprocess_exec(
                     MAC_OS_SET_FILE, *cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
                 )
+                _ = await process.wait()
 
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError, ValueError):
             pass

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -32,9 +32,9 @@ WIN_EPOCH_OFFSET = 116444736e9
 MAC_OS_SET_FILE = None
 
 if sys.platform == "win32":
-    from ctypes import byref, win32con, windll, wintypes
+    from ctypes import byref, windll, wintypes
 
-    # Offset for file datetimes.
+    import win32con
 
 elif sys.platform == "darwin":
     # SetFile is non standard in macOS. Only users that have xcode installed will have SetFile
@@ -254,7 +254,7 @@ class Downloader:
                     timestamp = int(nano_ts + WIN_EPOCH_OFFSET)
 
                     # Windows dates are 64bits, split into 2 32bits unsigned ints (dwHighDateTime , dwLowDateTime)
-                    # XOR to get the date as bytes, then shift to get the last 32 bits (dwLowDateTime)
+                    # XOR to get the date as bytes, then shift to get the first 32 bits (dwHighDateTime)
                     ctime = wintypes.FILETIME(timestamp & 0xFFFFFFFF, timestamp >> 32)
                     access_mode = win32con.GENERIC_WRITE
                     sharing_mode = win32con.FILE_SHARE_READ | win32con.FILE_SHARE_WRITE | win32con.FILE_SHARE_DELETE
@@ -278,7 +278,7 @@ class Downloader:
                     handle = windll.kernel32.CreateFileW(complete_file, *params)
                     windll.kernel32.SetFileTime(
                         handle,
-                        byref(ctime),  # Creation time, byref to make it relative to the current dwHighDateTime
+                        byref(ctime),  # Creation time
                         None,  # Access time
                         None,  # Modification time
                     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -732,20 +732,6 @@ files = [
 ]
 
 [[package]]
-name = "filedate"
-version = "3.0"
-description = ""
-optional = false
-python-versions = ">=3.4"
-groups = ["main"]
-files = [
-    {file = "filedate-3.0-py3-none-any.whl", hash = "sha256:10af3be124bc17c041a4fb0381f7ab6761384be8f455e785936c9a8cf614dedb"},
-]
-
-[package.dependencies]
-python-dateutil = "*"
-
-[[package]]
 name = "filelock"
 version = "3.18.0"
 description = "A platform independent file lock."
@@ -2675,4 +2661,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4"
-content-hash = "9c656f1b51a3b5d438450245fc66a62151c013a48a936eb35485f776e16b9cfd"
+content-hash = "a47a76bece39df8b7fbf7c9fc53421daee7155ba89b2aec16a6ce3fe6495b339"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "browser-cookie3 (>=0.20.1,<0.21.0)",
     "certifi (>=2025.1.31,<2026.0.0)",
     "curl-cffi (>=0.9.0,<0.10.0)",
-    "filedate (>=3.0,<4.0)",
     "get-video-properties (>=0.1.1,<0.2.0)",
     "inquirerpy (>=0.3.4,<0.4.0)",
     "mediafire (>=0.6.1,<0.7.0)",


### PR DESCRIPTION
- Make updating files' dates non blocking.
- Remove `filedate` dependency. We only used it for this.
- Try to set "Creation time" in MacOS