### PR TITLE
fix: exclude real-debrid from base crawler's  validation

### DIFF
--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -128,7 +128,7 @@ class Crawler(ABC):
         if is_abc:
             return
 
-        if cls.DOMAIN != "generic":
+        if cls.DOMAIN not in ("generic", "real-debrid"):
             REQUIRED_FIELDS = "PRIMARY_URL", "DOMAIN", "SUPPORTED_PATHS"
             for field_name in REQUIRED_FIELDS:
                 assert getattr(cls, field_name, None), f"Subclass {cls.__name__} must override: {field_name}"

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -73,8 +73,8 @@ class ScrapeMapper:
         if self.manager.real_debrid_manager.enabled:
             from cyberdrop_dl.crawlers.realdebrid import RealDebridCrawler
 
-            self.existing_crawlers["real-debrid"] = RealDebridCrawler(self.manager)
-            await self.existing_crawlers["real-debrid"].startup()
+            self.existing_crawlers["real-debrid"] = real = RealDebridCrawler(self.manager)
+            await real.startup()
 
     async def start(self) -> None:
         """Starts the orchestra."""


### PR DESCRIPTION
Real-debrid does not define any concrete supported path.

Fixes startup error: `AssertionError: Subclass RealDebridCrawler must override: SUPPORTED_PATHS`