### PR TITLE
fix: messages being logged twice

### DIFF
--- a/cyberdrop_dl/crawlers/_forum.py
+++ b/cyberdrop_dl/crawlers/_forum.py
@@ -229,6 +229,8 @@ class MessageBoardCrawler(Crawler, is_abc=True):
 
     async def fetch_thread(self, scrape_item: ScrapeItem) -> None:
         thread_part_index = len(self.PRIMARY_URL.parts)
+        if not self.PRIMARY_URL.name:
+            thread_part_index -= 1
         match scrape_item.url.parts[thread_part_index:]:
             case [thread_part, thread_name_and_id, *_] if thread_part in self.THREAD_PART_NAMES:
                 self.check_thread_recursion(scrape_item)

--- a/cyberdrop_dl/utils/logger.py
+++ b/cyberdrop_dl/utils/logger.py
@@ -222,10 +222,9 @@ def log(
 ) -> None:
     """Simple logging function."""
     msg = prefix + process_log_msg(message)
-    logger.log(level, msg, **kwargs)
     log_debug(msg, level, **kwargs)
     if bug:
-        msg = msg.rstrip() + f". Please file a bug report at {NEW_ISSUE_URL}"
+        msg = msg.rstrip() + f". Please open a bug report at {NEW_ISSUE_URL}"
     logger.log(level, msg, **kwargs)
 
 

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -83,7 +83,7 @@ class Sorter:
 
     async def run(self) -> None:
         """Sorts the files in the download directory into their respective folders."""
-        if not asyncio.to_thread(self.download_folder.is_dir):
+        if not await asyncio.to_thread(self.download_folder.is_dir):
             log_with_color(f"Download directory ({self.download_folder}) does not exist", "red", 40)
             return
 


### PR DESCRIPTION
- Fix sorting not waited
- Fix messages being logged twice
- Fix parsing of forums links that have a trailing slash in their PRIMARY URL (xbunkr)
- Resolves #1165 