### PR TITLE
perf: use an eager task factory on python 3.12+

### DIFF
--- a/cyberdrop_dl/director.py
+++ b/cyberdrop_dl/director.py
@@ -340,6 +340,8 @@ class Director:
         if os.name == "nt":
             asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
         self.loop = asyncio.new_event_loop()
+        if sys.version_info > (3, 12):
+            self.loop.set_task_factory(asyncio.eager_task_factory)
         asyncio.set_event_loop(self.loop)
         self.manager = _setup_manager(args)
 


### PR DESCRIPTION
If a task does not await anything, run it to completion immediately instead of waiting for the next loop iteration.

This may brake code that awaits tasks explicitly:
- The main loop of the storage manager
- The main loop of the auto-rotate logic
- The scheduler

I'm pretty sure the current tests do not cover any of that. I have to test it manually