### PR TITLE
feat: allow mapping URLs to generic crawlers

### DIFF
--- a/cyberdrop_dl/config/config_model.py
+++ b/cyberdrop_dl/config/config_model.py
@@ -92,7 +92,8 @@ class Logs(PathAliasModel):
     @field_validator("logs_expire_after", mode="before")
     @staticmethod
     def parse_logs_duration(input_date: timedelta | str | int | None) -> timedelta | str | None:
-        return falsy_as(input_date, None, to_timedelta)
+        if value := falsy_as(input_date, None):
+            return to_timedelta(value)
 
     def _set_output_filenames(self, now: datetime) -> None:
         self.log_folder.mkdir(exist_ok=True, parents=True)
@@ -136,13 +137,7 @@ class MediaDurationLimits(BaseModel):
 
     @field_validator("*", mode="before")
     @staticmethod
-    def parse_runtime_duration(input_date: timedelta | str | int | None) -> timedelta:
-        """Parses `datetime.timedelta`, `str` or `int` into a timedelta format.
-        for `str`, the expected format is `value unit`, ex: `5 days`, `10 minutes`, `1 year`
-        valid units:
-            year(s), week(s), day(s), hour(s), minute(s), second(s), millisecond(s), microsecond(s)
-        for `int`, value is assumed as `days`
-        """
+    def parse_runtime_duration(input_date: timedelta | str | int | None) -> timedelta | str:
         if input_date is None:
             return timedelta(seconds=0)
         return to_timedelta(input_date)

--- a/cyberdrop_dl/config/global_model.py
+++ b/cyberdrop_dl/config/global_model.py
@@ -35,7 +35,7 @@ class General(BaseModel):
 
     @field_validator("flaresolverr", "proxy", mode="before")
     @classmethod
-    def convert_to_str(cls, value: URL | str) -> str | None:
+    def convert_to_str(cls, value: str) -> str | None:
         return falsy_as(value, None, str)
 
     @field_validator("required_free_space", mode="after")
@@ -59,7 +59,7 @@ class RateLimiting(BaseModel):
 
     @field_validator("file_host_cache_expire_after", "forum_cache_expire_after", mode="before")
     @staticmethod
-    def parse_cache_duration(input_date: timedelta | str | int) -> timedelta:
+    def parse_cache_duration(input_date: timedelta | str | int) -> timedelta | str:
         return to_timedelta(input_date)
 
     @property

--- a/cyberdrop_dl/config/global_model.py
+++ b/cyberdrop_dl/config/global_model.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ByteSize, NonNegativeFloat, PositiveInt, field_s
 from yarl import URL
 
 from cyberdrop_dl.config._common import ConfigModel, Field
-from cyberdrop_dl.models.types import ByteSizeSerilized, HttpURL, ListHttpURL, ListNonEmptyStr, NonEmptyStr
+from cyberdrop_dl.models.types import ByteSizeSerilized, HttpURL, ListNonEmptyStr, ListPydanticURL, NonEmptyStr
 from cyberdrop_dl.models.validators import falsy_as, to_bytesize, to_timedelta
 
 MIN_REQUIRED_FREE_SPACE = to_bytesize("512MB")
@@ -80,9 +80,9 @@ class UIOptions(BaseModel):
 
 
 class GenericCrawlerInstances(BaseModel):
-    wordpress_media: ListHttpURL = []
-    wordpress_html: ListHttpURL = []
-    discourse: ListHttpURL = []
+    wordpress_media: ListPydanticURL = []
+    wordpress_html: ListPydanticURL = []
+    discourse: ListPydanticURL = []
 
 
 class GlobalSettings(ConfigModel):

--- a/cyberdrop_dl/config/global_model.py
+++ b/cyberdrop_dl/config/global_model.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ByteSize, NonNegativeFloat, PositiveInt, field_s
 from yarl import URL
 
 from cyberdrop_dl.config._common import ConfigModel, Field
