### PR TITLE
perf: update blocked domains

### DIFF
--- a/cyberdrop_dl/constants.py
+++ b/cyberdrop_dl/constants.py
@@ -55,7 +55,22 @@ class CustomHTTPStatus(IntEnum):
     DDOS_GUARD = 429
 
 
-BLOCKED_DOMAINS = ("facebook", "instagram", "fbcdn")
+BLOCKED_DOMAINS = (
+    "facebook",
+    "instagram",
+    "fbcdn",
+    "gfycat",
+    "ko-fi.com",
+    "paypal.me",
+    "amazon.com",
+    "throne.com",
+    "youtu.be",
+    "youtube.com",
+    "linktr.ee",
+    "beacons.page",
+    "beacons.ai",
+    "allmylinks.com",
+)
 
 
 DEFAULT_APP_STORAGE = Path("./AppData")


### PR DESCRIPTION
Add some sites that we do not support and will never support, but they seen to be common in profiles/forums. I see them frequently in user's logs.

Most users do not update their `--skip-hosts` list