### PR TITLE
refactor: use strict URL matching for all paths (pornhub)

### DIFF
--- a/cyberdrop_dl/crawlers/pornhub.py
+++ b/cyberdrop_dl/crawlers/pornhub.py
@@ -217,7 +217,7 @@ class PornHubCrawler(Crawler):
         link_str: str = css.select_one_get_attr(soup, _SELECTORS.PHOTO, "src")
         link = self.parse_url(link_str)
         album_tag = css.select_one(soup, _SELECTORS.ALBUM_FROM_PHOTO)
-        album_name = album_tag.get_text(strip=True)
+        album_name = css.get_text(album_tag)
         album_link_str: str = css.get_attr(album_tag, "href")
         album_id: str = album_link_str.split("/")[-1]
         title = self.create_title(album_name, album_id)
@@ -322,11 +322,6 @@ def check_video_is_available(soup: BeautifulSoup) -> None:
     if soup.select_one(_SELECTORS.GEO_BLOCKED) or "This content is unavailable in your country" in page_text:
         raise ScrapeError(HTTPStatus.FORBIDDEN)
 
-    if soup.select_one(_SELECTORS.REMOVED) or any(
-        text in page_text for text in ("This video has been removed", "This video is currently unavailable")
-    ):
-        raise ScrapeError(HTTPStatus.GONE)
-
     if any(
         text in page_text
         for text in (
@@ -335,3 +330,8 @@ def check_video_is_available(soup: BeautifulSoup) -> None:
         )
     ):
         raise ScrapeError(HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS)
+
+    if soup.select_one(_SELECTORS.REMOVED) or any(
+        text in page_text for text in ("This video has been removed", "This video is currently unavailable")
+    ):
+        raise ScrapeError(HTTPStatus.GONE)


### PR DESCRIPTION
match profile URLs by exact pattern, not just parts.

This means:
1. If the input  URL is the root of the profile, it will download videos, photos and gifs from that profile
2. If the URL is a subpath of the profile (videos, photos or gifs), it will only download videos, photos or gifs, respectively.

I also changed what's downloaded in each category:

- For gifs, it will only download gifs uploaded by the profile.
- For photos, it will only download photos uploaded by the profile.
- For videos, it will download all videos in the profile, which includes videos uploaded in the profile itself and videos that the model in the profile was tagged in. It will not include "similar videos", "related videos" or videos from other models
- Fixes #1098 