-from cyberdrop_dl.models.types import ByteSizeSerilized, HttpURL, NonEmptyStr
+from cyberdrop_dl.models.types import ByteSizeSerilized, HttpURL, ListHttpURL, ListNonEmptyStr, NonEmptyStr
 from cyberdrop_dl.models.validators import falsy_as, to_bytesize, to_timedelta
 
 MIN_REQUIRED_FREE_SPACE = to_bytesize("512MB")
@@ -14,7 +14,7 @@ DEFAULT_REQUIRED_FREE_SPACE = to_bytesize("5GB")
 
 class General(BaseModel):
     allow_insecure_connections: bool = False
-    disable_crawlers: list[NonEmptyStr] = []
+    disable_crawlers: ListNonEmptyStr = []
     enable_generic_crawler: bool = True
     flaresolverr: HttpURL | None = None
     max_file_name_length: PositiveInt = 95
@@ -23,11 +23,6 @@ class General(BaseModel):
     required_free_space: ByteSizeSerilized = DEFAULT_REQUIRED_FREE_SPACE
     user_agent: NonEmptyStr = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
     pause_on_insufficient_space: bool = False
-
-    @field_validator("disable_crawlers", mode="before")
-    @classmethod
-    def as_list(cls, value: str | list[str]) -> list[str]:
-        return falsy_as(value, [])
 
     @field_validator("disable_crawlers", mode="after")
     @classmethod
@@ -84,7 +79,14 @@ class UIOptions(BaseModel):
     vi_mode: bool = False
 
 
+class GenericCrawlerInstances(BaseModel):
+    wordpress_media: ListHttpURL = []
+    wordpress_html: ListHttpURL = []
+    discourse: ListHttpURL = []
+
+
 class GlobalSettings(ConfigModel):
     general: General = Field(General(), "General")
     rate_limiting_options: RateLimiting = Field(RateLimiting(), "Rate_Limiting_Options")
     ui_options: UIOptions = Field(UIOptions(), "UI_Options")
+    generic_crawlers_instances: GenericCrawlerInstances = GenericCrawlerInstances()

--- a/cyberdrop_dl/crawlers/__init__.py
+++ b/cyberdrop_dl/crawlers/__init__.py
@@ -102,7 +102,7 @@ from .yandex_disk import YandexDiskCrawler
 from .youjizz import YouJizzCrawler
 
 FORUM_CRAWLERS = DISCOURSE_CRAWLERS.union(XF_CRAWLERS)
-GENERIC_CRAWLERS = WP_GENERIC_CRAWLERS.union({DiscourseCrawler})
+GENERIC_CRAWLERS: set[type[Crawler]] = WP_GENERIC_CRAWLERS.union({DiscourseCrawler})
 ALL_CRAWLERS: set[type[Crawler]] = {
     crawler for name, crawler in globals().items() if name.endswith("Crawler") and crawler is not Crawler
 }

--- a/cyberdrop_dl/crawlers/discourse/_discourse.py
+++ b/cyberdrop_dl/crawlers/discourse/_discourse.py
@@ -97,7 +97,7 @@ class DiscourseCrawler(MessageBoardCrawler, is_generic=True):
         last_post_id = None
         async for post in self.iter_posts(topic):
             new_scrape_item = scrape_item.create_child(
-                self.PRIMARY_URL / post.path,
+                self.PRIMARY_URL / post.path.removeprefix("/"),
                 possible_datetime=to_timestamp(post.created_at),
             )
             await self.post(new_scrape_item, post)
@@ -108,7 +108,7 @@ class DiscourseCrawler(MessageBoardCrawler, is_generic=True):
                 break
 
         if last_post_id:
-            topic_url = self.PRIMARY_URL / topic.path
+            topic_url = self.PRIMARY_URL / topic.path.removeprefix("/")
             post_url = topic_url / str(last_post_id)
             await self.write_last_forum_post(topic_url, post_url)
 
