### PR TITLE
refactor: add `ffprobe` checks and fallback to builtin binary

### DIFF
--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -23,6 +23,7 @@ from cyberdrop_dl.exceptions import (
     InvalidContentTypeError,
     RestrictedFiletypeError,
 )
+from cyberdrop_dl.utils import ffmpeg
 from cyberdrop_dl.utils.logger import log
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_size_or_none, parse_url
 
@@ -150,8 +151,11 @@ class Downloader:
     @error_handling_wrapper
     async def download_hls(self, media_item: MediaItem, m3u8_group: RenditionGroup) -> None:
         await self.client.mark_incomplete(media_item, self.domain)
-        if not self.manager.ffmpeg.is_available:
-            raise DownloadError("FFmpeg Error", "FFmpeg is required for HLS downloads but is not available", media_item)
+        try:
+            ffmpeg.check_is_available()
+        except RuntimeError as e:
+            msg = f"{e} - ffmpeg and ffprobe are required for HLS downloads"
+            raise DownloadError("FFmpeg Error", msg, media_item) from None
 
         media_item.complete_file = media_item.download_folder / media_item.filename
         self.update_queued_files()
@@ -162,7 +166,7 @@ class Downloader:
             await asyncio.to_thread(video.rename, media_item.complete_file)
         else:
             parts = [part for part in (video, audio, subtitles) if part]
-            ffmpeg_result = await self.manager.ffmpeg.merge(*parts, output_file=media_item.complete_file)
+            ffmpeg_result = await ffmpeg.merge(*parts, output_file=media_item.complete_file)
 
             if not ffmpeg_result.success:
                 raise DownloadError("FFmpeg Concat Error", ffmpeg_result.stderr, media_item)
@@ -192,7 +196,7 @@ class Downloader:
 
             seg_paths = [item.complete_file for item in items if item.complete_file]
             output = media_item.complete_file.with_suffix(f".{media_type}.ts")
-            ffmpeg_result = await self.manager.ffmpeg.concat(*seg_paths, output_file=output)
+            ffmpeg_result = await ffmpeg.concat(*seg_paths, output_file=output)
             if not ffmpeg_result.success:
                 raise DownloadError("FFmpeg Concat Error", ffmpeg_result.stderr, media_item)
             results.append(output)

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -166,7 +166,7 @@ class Downloader:
             await asyncio.to_thread(video.rename, media_item.complete_file)
         else:
             parts = [part for part in (video, audio, subtitles) if part]
-            ffmpeg_result = await ffmpeg.merge(*parts, output_file=media_item.complete_file)
+            ffmpeg_result = await ffmpeg.merge(parts, media_item.complete_file)
 
             if not ffmpeg_result.success:
                 raise DownloadError("FFmpeg Concat Error", ffmpeg_result.stderr, media_item)
@@ -196,7 +196,7 @@ class Downloader:
 
             seg_paths = [item.complete_file for item in items if item.complete_file]
             output = media_item.complete_file.with_suffix(f".{media_type}.ts")
-            ffmpeg_result = await ffmpeg.concat(*seg_paths, output_file=output)
+            ffmpeg_result = await ffmpeg.concat(seg_paths, output)
             if not ffmpeg_result.success:
                 raise DownloadError("FFmpeg Concat Error", ffmpeg_result.stderr, media_item)
             results.append(output)

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -22,8 +22,8 @@ from cyberdrop_dl.managers.progress_manager import ProgressManager
 from cyberdrop_dl.managers.realdebrid_manager import RealDebridManager
 from cyberdrop_dl.managers.storage_manager import StorageManager
 from cyberdrop_dl.ui.textual import TextualUI
+from cyberdrop_dl.utils import ffmpeg
 from cyberdrop_dl.utils.args import ParsedArgs, parse_args
-from cyberdrop_dl.utils.ffmpeg import get_ffmpeg_version
 from cyberdrop_dl.utils.logger import QueuedLogger, log
 from cyberdrop_dl.utils.transfer import transfer_v5_db_to_v6
 from cyberdrop_dl.utils.utilities import close_if_defined, get_system_information
@@ -225,19 +225,23 @@ class Manager:
         cli_only_args = self.parsed_args.cli_only_args.model_dump_json(indent=4)
         system_info = get_system_information()
 
