### PR TITLE
refactor: use aiohttp to get filename from headers

### DIFF
--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -354,7 +354,7 @@ class ScraperClient:
         return BeautifulSoup(content, "html.parser")
 
     @limiter
-    async def get_head(
+    async def _get_head(
         self,
         domain: str,
         url: URL,
@@ -362,7 +362,7 @@ class ScraperClient:
         request_params: dict[str, Any] | None = None,
         *,
         cache_disabled: bool = False,
-    ) -> CIMultiDictProxy[str]:
+    ) -> aiohttp.ClientResponse:
         """
         Makes a GET request to an URL and returns its headers
 
@@ -377,6 +377,11 @@ class ScraperClient:
         async with cache_control_manager(self._session, disabled=cache_disabled):
             response = await self._session.head(url, headers=headers, **request_params)
         await self.client_manager.check_http_status(response)
+        return response
+
+    @copy_signature(_get_head)
+    async def get_head(self, *args: Any, **kwargs: Any) -> CIMultiDictProxy[str]:
+        response = await self._get_head(*args, **kwargs)
         return response.headers
 
     async def write_soup_to_disk(

--- a/cyberdrop_dl/crawlers/buzzheavier.py
+++ b/cyberdrop_dl/crawlers/buzzheavier.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.types import AbsoluteHttpURL, SupportedPaths
-from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_from_headers
+from cyberdrop_dl.utils.utilities import error_handling_wrapper
 
 if TYPE_CHECKING:
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
@@ -29,11 +29,10 @@ class BuzzHeavierCrawler(Crawler):
         url = scrape_item.url / "download"
         headers = {"HX-Current-URL": str(scrape_item.url), "HX-Request": "true"}
         async with self.request_limiter:
-            headers = await self.client.get_head(self.DOMAIN, url, headers=headers)
-            redirect = headers["hx-redirect"]
-            filename = get_filename_from_headers(headers)
+            response = await self.client._get_head(self.DOMAIN, url, headers=headers)
 
-        assert filename
-        link = self.parse_url(redirect)
-        filename, ext = self.get_filename_and_ext(filename, assume_ext=".zip")
+        assert response.content_disposition
+        assert response.content_disposition.filename
+        link = self.parse_url(response.headers["hx-redirect"])
+        filename, ext = self.get_filename_and_ext(response.content_disposition.filename, assume_ext=".zip")
         await self.handle_file(scrape_item.url, scrape_item, filename, ext, debrid_link=link)

--- a/cyberdrop_dl/crawlers/dropbox.py
+++ b/cyberdrop_dl/crawlers/dropbox.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.types import AbsoluteHttpURL, SupportedPaths
-from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_from_headers
+from cyberdrop_dl.utils.utilities import error_handling_wrapper
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -69,10 +69,9 @@ class DropboxCrawler(Crawler):
     async def get_folder_name(self, url: URL) -> str | None:
         url = await self.get_redict_url(url)
         async with self.request_limiter:
-            headers = await self.client.get_head(self.DOMAIN, url)
-        if not ("Content-Disposition" in headers and not is_html(headers)):
-            raise ScrapeError(422)
-        return get_filename_from_headers(headers)
+            response = await self.client._get_head(self.DOMAIN, url)
+        if response.content_disposition:
+            return response.content_disposition.filename
 
     async def get_redict_url(self, url: URL) -> AbsoluteHttpURL:
         async with self.request_limiter:

--- a/cyberdrop_dl/crawlers/google_drive.py
+++ b/cyberdrop_dl/crawlers/google_drive.py
@@ -41,7 +41,7 @@ from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.exceptions import DownloadError, ScrapeError
 from cyberdrop_dl.types import AbsoluteHttpURL, SupportedDomains, SupportedPaths
 from cyberdrop_dl.utils import css
-from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_from_headers
+from cyberdrop_dl.utils.utilities import error_handling_wrapper
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -139,31 +139,25 @@ class GoogleDriveCrawler(Crawler):
         if await self.check_complete_from_referer(canonical_url):
             return
 
-        download_url = get_download_url(file_id)
-        link, headers = await self.get_file_url_and_headers(download_url, file_id)
         scrape_item.url = canonical_url
-
-        filename = get_filename_from_headers(headers) or link.name
-        filename, ext = self.get_filename_and_ext(filename)
+        download_url = get_download_url(file_id)
+        link, filename = await self.get_file_url_and_name(download_url, file_id)
+        filename, ext = self.get_filename_and_ext(filename or link.name)
         await self.handle_file(canonical_url, scrape_item, filename, ext, debrid_link=link)
 
-    async def get_file_url_and_headers(
-        self, url: AbsoluteHttpURL, file_id: str
-    ) -> tuple[AbsoluteHttpURL, Mapping[str, str]]:
+    async def get_file_url_and_name(self, url: AbsoluteHttpURL, file_id: str) -> tuple[AbsoluteHttpURL, str | None]:
         soup = last_error = None
         current_url: AbsoluteHttpURL | None = url
         try_file_open_url = True
 
-        headers = {}
         while current_url:
-            current_url, headers = await self.add_headers(current_url)
-            if are_valid_headers(headers):
-                return current_url, headers
+            current_url, filename = await self.add_filename(current_url)
+            if filename:
+                return current_url, filename
 
             try:
                 async with self.request_limiter:
                     response, soup = await self.client._get_response_and_soup(self.DOMAIN, current_url)
-                    headers = response.headers
 
             except DownloadError as e:
                 last_error = e
@@ -179,24 +173,27 @@ class GoogleDriveCrawler(Crawler):
                 current_url = docs_url
                 continue
 
-            if are_valid_headers(headers):
-                return current_url, headers
+            if response.content_disposition and response.content_disposition.filename:
+                return current_url, response.content_disposition.filename
 
             current_url = self.get_url_from_download_button(soup)
             if not current_url:
                 break
-            return await self.add_headers(current_url)
+
+            return await self.add_filename(current_url)
 
         raise ScrapeError(422)
 
-    async def add_headers(self, url: AbsoluteHttpURL) -> tuple[AbsoluteHttpURL, Mapping[str, str]]:
+    async def add_filename(self, url: AbsoluteHttpURL) -> tuple[AbsoluteHttpURL, str | None]:
         async with self.request_limiter:
-            headers = await self.client.get_head(self.DOMAIN, url)
-        location = headers.get("location")
+            response = await self.client._get_head(self.DOMAIN, url)
+        location = response.headers.get("location")
         if location:
             link = self.parse_url(location)
-            return await self.add_headers(link)
-        return url, headers
+            return await self.add_filename(link)
+        if response.content_disposition and response.content_disposition.filename:
+            return url, response.content_disposition.filename
+        return url, None
 
     def get_url_from_download_button(self, soup: BeautifulSoup) -> AbsoluteHttpURL | None:
         form = soup.select_one("#download-form")

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -54,7 +54,6 @@ R = TypeVar("R")
 
 
 TEXT_EDITORS = "micro", "nano", "vim"  # Ordered by preference
-FILENAME_REGEX = re.compile(r"filename\*=UTF-8''(.+)|.*filename=\"(.*?)\"", re.IGNORECASE)
 ALLOWED_FILEPATH_PUNCTUATION = " .-_!#$%'()+,;=@[]^{}~"
 subprocess_get_text = partial(subprocess.run, capture_output=True, text=True, check=False)
 
@@ -522,16 +521,6 @@ def get_og_properties(soup: BeautifulSoup) -> OGProperties:
         og_properties[property_name] = meta["content"] or ""  # type: ignore
 
     return OGProperties(**og_properties)
-
-
-def get_filename_from_headers(headers: Mapping[str, Any]) -> str | None:
-    """Get `filename=` value from `Content-Disposition`"""
-    content_disposition: str | None = headers.get("Content-Disposition")
-    if not content_disposition:
-        return
-    if match := re.search(FILENAME_REGEX, content_disposition):
-        matches = match.groups()
-        return matches[0] or matches[1]
 
 
 def get_size_or_none(path: Path) -> int | None:


### PR DESCRIPTION
Regex sometimes fails. `aiohttp` uses actual logic to parse it