@@ -117,7 +117,7 @@ class DiscourseCrawler(MessageBoardCrawler, is_generic=True):
             remaining = topic.stream[offset : offset + _MAX_POSTS_PER_REQUEST]
             if not remaining:
                 return
-            stream = await self.make_request(PostStream, f"/t/{topic.id}/posts.json", {"post_ids[]": remaining})
+            stream = await self.make_request(PostStream, f"t/{topic.id}/posts.json", {"post_ids[]": remaining})
             for post in stream.posts:
                 yield post
                 if topic.init_post_number != 1 and self.scrape_single_forum_post:

--- a/cyberdrop_dl/crawlers/discourse/models.py
+++ b/cyberdrop_dl/crawlers/discourse/models.py
@@ -50,7 +50,7 @@ class PostStream(BaseModel):
 
     @property
     def posts(self) -> Iterable[AvailablePost]:
-        for post in self.posts:
+        for post in self.all_posts:
             if isinstance(post, AvailablePost):
                 yield post
 
@@ -70,4 +70,4 @@ class Topic(PostStream):
 
     @property
     def path(self) -> str:
-        return f"/t/{self.slug}/{self.id}"
+        return f"t/{self.slug}/{self.id}"

--- a/cyberdrop_dl/models/types.py
+++ b/cyberdrop_dl/models/types.py
@@ -43,4 +43,4 @@ HttpURL = Annotated[yarl.URL, PlainValidator(to_yarl_url_w_pydantyc_validation),
 # ~~~~~ Others ~~~~~~~
 ByteSizeSerilized = Annotated[ByteSize, PlainSerializer(bytesize_to_str, return_type=str)]
 ListNonNegativeInt = Annotated[list[NonNegativeInt], BeforeValidator(falsy_as_list)]
-ListHttpURL = Annotated[list[HttpURL], BeforeValidator(falsy_as_list)]
+ListPydanticURL = Annotated[list[HttpURL], BeforeValidator(falsy_as_list)]

--- a/cyberdrop_dl/models/types.py
+++ b/cyberdrop_dl/models/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, TypeVar
 
 import yarl
 from pydantic import (
@@ -22,11 +22,13 @@ from cyberdrop_dl.models.validators import (
     to_yarl_url_w_pydantyc_validation,
 )
 
+T = TypeVar("T")
 # ~~~~~ Strings ~~~~~~~
 StrSerializer = PlainSerializer(str, return_type=str, when_used="json-unless-none")
 NonEmptyStr = Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)]
 NonEmptyStrOrNone = Annotated[NonEmptyStr | None, BeforeValidator(falsy_as_none)]
 ListNonEmptyStr = Annotated[list[NonEmptyStr], BeforeValidator(falsy_as_list)]
+
 
 # ~~~~~ Paths ~~~~~~~
 PathOrNone = Annotated[Path | None, BeforeValidator(falsy_as_none)]
