### PR TITLE
fix: use proactor event loop on Windows

### DIFF
--- a/cyberdrop_dl/director.py
+++ b/cyberdrop_dl/director.py
@@ -343,7 +343,7 @@ class Director:
 
     def __init__(self, args: tuple[str, ...] | None = None) -> None:
         if os.name == "nt":
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
         self.manager = _setup_manager(args)


### PR DESCRIPTION
Required to run `ffmpeg` as a subprocess on Windows.

I explicitly switched to a Selector loop in https://github.com/jbsparrow/CyberDropDownloader/pull/1022 but i don't remember why. I think it was solve some pytest issues