### PR TITLE
fix: laggy playback and frozen start in concatenated video file (m3u8)

### DIFF
--- a/cyberdrop_dl/utils/ffmpeg.py
+++ b/cyberdrop_dl/utils/ffmpeg.py
@@ -113,7 +113,7 @@ async def _create_concat_input_file(*input: Path, file_path: Path) -> None:
 async def _fixup_concatenated_video_file(input_file: Path, output_file: Path) -> SubProcessResult:
     command = *FFMPEG_CALL_PREFIX, "-i", str(input_file), *FFMPEG_FIXUP_INPUT_ARGS
     probe_result = await FFmpeg.probe(input_file)
-    if probe_result.audio.codec_name == "aac":
+    if probe_result and probe_result.audio.codec_name == "aac":
         command += FFMPEG_FIXUP_AUDIO_FILTER_ARGS
     command = *command, str(output_file)
     result = await _run_command(command)


### PR DESCRIPTION
Previously concatenated video files produced by ffmpeg are laggy or freeze for some seconds when seeking or starting playback.

This commit adds a post-processing step after concatenation, remuxing without re-encoding the intermediate file to a proper MP4 using ffmpeg with additional fixup options.

These options ensure all streams are included, unnecessary data streams are removed, and the output is optimized for fast start and smooth seeking.

The result is improved playback performance.