@@ -41,3 +43,4 @@ HttpURL = Annotated[yarl.URL, PlainValidator(to_yarl_url_w_pydantyc_validation),
 # ~~~~~ Others ~~~~~~~
 ByteSizeSerilized = Annotated[ByteSize, PlainSerializer(bytesize_to_str, return_type=str)]
 ListNonNegativeInt = Annotated[list[NonNegativeInt], BeforeValidator(falsy_as_list)]
+ListHttpURL = Annotated[list[HttpURL], BeforeValidator(falsy_as_list)]

--- a/cyberdrop_dl/models/validators.py
+++ b/cyberdrop_dl/models/validators.py
@@ -15,13 +15,12 @@ from typing import (
     overload,
 )
 
+import yarl
 from pydantic import AnyUrl, ByteSize, HttpUrl, TypeAdapter
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
-
-    import yarl
 
 
 _DATE_PATTERN_REGEX = r"(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days|week|weeks|month|months|year|years)"
@@ -50,6 +49,8 @@ def to_yarl_url(value: AnyUrl | str, *args, **kwargs) -> yarl.URL:
 
 
 def to_yarl_url_w_pydantyc_validation(value: str) -> yarl.URL:
+    if isinstance(value, yarl.URL):
+        value = str(value)
     url = HttpUrl(value)
     return to_yarl_url(url)
 

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import Field
 from datetime import date, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Literal, Self
 
 import aiofiles
 import arrow
@@ -398,7 +398,7 @@ def register_crawler(
     existing_crawlers: dict[str, Crawler],
     crawler: Crawler,
     include_generics: bool = False,
-    from_user: bool = False,
+    from_user: bool | Literal["raise"] = False,
 ) -> None:
     if crawler.IS_GENERIC and include_generics:
         keys = (crawler.GENERIC_NAME,)
@@ -416,6 +416,8 @@ def register_crawler(
                     f"URL conflicts with URL format of builtin crawler {other.NAME}. "
                     "URL will be ignored"
                 )
+                if from_user == "raise":
+                    raise ValueError(msg)
                 log(msg, 40)
                 continue
             else:

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -13,7 +13,10 @@ from yarl import URL
 
 from cyberdrop_dl.constants import BLOCKED_DOMAINS, REGEX_LINKS
 from cyberdrop_dl.crawlers import CRAWLERS
-from cyberdrop_dl.crawlers.crawler import Crawler
+from cyberdrop_dl.crawlers.crawler import Crawler, create_crawlers
+from cyberdrop_dl.crawlers.discourse import DiscourseCrawler
+from cyberdrop_dl.crawlers.generic import GenericCrawler
+from cyberdrop_dl.crawlers.wordpress import WordPressHTMLCrawler, WordPressMediaCrawler
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL, MediaItem, ScrapeItem
 from cyberdrop_dl.downloader.downloader import Downloader
 from cyberdrop_dl.exceptions import JDownloaderError, NoExtensionError
@@ -26,6 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Sequence
     from types import TracebackType
 
+    from cyberdrop_dl.config.global_model import GenericCrawlerInstances, GlobalSettings
     from cyberdrop_dl.crawlers import Crawler
     from cyberdrop_dl.managers.manager import Manager
 
@@ -44,6 +48,7 @@ class ScrapeMapper:
         self.using_input_file = False
         self.groups = set()
         self.count = 0
+        self.fallback_generic: GenericCrawler
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
@@ -51,15 +56,25 @@ class ScrapeMapper:
     def group_count(self) -> int:
         return len(self.groups)
 
+    @property
+    def global_settings(self) -> GlobalSettings:
+        return self.manager.config_manager.global_settings_data
+
+    @property
+    def enable_generic_crawler(self) -> bool:
+        return self.global_settings.general.enable_generic_crawler
+
     def start_scrapers(self) -> None:
         """Starts all scrapers."""
         self.existing_crawlers = get_crawlers_mapping(self.manager)
-        if not self.manager.config_manager.global_settings_data.general.enable_generic_crawler:
-            _ = self.existing_crawlers.pop(".")
+        fallback_generic = self.existing_crawlers.pop("generic")
+        assert isinstance(fallback_generic, GenericCrawler)
+        self.fallback_generic = fallback_generic
 
-        disable_crawlers_by_config(
-            self.existing_crawlers, self.manager.config_manager.global_settings_data.general.disable_crawlers
-        )
+        generic_crawlers = create_generic_crawlers_by_config(self.global_settings.generic_crawlers_instances)
+        for crawler in generic_crawlers:
+            register_crawler(self.existing_crawlers, crawler(self.manager), from_user=True)
+        disable_crawlers_by_config(self.existing_crawlers, self.global_settings.general.disable_crawlers)
 
     def start_jdownloader(self) -> None:
         """Starts JDownloader."""
@@ -212,15 +227,12 @@ class ScrapeMapper:
     async def send_to_crawler(self, scrape_item: ScrapeItem) -> None:
         """Maps URLs to their respective handlers."""
         scrape_item.url = remove_trailing_slash(scrape_item.url)
-        supported_domain = [key for key in self.existing_crawlers if key in scrape_item.url.host]
-        is_generic = supported_domain == ["."]
+        supported_domain = match_url_to_crawler(self.existing_crawlers, scrape_item.url)
         jdownloader_whitelisted = True
         if self.jdownloader_whitelist:
             jdownloader_whitelisted = any(domain in scrape_item.url.host for domain in self.jdownloader_whitelist)
 
-        if supported_domain and not is_generic:
-            # get most restrictive domain if multiple domain matches
-            supported_domain = max(supported_domain, key=len)
+        if supported_domain:
             crawler = self.existing_crawlers[supported_domain]
             if not crawler.ready:
                 await crawler.startup()
@@ -270,11 +282,10 @@ class ScrapeMapper:
             self.manager.progress_manager.scrape_stats_progress.add_unsupported(sent_to_jdownloader=success)
             return
 
-        if is_generic:
-            generic_crawler = self.existing_crawlers["."]
-            if not generic_crawler.ready:
-                await generic_crawler.startup()
-            self.manager.task_group.create_task(generic_crawler.run(scrape_item))
+        if self.enable_generic_crawler:
+            if not self.fallback_generic.ready:
+                await self.fallback_generic.startup()
+            self.manager.task_group.create_task(self.fallback_generic.run(scrape_item))
             return
 
         log(f"Unsupported URL: {scrape_item.url}", 30)
@@ -378,21 +389,57 @@ def get_crawlers_mapping(manager: Manager | None = None, include_generics: bool 
     global existing_crawlers
     if not existing_crawlers:
         for crawler in CRAWLERS:
-            site_crawler = crawler(manager_)
-            if site_crawler.IS_GENERIC and include_generics:
-                keys = (site_crawler.GENERIC_NAME,)
-            else:
-                keys = site_crawler.SCRAPE_MAPPER_KEYS
-
-            for domain in keys:
-                msg = f"{domain} from {site_crawler.NAME} already registered by {existing_crawlers.get(domain)}"
-                assert domain not in existing_crawlers, msg
-                existing_crawlers[domain] = site_crawler
+            crawler_instance = crawler(manager_)
+            register_crawler(existing_crawlers, crawler_instance, include_generics)
     return existing_crawlers
+
+
+def register_crawler(
+    existing_crawlers: dict[str, Crawler],
+    crawler: Crawler,
+    include_generics: bool = False,
+    from_user: bool = False,
+) -> None:
+    if crawler.IS_GENERIC and include_generics:
+        keys = (crawler.GENERIC_NAME,)
+    else:
+        keys = crawler.SCRAPE_MAPPER_KEYS
+
+    for domain in keys:
+        other = existing_crawlers.get(domain)
+        if from_user:
+            if not other and (match := match_url_to_crawler(existing_crawlers, crawler.PRIMARY_URL)):
+                other = existing_crawlers[match]
+            if other:
+                msg = (
+                    f"Unable to assign {crawler.PRIMARY_URL} to generic crawler {crawler.GENERIC_NAME}. "
+                    f"URL conflicts with URL format of builtin crawler {other.NAME}. "
+                    "URL will be ignored"
+                )
+                log(msg, 40)
+                continue
+            else:
+                log(f"Successfully mapped {crawler.PRIMARY_URL} to generic crawler {crawler.GENERIC_NAME}")
+
+        elif other:
+            msg = f"{domain} from {crawler.NAME} already registered by {other}"
+            assert domain not in existing_crawlers, msg
+        existing_crawlers[domain] = crawler
 
 
 def get_unique_crawlers() -> list[Crawler]:
     return sorted(set(get_crawlers_mapping(include_generics=True).values()), key=lambda x: x.INFO.site)
+
+
+def create_generic_crawlers_by_config(generic_crawlers: GenericCrawlerInstances) -> set[type[Crawler]]:
+    new_crawlers: set[type[Crawler]] = set()
+    if generic_crawlers.wordpress_html:
+        new_crawlers.update(create_crawlers(generic_crawlers.wordpress_html, WordPressHTMLCrawler))
+    if generic_crawlers.wordpress_media:
+        new_crawlers.update(create_crawlers(generic_crawlers.wordpress_media, WordPressMediaCrawler))
+    if generic_crawlers.discourse:
+        new_crawlers.update(create_crawlers(generic_crawlers.discourse, DiscourseCrawler))
+    return new_crawlers
 
 
 def disable_crawlers_by_config(existing_crawlers: dict[str, Crawler], crawlers_to_disable: list[str]) -> None:
@@ -422,3 +469,11 @@ def disable_crawlers_by_config(existing_crawlers: dict[str, Crawler], crawlers_t
         )
         log(f"Crawlers disabled by config: \n{crawlers_info}")
     log_spacer(10)
+
+
+def match_url_to_crawler(existing_crawlers: dict[str, Crawler], url: AbsoluteHttpURL) -> str | None:
+    # get most restrictive domain if multiple domain matches
+    try:
+        return max((key for key in existing_crawlers if key in url.host), key=len)
+    except (ValueError, TypeError):
+        return

--- a/tests/test_scrape_mapper.py
+++ b/tests/test_scrape_mapper.py
@@ -1,0 +1,55 @@
+import pytest
+
+from cyberdrop_dl import crawlers
+from cyberdrop_dl.crawlers.crawler import create_crawlers
+from cyberdrop_dl.managers.manager import Manager
+from cyberdrop_dl.scraper import scrape_mapper
+
+_ = scrape_mapper.get_crawlers_mapping()
+
+TEST_BASE_CRAWLER = next(iter(crawlers.GENERIC_CRAWLERS))
+
+
+class MockProgress:
+    scraping_progress = None
+
+
+manager = Manager()
+manager.progress_manager = MockProgress()  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        "https://bunkr.com",
+        "https://dropbox.uk",
+        "https://forum.allporncomix.com",
+        "https://cyberfile.me/abhl",
+        "https://forums.plex.tv/"
+        "https://forums.socialmediagirls.com/threads/en-fr-tools-to-download-upload-content-websites-softwares-extensions.13930/#post-2070848",
+    ],
+)
+def test_generic_crawlers_that_match_supported_crawlers_should_not_be_created(link: str) -> None:
+    crawler = next(iter(create_crawlers([link], TEST_BASE_CRAWLER)))
+    with pytest.raises(ValueError) as exc_info:
+        scrape_mapper.register_crawler(scrape_mapper.existing_crawlers, crawler(manager), from_user="raise")
+    assert f"Unable to assign {link.split('/')[0]}" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        "https://forum.otherforum.com",
+        "https://cyberfolder.me/abhl",
+        "https://meta.discourse.org/",
+    ],
+)
+def test_generic_crawlers_that_do_no_match_supported_crawlers_should_be_created(link: str) -> None:
+    crawler = next(iter(create_crawlers([link], TEST_BASE_CRAWLER)))
+    existing_crawlers = scrape_mapper.existing_crawlers.copy()
+    crawlers_before = set(existing_crawlers.values())
+    scrape_mapper.register_crawler(existing_crawlers, crawler(manager), from_user="raise")
+    new_crawlers = set(existing_crawlers.values()) - crawlers_before
+    assert len(new_crawlers) == 1
+    created_crawler = next(iter(new_crawlers))
+    assert issubclass(type(created_crawler), TEST_BASE_CRAWLER)


### PR DESCRIPTION
 - Adds config option to let the user map a list of URLs to the `wordpress_media`,`wordpress_html` and `discourse`
 - Fixes some type annotations of the config models
 - Simplify logic for additive cli arguments

URLs that match with a built-in crawler will be ignored.