### PR TITLE
refactor: show OS common name in logs

### DIFF
--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-import platform
 import sys
 from dataclasses import Field, field
 from time import perf_counter
@@ -28,6 +27,7 @@ from cyberdrop_dl.utils.args import ParsedArgs
 from cyberdrop_dl.utils.ffmpeg import FFmpeg, get_ffmpeg_version
 from cyberdrop_dl.utils.logger import QueuedLogger, log
 from cyberdrop_dl.utils.transfer import transfer_v5_db_to_v6
+from cyberdrop_dl.utils.utilities import get_system_information
 
 if TYPE_CHECKING:
     import queue
@@ -340,43 +340,7 @@ class Manager:
         constants.DISABLE_CACHE = self.parsed_args.cli_only_args.disable_cache
 
 
-def get_system_information() -> str:
-    system_info = platform.uname()._asdict() | {
-        "architecture": str(platform.architecture()),
-        "python": f"{platform.python_version()} {platform.python_implementation()}",
-        "common_name": get_os_common_name(),
-    }
-    return json.dumps(system_info, indent=4)
-
-
-def get_os_common_name() -> str:
-    system = platform.system()
-    if system in ("Linux",):
-        try:
-            distro = platform.freedesktop_os_release()
-        except OSError:
-            pass
-        else:
-            if distro_name := distro.get("PRETTY_NAME"):
-                return distro_name
-
-    if system == "Android" and sys.version_info >= (3, 13):
-        ver = platform.android_ver()
-        os_name = f"{system} {ver.release}"
-        for component in [ver.manufacturer, ver.model, ver.device]:
-            if component:
-                os_name += f" ({component})"
-        return os_name
-
-    default = platform.platform(aliased=True, terse=True).replace("-", " ")
-    if system == "Windows" and (edition := platform.win32_edition()):
-        return f"{default} {edition}"
-    return default
-
-
 def show_supported_sites():
-    import sys
-
     from rich import print
     from rich.table import Table
 

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -8,6 +8,7 @@ import platform
 import re
 import shutil
 import subprocess
+import sys
 import unicodedata
 from dataclasses import dataclass, fields
 from functools import lru_cache, partial, wraps
@@ -530,6 +531,40 @@ def get_size_or_none(path: Path) -> int | None:
             return stat.st_size
     except (OSError, ValueError):
         return None
+
+
+@lru_cache
+def get_system_information() -> str:
+    system_info = platform.uname()._asdict() | {
+        "architecture": str(platform.architecture()),
+        "python": f"{platform.python_version()} {platform.python_implementation()}",
+        "common_name": get_os_common_name(),
+    }
+    return json.dumps(system_info, indent=4)
+
+
+@lru_cache
+def get_os_common_name() -> str:
+    system = platform.system()
+
+    if system in ("Linux",):
+        try:
+            return platform.freedesktop_os_release()["PRETTY_NAME"]
+        except OSError:
+            pass
+
+    if system == "Android" and sys.version_info >= (3, 13):
+        ver = platform.android_ver()
+        os_name = f"{system} {ver.release}"
+        for component in (ver.manufacturer, ver.model, ver.device):
+            if component:
+                os_name += f" ({component})"
+        return os_name
+
+    default = platform.platform(aliased=True, terse=True).replace("-", " ")
+    if system == "Windows" and (edition := platform.win32_edition()):
+        return f"{default} {edition}"
+    return default
 
 
 log_cyan = partial(log_with_color, style="cyan", level=20)


### PR DESCRIPTION
Will show up as "Fedora Linux 42 (KDE)", "Windows 10 Home" or "macOS 14.0.5" in logs