### PR TITLE
fix: bunkr.si wasn't being scraped

### DIFF
--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -130,7 +130,7 @@ class BunkrrCrawler(Crawler):
     }
     DATABASE_PRIMARY_HOST: ClassVar[str] = "bunkr.site"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL(f"https://{DATABASE_PRIMARY_HOST}")
-    DOMAIN: ClassVar[str] = "bunkrr"
+    DOMAIN: ClassVar[str] = "bunkr"
 
     def __post_init__(self) -> None:
         self.known_good_host: str = ""


### PR DESCRIPTION
It was looking for the key "bunkrr" in the host bunkr.si or any other bunkr host with one single "r"  here:
`async def send_to_crawler(self, scrape_item: ScrapeItem) -> None:
        """Maps URLs to their respective handlers."""
        scrape_item.url = remove_trailing_slash(scrape_item.url)
        supported_domain = [key for key in self.existing_crawlers if key in scrape_item.url.host]`