### PR TITLE
fix: do not check DDoS-Guard on successful responses

### DIFF
--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -204,7 +204,7 @@ class ClientManager:
         check_etag()
         if HTTPStatus.OK <= status < HTTPStatus.BAD_REQUEST:
             # Check DDosGuard even on successful pages
-            await check_ddos_guard()
+            # await check_ddos_guard()
             return
 
         await check_json_status()


### PR DESCRIPTION
This is still broken even with the new aiohttpcache v13.0