### PR TITLE
fix: do not timeout when downloading very large files

### DIFF
--- a/cyberdrop_dl/config/global_model.py
+++ b/cyberdrop_dl/config/global_model.py
@@ -78,6 +78,7 @@ class RateLimiting(BaseModel):
     def model_post_init(self, *_) -> None:
         self._timeout = Timeout(self.connection_timeout, self.read_timeout)
         self._aiohttp_timeout = aiohttp.ClientTimeout(self._timeout.total, self._timeout.connect)
+        self._download_timeout = aiohttp.ClientTimeout(None, self._timeout.connect, 30)
 
     @field_validator("file_host_cache_expire_after", "forum_cache_expire_after", mode="before")
     @staticmethod

--- a/cyberdrop_dl/config/global_model.py
+++ b/cyberdrop_dl/config/global_model.py
@@ -77,8 +77,8 @@ class RateLimiting(BaseModel):
 
     def model_post_init(self, *_) -> None:
         self._timeout = Timeout(self.connection_timeout, self.read_timeout)
-        self._aiohttp_timeout = aiohttp.ClientTimeout(self._timeout.total, self._timeout.connect)
-        self._download_timeout = aiohttp.ClientTimeout(None, self._timeout.connect, 30)
+        self._scrape_timeout = aiohttp.ClientTimeout(total=self._timeout.total, connect=self._timeout.connect)
+        self._download_timeout = aiohttp.ClientTimeout(total=None, connect=self._timeout.connect, sock_read=20)
 
     @field_validator("file_host_cache_expire_after", "forum_cache_expire_after", mode="before")
     @staticmethod

--- a/cyberdrop_dl/downloader/mega_nz.py
+++ b/cyberdrop_dl/downloader/mega_nz.py
@@ -835,6 +835,13 @@ class MegaDownloadClient(DownloadClient):
 
         return asyncio.to_thread(prepare)
 
+    async def download_file(self, manager: Manager, domain: str, media_item: MediaItem) -> bool:
+        try:
+            return await super().download_file(manager, domain, media_item)
+        except DownloadError as e:
+            e.retry = False  # can not retry
+            raise e
+
 
 class MegaDownloader(Downloader):
     def __init__(self, manager: Manager, domain: str) -> None:

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -170,7 +170,7 @@ class ClientManager:
             headers=self._headers,
             raise_for_status=False,
             cookie_jar=self.cookies,
-            timeout=self.manager.global_config.rate_limiting_options._aiohttp_timeout,
+            timeout=self.manager.global_config.rate_limiting_options._download_timeout,
             trace_configs=trace_configs,
             proxy=self.manager.global_config.general.proxy,
             connector=self._new_tcp_connector(),

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -164,13 +164,19 @@ class ClientManager:
     def _new_session(
         self, cached: bool = False, trace_configs: list[aiohttp.TraceConfig] | None = None
     ) -> CachedSession | ClientSession:
-        session_cls = CachedSession if cached else ClientSession
-        kwargs: dict[str, Any] = {"cache": self.manager.cache_manager.request_cache} if cached else {}
+        if cached:
+            timeout = self.manager.global_config.rate_limiting_options._scrape_timeout
+            session_cls = CachedSession
+            kwargs: dict[str, Any] = {"cache": self.manager.cache_manager.request_cache}
+        else:
+            timeout = self.manager.global_config.rate_limiting_options._download_timeout
+            session_cls = ClientSession
+            kwargs = {}
         return session_cls(
             headers=self._headers,
             raise_for_status=False,
             cookie_jar=self.cookies,
-            timeout=self.manager.global_config.rate_limiting_options._download_timeout,
+            timeout=timeout,
             trace_configs=trace_configs,
             proxy=self.manager.global_config.general.proxy,
             connector=self._new_tcp_connector(),
@@ -392,7 +398,7 @@ class Flaresolverr:
         return await self._make_request(command, client_session, **kwargs)
 
     async def _make_request(self, command: str, client_session: ClientSession, **kwargs) -> dict[str, Any]:
-        timeout = self.client_manager.manager.global_config.rate_limiting_options._aiohttp_timeout
+        timeout = self.client_manager.manager.global_config.rate_limiting_options._scrape_timeout
         if command == "sessions.create":
             timeout = aiohttp.ClientTimeout(total=5 * 60, connect=60)  # 5 minutes to create session
 


### PR DESCRIPTION
Current default timeout is 5 minutes. Big files can take longer than that so they always timeout.

## Changes
- Added a hardcoded timeout of 20 seconds for downloads but for each chunk, not for the entire connection
- Do not retry downloads from mega.nz