### PR TITLE
feat: Dockerize application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+.venv/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Other
+.vscode/
+.idea/
+*.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Use an official Python 3.11 image.
+FROM python:3.11-slim
+
+# Set environment variables
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    POETRY_VERSION=1.8.3 \
+    POETRY_HOME="/opt/poetry" \
+    POETRY_VENV_CREATE=false \
+    PATH="/opt/poetry/bin:$PATH"
+
+# Install poetry
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -sSL https://install.python-poetry.org | python3 - && \
+    apt-get remove -y curl && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the project files for dependency installation
+COPY pyproject.toml poetry.lock* /app/
+
+# Install project dependencies
+RUN poetry install --no-dev --no-root --no-interaction --no-ansi
+
+# Copy the rest of the application code
+COPY . /app/
+
+# Set the entrypoint
+ENTRYPOINT ["cyberdrop-dl"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,46 @@ See the [list of supported sites](https://script-ware.gitbook.io/cyberdrop-dl/re
 
 Follow the [getting-started guide](https://script-ware.gitbook.io/cyberdrop-dl/getting-started) for instructions on how to install and configure Cyberdrop-DL
 
+## Docker
+
+You can also build and run `cyberdrop-dl` using Docker.
+
+### Building the Image
+
+To build the Docker image, navigate to the root directory of the project (where the `Dockerfile` is located) and run:
+
+```bash
+docker build -t cyberdrop-dl .
+```
+
+### Running the Container
+
+Once the image is built, you can run `cyberdrop-dl` in a container.
+You'll likely want to mount volumes for configuration and downloads.
+
+**Example:**
+
+To run the container and mount a local directory `./data` to `/app/downloads` inside the container, and a local `./config` to `/app/config` for configuration persistence:
+
+```bash
+docker run -it --rm \
+  -v ./data:/app/downloads \
+  -v ./config:/app/config \
+  cyberdrop-dl [cyberdrop-dl arguments]
+```
+
+Replace `[cyberdrop-dl arguments]` with any arguments you would normally pass to the `cyberdrop-dl` command-line tool.
+
+For example, to download files from a URL and save them to the mounted `downloads` directory:
+```bash
+docker run -it --rm \
+  -v ./data:/app/downloads \
+  -v ./config:/app/config \
+  cyberdrop-dl --url https://some-url.com/album
+```
+
+Refer to the [CLI arguments documentation](https://script-ware.gitbook.io/cyberdrop-dl/reference/cli-arguments) for available options.
+The application inside the container will look for its configuration in `/app/config`. Make sure to place your `config.yml` (or other configuration files) in the local directory you mount to `/app/config`.
 
 ## Contributing
 If there is a feature you want, you've discovered a bug, or if you have other general feedback, please create an issue for it!


### PR DESCRIPTION
Adds a Dockerfile to containerize the cyberdrop-dl application.

The Dockerfile uses a multi-stage build to keep the final image slim. It installs Poetry and then uses it to install project dependencies.

A .dockerignore file is included to exclude unnecessary files from the Docker build context.

The README.md has been updated with instructions on how to build the Docker image and run the application in a container, including examples for mounting volumes for data and configuration.