### PR TITLE
misc: allow folders as input (filter_logs)

### DIFF
--- a/scripts/tools/filter_logs.py
+++ b/scripts/tools/filter_logs.py
@@ -5,6 +5,7 @@
 # ]
 # ///
 import argparse
+from collections.abc import Iterable
 from pathlib import Path
 
 from alive_progress import alive_it  # type: ignore
@@ -12,28 +13,35 @@ from alive_progress import alive_it  # type: ignore
 LEVELS_TO_INCLUDE = {"WARNING", "ERROR", "CRITICAL"}
 
 
-def filter_log_file(log_file: Path, output_file: Path) -> None:
+def filter_log_file(log_file: Path) -> Iterable[str]:
     print(f"Filtering: {log_file.resolve()}")  # noqa: T201
     log_content = log_file.read_text(encoding="utf8")
-    log_lines = log_content.splitlines()
-    lines_to_keep = []
     last_level = None
-    for line in alive_it(log_lines):
+    for line in alive_it(log_content.splitlines()):
         level = line[20:29].strip()
         if level:
             last_level = level
             if level in LEVELS_TO_INCLUDE:
-                lines_to_keep.append(line)
+                yield line
         elif last_level in LEVELS_TO_INCLUDE:
-            lines_to_keep.append(line)
-
-    output_file.unlink(missing_ok=True)
-    output_file.write_text("\n".join(lines_to_keep), encoding="utf-8")
+            yield line
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Filter a log file, keeping WARNING, ERROR and CRITICAL log messages")
-    parser.add_argument("input_file", help="Path to the input log file", type=Path)
-    parser.add_argument("output_file", help="Path to the output log file", type=Path)
+    parser.add_argument("input", help="Path to the input log file/folder", type=Path)
+    parser.add_argument("output", help="Path to the output log file", type=Path)
     args = parser.parse_args()
-    filter_log_file(args.input_file, args.output_file)
+    input_: Path = args.input
+    output: Path = args.output
+    if input_.is_dir():
+        files = (file for file in input_.iterdir() if file.suffix == ".log")
+    elif input_.is_file():
+        files = (input_,)
+    else:
+        raise FileNotFoundError(input_)
+
+    lines = ("\n".join(filter_log_file(file)) for file in files)
+    content = "\n".join(lines)
+    output.unlink(missing_ok=True)
+    output.write_text(content, encoding="utf-8")


### PR DESCRIPTION
It will filter all the `.log` files in the folder and create a single output file with just the errors