### PR TITLE
fix obvious typo on `7.2.1` release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.1] - 2025-07-25
+## [7.2.1] - 2025-07-18
 
 ### Changed
 


### PR DESCRIPTION
it looks more like `2025-07-19` from where I am, but [pypi](https://pypi.org/project/cyberdrop-dl-patched/#history) says `Jul 18` so who am I to disagree. But it's very clearly not Jul 25 yet, unless you're on Mars or something.