### PR TITLE
perf: add custom cached session 

### DIFF
--- a/cyberdrop_dl/cached_session.py
+++ b/cyberdrop_dl/cached_session.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import warnings
+from contextlib import nullcontext
+from typing import TYPE_CHECKING
+
+from aiohttp import ClientResponse, ClientSession
+from aiohttp_client_cache.backends import get_valid_kwargs
+from aiohttp_client_cache.session import CacheMixin
+from aiohttp_client_cache.signatures import extend_signature
+
+if TYPE_CHECKING:
+    from aiohttp.typedefs import StrOrURL
+    from aiolimiter import AsyncLimiter
+
+    MIXIN_BASE = ClientSession
+
+else:
+    MIXIN_BASE = object
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+
+    class LimiterMixin(MIXIN_BASE):
+        """A mixin class for `aiohttp.ClientSession` that adds async limiter support by headers"""
+
+        @extend_signature(ClientSession.__init__)
+        def __init__(
+            self,
+            base_url: StrOrURL | None = None,
+            *,
+            crawler_limiters: dict[str, AsyncLimiter] | None = None,
+            **kwargs,
+        ) -> None:
+            self._crawler_limiters = crawler_limiters or {}
+            self._null_cdl_limiter = nullcontext()
+            session_kwargs = get_valid_kwargs(super().__init__, {**kwargs, "base_url": base_url})
+            super().__init__(**session_kwargs)
+
+        @extend_signature(ClientSession._request)
+        async def _request(
+            self,
+            method: str,
+            str_or_url: StrOrURL,
+            **kwargs,
+        ) -> ClientResponse:
+            headers = self._prepare_headers(kwargs.get("headers"))
+            if domain := headers.pop("CDL_DOMAIN", None):
+                limiter = self._crawler_limiters[domain]
+            else:
+                limiter = self._null_cdl_limiter
+
+            kwargs["headers"] = headers
+            async with limiter:
+                return await super()._request(method, str_or_url, **kwargs)
+
+    class CDLCachedSession(CacheMixin, LimiterMixin, ClientSession):
+        async def __aenter__(self) -> CDLCachedSession:
+            return self

--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -26,11 +26,11 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
     from types import TracebackType
 
-    from aiohttp_client_cache.session import CachedSession
     from curl_cffi.requests.impersonate import BrowserTypeLiteral as BrowserTarget
     from curl_cffi.requests.models import Response as CurlResponse
     from multidict import CIMultiDictProxy
 
+    from cyberdrop_dl.cached_session import CDLCachedSession
     from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
     from cyberdrop_dl.managers.client_manager import ClientManager
 
@@ -82,7 +82,7 @@ def copy_signature(target: Callable[_P, _R]) -> Callable[[Callable[..., _T]], Ca
 
 
 @asynccontextmanager
-async def cache_control_manager(client_session: CachedSession, disabled: bool = False):
+async def cache_control_manager(client_session: CDLCachedSession, disabled: bool = False):
     try:
         client_session.cache.disabled = constants.DISABLE_CACHE or disabled
         yield
@@ -100,7 +100,7 @@ class ScraperClient:
         # folder len + date_prefix len + 10 [suffix (.html) + 1 OS separator + 4 (padding)]
         min_html_file_path_len = len(str(self._pages_folder)) + len(constants.STARTUP_TIME_STR) + 10
         self._max_html_stem_len = 245 - min_html_file_path_len
-        self._session: CachedSession
+        self._session: CDLCachedSession
         self._curl_session: AsyncSession
 
     def _startup(self) -> None:
@@ -251,7 +251,7 @@ class ScraperClient:
         cache_disabled: bool = False,
     ) -> tuple[AnyResponse, BeautifulSoup | None]:
         """_resilient_get with cache_control."""
-        headers = self.client_manager._headers | (headers or {})
+        headers = self.client_manager._headers | {"CDL_DOMAIN": domain} | (headers or {})
         async with cache_control_manager(self._session, disabled=cache_disabled):
             response, soup_or_none = await self._resilient_get(url, headers, request_params)
 


### PR DESCRIPTION
Adds custom CDL client session that auto rate limits the requests.

Cache lookup will have no lock. Only actual new requests will be limited. This will improve performance drastically.

However, cache lookup are still limited by the scrape limiter and the download limiter.

https://github.com/jbsparrow/CyberDropDownloader/blob/c45035adc18af453a42b5cec37cf1aaf462e7090/cyberdrop_dl/clients/scraper_client.py#L48-L64

We need to unify all of those limiters into a single limiter, essentially solving #556.

This PR only adds the class. None of the crawlers are actually using it yet.

New requests will have no limiter by default, but passing a special header `CDL_DOMAIN`, will apply the limiter for that domain.