-        log("Starting Cyberdrop-DL Process")
-        log(f"Running Version: {__version__}")
-        log(f"System Info:{system_info}")
-        log(f"Using Config: {self.config_manager.loaded_config}")
-        log(f"Using Config File: {self.config_manager.settings}")
-        log(f"Using Input File: {self.path_manager.input_file}")
-        log(f"Using Download Folder: {self.path_manager.download_folder}")
-        log(f"Using Database File: {self.path_manager.history_db}")
-        log(f"Using CLI only options: {cli_only_args}")
-        log(f"Using Authentication: \n{json.dumps(auth_provided, indent=4, sort_keys=True)}")
-        log(f"Using Settings: \n{config_settings}")
-        log(f"Using Global Settings: \n{global_settings}")
-        log(f"Using FFmpeg version: {get_ffmpeg_version()}")
+        args_info = (
+            "Starting Cyberdrop-DL Process",
+            f"Running Version: {__version__}",
+            f"System Info:{system_info}",
+            f"Using Config: {self.config_manager.loaded_config}",
+            f"Using Config File: {self.config_manager.settings}",
+            f"Using Input File: {self.path_manager.input_file}",
+            f"Using Download Folder: {self.path_manager.download_folder}",
+            f"Using Database File: {self.path_manager.history_db}",
+            f"Using CLI only options: {cli_only_args}",
+            f"Using Authentication: \n{json.dumps(auth_provided, indent=4, sort_keys=True)}",
+            f"Using Settings: \n{config_settings}",
+            f"Using Global Settings: \n{global_settings}",
+            f"Using ffmpeg version: {ffmpeg.get_ffmpeg_version()}",
+            f"Using ffprobe version: {ffmpeg.get_ffprobe_version()}",
+        )
+        log("\n".join(args_info))
 
     async def async_db_close(self) -> None:
         "Partial shutdown for managers used for hash directory scanner"

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -23,7 +23,7 @@ from cyberdrop_dl.managers.realdebrid_manager import RealDebridManager
 from cyberdrop_dl.managers.storage_manager import StorageManager
 from cyberdrop_dl.ui.textual import TextualUI
 from cyberdrop_dl.utils.args import ParsedArgs, parse_args
-from cyberdrop_dl.utils.ffmpeg import FFmpeg, get_ffmpeg_version
+from cyberdrop_dl.utils.ffmpeg import get_ffmpeg_version
 from cyberdrop_dl.utils.logger import QueuedLogger, log
 from cyberdrop_dl.utils.transfer import transfer_v5_db_to_v6
 from cyberdrop_dl.utils.utilities import close_if_defined, get_system_information
@@ -58,7 +58,6 @@ class Manager:
         self.progress_manager: ProgressManager = field(init=False)
         self.live_manager: LiveManager = field(init=False)
         self.textual_log_queue: queue.Queue = field(init=False)
-        self.ffmpeg: FFmpeg = FFmpeg()
         self._textual_ui: TextualUI = field(init=False)
 
         self._loaded_args_config: bool = False

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -58,7 +58,7 @@ class Manager:
         self.progress_manager: ProgressManager = field(init=False)
         self.live_manager: LiveManager = field(init=False)
         self.textual_log_queue: queue.Queue = field(init=False)
-        self.ffmpeg: FFmpeg = field(init=False)
+        self.ffmpeg: FFmpeg = FFmpeg()
         self._textual_ui: TextualUI = field(init=False)
 
         self._loaded_args_config: bool = False
@@ -169,9 +169,6 @@ class Manager:
             self.download_manager = DownloadManager(self)
         if not isinstance(self.real_debrid_manager, RealDebridManager):
             self.real_debrid_manager = RealDebridManager(self)
-
-        if not isinstance(self.ffmpeg, FFmpeg):
-            self.ffmpeg = FFmpeg(self)
 
         await self.async_db_hash_startup()
 

--- a/cyberdrop_dl/utils/ffmpeg.py
+++ b/cyberdrop_dl/utils/ffmpeg.py
@@ -59,11 +59,13 @@ def which_ffprobe() -> str | None:
 
 
 def get_ffmpeg_version() -> str | None:
-    return _get_bin_version(which_ffmpeg())
+    if bin_path := which_ffmpeg():
+        return _get_bin_version(bin_path)
 
 
 def get_ffprobe_version() -> str | None:
-    return _get_bin_version(which_ffprobe())
+    if bin_path := which_ffprobe():
+        return _get_bin_version(bin_path)
 
 
 async def concat(*input_files: Path, output_file: Path, same_folder: bool = True) -> SubProcessResult:


### PR DESCRIPTION
- Make `ffmpeg` no longer depend on the manager. Now is just a module with functions instead of a class
- Check `ffprobe` version and fallback to builtin binary if none is available