### PR TITLE
feat: make filename sanitize function OS specific

### DIFF
--- a/cyberdrop_dl/clients/errors.py
+++ b/cyberdrop_dl/clients/errors.py
@@ -61,11 +61,14 @@ class InvalidContentTypeError(CDLBaseError):
         super().__init__(ui_failure, message=message, origin=origin)
 
 
-class NoExtensionError(CDLBaseError):
+class InvalidDownloadPathError(CDLBaseError): ...
+
+
+class NoExtensionError(InvalidDownloadPathError):
     def __init__(self, *, message: str | None = None, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
         """This error will be thrown when no extension is given for a file."""
-        ui_failure = "No File Extension"
-        super().__init__(ui_failure, message=message, origin=origin)
+        super().__init__(message=message, origin=origin)
+        self.ui_failure = "No File Extension"
 
 
 class InvalidExtensionError(NoExtensionError):

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -25,6 +25,8 @@ from cyberdrop_dl.utils.logger import log, log_spacer
 from cyberdrop_dl.utils.utilities import get_soup_from_response
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from aiohttp_client_cache import CachedResponse
     from curl_cffi.requests.models import Response as CurlResponse
 
@@ -210,7 +212,7 @@ class ClientManager:
         raise DownloadError(status=status, message=message, origin=origin)
 
     @staticmethod
-    def check_bunkr_maint(headers: dict):
+    def check_bunkr_maint(headers: Mapping[str, Any]) -> None:
         if headers.get("Content-Length") == "322509" and headers.get("Content-Type") == "video/mp4":
             raise DownloadError(status="Bunkr Maintenance", message="Bunkr under maintenance")
 

--- a/cyberdrop_dl/utils/data_enums_classes/url_objects.py
+++ b/cyberdrop_dl/utils/data_enums_classes/url_objects.py
@@ -57,9 +57,9 @@ class MediaItem:
     parent_media_item: MediaItem | None = field(init=False, default=None, hash=False, compare=False)
     file_lock_reference_name: str | None = field(default=None, init=False)
     download_filename: str | None = field(default=None, init=False)
-    filesize: int | None = field(default=None, init=False)
+    filesize: int = field(init=False)
     current_attempt: int = field(default=0, init=False, hash=False, compare=False)
-    partial_file: Path | None = field(default=None, init=False)
+    partial_file: Path = field(init=False)
     complete_file: Path = field(default=None, init=False)  # type: ignore
     hash: str | None = field(default=None, init=False, hash=False, compare=False)
     downloaded: bool = field(default=False, init=False, hash=False, compare=False)

--- a/cyberdrop_dl/utils/database/tables/history_table.py
+++ b/cyberdrop_dl/utils/database/tables/history_table.py
@@ -225,7 +225,7 @@ class HistoryTable:
         sql_file_check = await result.fetchone()
         return sql_file_check == 1
 
-    async def get_downloaded_filename(self, domain: str, media_item: MediaItem) -> str:
+    async def get_downloaded_filename(self, domain: str, media_item: MediaItem) -> str | None:
         """Returns the downloaded filename from the database."""
 
         url_path = get_db_path(media_item.url, str(media_item.referer))


### PR DESCRIPTION
- Make filename sanitize function OS specific
- Make downloader file system calls non blocking
- Add filesystem limits
- Supersedes and closes #671 

### TODO

- [ ] Automatically truncate filename to max supported length of the target filesystem
- [ ] Simplify `get_final_file_info`
- [ ] Call `get_final_file_info` as early as possible