### PR TITLE
Reduce the number of lines in auto import config

### DIFF
--- a/cyberdrop_dl/ui/prompts/user_prompts.py
+++ b/cyberdrop_dl/ui/prompts/user_prompts.py
@@ -200,6 +200,7 @@ def domains_prompt(*, domain_message: str = "Select site(s):") -> tuple[list[str
 def extract_cookies(manager: Manager, *, dry_run: bool = False) -> None:
     """Asks the user to select browser(s) and domains(s) to import cookies from."""
 
+    supported_forums, supported_websites = list(SUPPORTED_FORUMS.values()), list(SUPPORTED_WEBSITES.values())
     domains, all_domains = domains_prompt(domain_message="Select site(s) to import cookies from:")
     if domains == []:
         return
@@ -211,7 +212,22 @@ def extract_cookies(manager: Manager, *, dry_run: bool = False) -> None:
     if dry_run:
         manager.config_manager.settings_data.browser_cookies.browsers = browsers
         current_sites = set(manager.config_manager.settings_data.browser_cookies.sites)
-        new_sites = (current_sites - set(all_domains)) | set(domains)
+        new_sites = current_sites - set(all_domains)
+        if domains == supported_forums:
+            new_sites -= {"all"}
+            new_sites.add("all_forums")
+        elif domains == supported_websites:
+            new_sites -= {"all"}
+            new_sites.add("all_file_hosts")
+        elif domains == SUPPORTED_SITES_DOMAINS:
+            new_sites -= {"all_forums", "all_file_hosts"}
+            new_sites.add("all")
+        else:
+            new_sites -= {"all", "all_forums", "all_file_hosts"}
+            new_sites.update(domains)
+        if "all_forums" in new_sites and "all_file_hosts" in new_sites:
+            new_sites -= {"all_forums", "all_file_hosts"}
+            new_sites.add("all")
         manager.config_manager.settings_data.browser_cookies.sites = sorted(new_sites)
         return
 

--- a/cyberdrop_dl/utils/cookie_management.py
+++ b/cyberdrop_dl/utils/cookie_management.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:
     from cyberdrop_dl.constants import BROWSERS
     from cyberdrop_dl.managers.manager import Manager
 
+from cyberdrop_dl.data_structures.supported_domains import (
+    SUPPORTED_FORUMS,
+    SUPPORTED_SITES_DOMAINS,
+    SUPPORTED_WEBSITES,
+)
+
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -76,6 +82,15 @@ def get_cookies_from_browsers(
     browsers_to_extract_from = browsers or manager.config_manager.settings_data.browser_cookies.browsers
     extractors_to_use = list(map(str.lower, browsers_to_extract_from))
     domains_to_extract: list[str] = domains or manager.config_manager.settings_data.browser_cookies.sites
+    if "all" in domains_to_extract:
+        domains_to_extract.remove("all")
+        domains_to_extract.extend(SUPPORTED_SITES_DOMAINS)
+    elif "all_forums" in domains_to_extract:
+        domains_to_extract.remove("all_forums")
+        domains_to_extract.extend(SUPPORTED_FORUMS.values())
+    elif "all_file_hosts" in domains_to_extract:
+        domains_to_extract.remove("all_file_hosts")
+        domains_to_extract.extend(SUPPORTED_WEBSITES.values())
 
     def is_decrypt_error(msg: str) -> bool:
         return "Unable to get key for cookie decryption" in msg


### PR DESCRIPTION
Reduce the number of lines in users' configs when auto import is enabled by using names (`all`, `all_file_hosts`, and `all_forums`) to reference groups of domains.