### PR TITLE
Handle unicode characters escaped with `\u` on Bunkr

### DIFF
--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -218,7 +218,7 @@ class BunkrrCrawler(Crawler):
         if not link and "f" in scrape_item.url.parts:
             slug = get_slug_from_soup(soup) or scrape_item.url.name or scrape_item.url.parent.name
             base = self.known_good_url or scrape_item.url.origin()
-            slug_url = base / "f" / slug
+            slug_url = base / "f" / slug.encode().decode('unicode-escape')
             link = await self.get_download_url_from_api(slug_url)
 
         # Fallback for everything else, try to get the download URL. `handle_direct_link` will make the final request to the API


### PR DESCRIPTION
Unescapes the unicode escapes found in the JavaScript `jsSlug` to fix the `/f/` slug URL that is created on Bunkr streaming API pages.

Without this fix, files names with a character that Bunkr escaped would be shown as getting a 404 because we requested the wrong URL.

Example:

```js
var jsSlug = 'a-\u0026-b-BMvk2CDL.mp4';
```

Before: `https://bunkr.cr/f/a-%5Cu0026-b-BMvk2CDL.mp4`
After: `https://bunkr.cr/f/a-&-b-BMvk2CDL.mp4`
