### PR TITLE
perf: skip duplicate URLs (Kemono)

### DIFF
--- a/cyberdrop_dl/crawlers/_kemono_base.py
+++ b/cyberdrop_dl/crawlers/_kemono_base.py
@@ -6,7 +6,7 @@ import itertools
 import re
 from collections import defaultdict
 from datetime import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, NamedTuple, NotRequired
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, NamedTuple, NotRequired, ParamSpec
 
 from pydantic import AliasChoices, BeforeValidator, Field
 from typing_extensions import TypedDict  # Import from typing is not compatible with pydantic
@@ -17,7 +17,7 @@ from cyberdrop_dl.models import AliasModel
 from cyberdrop_dl.models.validators import falsy_as_none
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.dates import to_timestamp
-from cyberdrop_dl.utils.utilities import error_handling_wrapper, remove_parts
+from cyberdrop_dl.utils.utilities import error_handling_wrapper
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable, Coroutine, Generator
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from bs4 import BeautifulSoup
 
     from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL, ScrapeItem
+
+    _P = ParamSpec("_P")
 
 
 _MAX_OFFSET_PER_CALL = 50
@@ -84,8 +86,10 @@ class Post(AliasModel):
     file: FileOrNone = None
     attachments: list[File] = []  # noqa: RUF012
     published_or_added: datetime | None = Field(None, validation_alias=AliasChoices("published", "added"))
-    soup_attachments: list[Any] = []  # noqa: RUF012, `Any` to skip validation, but these are `yarl.URL`. We generate them internally so no validation is needed
     date: int | None = None
+
+    # `Any` to skip validation, but these are `yarl.URL`. We generate them internally so no validation is needed
+    soup_attachments: list[Any] = []  # noqa: RUF012
 
     def model_post_init(self, *_) -> None:
         if self.published_or_added:
@@ -145,28 +149,30 @@ class PartialUserPost(NamedTuple):
         return PartialUserPost(**info)
 
 
-def fallback_if_no_api(func: Callable[..., Coroutine[None, None, Any]]) -> Callable[..., Coroutine[None, None, Any]]:
+def fallback_if_no_api(func: Callable[_P, Coroutine[None, None, Any]]) -> Callable[_P, Coroutine[None, None, Any]]:
     """Calls a fallback method is the current instance does not define an API"""
 
     @functools.wraps(func)
-    async def wrapper(self: KemonoBaseCrawler, *args, **kwargs) -> Any:
+    async def wrapper(*args, **kwargs) -> Any:
+        self: KemonoBaseCrawler = args[0]
         if hasattr(self, "API_ENTRYPOINT"):
-            return await func(self, *args, **kwargs)
-        fallback_func = getattr(self, f"{func.__name__}_w_no_api", None)
-        if not fallback_func:
-            raise ValueError
-        return await fallback_func(self, *args, **kwargs)
+            return await func(*args, **kwargs)
+
+        if fallback_func := getattr(self, f"{func.__name__}_w_no_api", None):
+            return await fallback_func(self, *args, **kwargs)
+
+        raise ValueError
 
     return wrapper
 
 
 class KemonoBaseCrawler(Crawler, is_abc=True):
     SUPPORTED_PATHS: ClassVar[dict[str, str]] = {  # type: ignore[reportIncompatibleVariableOverride]
-        "Model": "/<service>/user/<user>",
-        "Favorites": "/favorites/<user>",
-        "Search": "/search?...",
-        "Individual Post": "<service>/<user>/post/...",
-        "Direct links": "",
+        "Model": "/<service>/user/<user_id>",
+        "Favorites": "/favorites/<user_id>",
+        "Search": "/search?q=...",
+        "Individual Post": "/<service>/user/<user_id>/post/<post_id>",
+        "Direct links": "/(data|thumbnails)/...",
     }
     DEFAULT_POST_TITLE_FORMAT: ClassVar[str] = "{date} - {title}"
     API_ENTRYPOINT: ClassVar[AbsoluteHttpURL]
@@ -174,9 +180,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
-        REQUIRED_FIELDS = ("SERVICES",)
-        for field_name in REQUIRED_FIELDS:
-            assert getattr(cls, field_name, None), f"Subclass {cls.__name__} must override: {field_name}"
+        Crawler._assert_fields_overrides(cls, "SERVICES")
 
     def __post_init__(self) -> None:
         self._user_names: dict[User, str] = {}
@@ -198,15 +202,12 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             await self.__get_usernames(self.API_ENTRYPOINT / "creators.txt")
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
-        if "thumbnails" in scrape_item.url.parts:
-            return await self.handle_direct_link(scrape_item)
-
         match scrape_item.url.parts[1:]:
             case [service, "user", _, "post", _] if service in self.SERVICES:
                 return await self.post(scrape_item)
             case [service, "user", _] if service in self.SERVICES:
                 return await self.profile(scrape_item)
-            case ["favorites"]:
+            case ["favorites", _]:
                 return await self.favorites(scrape_item)
             case ["posts"] if search_query := scrape_item.url.query.get("q"):
                 return await self.search(scrape_item, search_query)
@@ -214,41 +215,46 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 return await self.discord_server(scrape_item, server_id)
             case ["discord", "server", _, channel_id]:
                 return await self.discord_channel(scrape_item, channel_id)
-
-        await self.handle_direct_link(scrape_item)
+            case ["thumbnails" | "data", _, *_]:
+                return await self.handle_direct_link(scrape_item)
+            case _:
+                raise ValueError
 
     @fallback_if_no_api
     @error_handling_wrapper
     async def search(self, scrape_item: ScrapeItem, query: str) -> None:
-        api_url = self.__make_api_url_w_offset("posts", scrape_item.url)
+        api_url = self.__make_api_url_w_offset(scrape_item.url, "posts")
         title = self.create_title(f"{query} [search]")
         scrape_item.setup_as_profile(title)
         await self.__iter_user_posts_from_url(scrape_item, api_url)
 
     @fallback_if_no_api
     @error_handling_wrapper
-    async def profile(self, scrape_item: ScrapeItem, service: str, user_id: str) -> None:
-        path = f"{service}/user/{user_id}"
-        api_url = self.__make_api_url_w_offset(path, scrape_item.url)
+    async def profile(self, scrape_item: ScrapeItem) -> None:
+        api_url = self.__make_api_url_w_offset(scrape_item.url)
         scrape_item.setup_as_profile("")
         await self.__iter_user_posts_from_url(scrape_item, api_url)
 
+    @fallback_if_no_api
+    @error_handling_wrapper
     async def discord_server(self, scrape_item: ScrapeItem, server_id: str) -> None:
         scrape_item.setup_as_forum("")
         server = await self.__get_discord_server(server_id)
         for channel in server.channels:
             url = self.PRIMARY_URL / "discord/server" / server_id / channel.id
             new_scrape_item = scrape_item.create_child(url)
-            self.manager.task_group.create_task(self.run(new_scrape_item))
+            self.create_task(self.run(new_scrape_item))
             scrape_item.add_children()
 
+    @fallback_if_no_api
+    @error_handling_wrapper
     async def discord_channel(self, scrape_item: ScrapeItem, channel_id: str) -> None:
         scrape_item.setup_as_profile("")
-        api_url_template = self.__make_api_url_w_offset(f"discord/channel/{channel_id}", scrape_item.url)
-        async for json_response_list in self.__api_pager(api_url_template, step_size=_DISCORD_CHANNEL_PAGE_SIZE):
+        api_url = self.__make_api_url_w_offset(scrape_item.url)
+        async for json_response_list in self.__api_pager(api_url, step_size=_DISCORD_CHANNEL_PAGE_SIZE):
             if not isinstance(json_response_list, list):
                 error_msg = (
-                    f"[{self.NAME}] Invalid API response for Discord channel '{channel_id}' posts (URL template: {api_url_template}). "
+                    f"[{self.NAME}] Invalid API response for Discord channel '{channel_id}' posts (URL: {api_url}). "
                     f"Expected a list, but got type {type(json_response_list).__name__}. "
                     f"Response data (truncated): {str(json_response_list)[:200]}"
                 )
@@ -261,7 +267,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 num_posts_in_page += 1
                 if not isinstance(post_data, dict):
                     error_msg = (
-                        f"[{self.NAME}] Invalid post data type in list for Discord channel '{channel_id}' (URL template: {api_url_template}). "
+                        f"[{self.NAME}] Invalid post data type in list for Discord channel '{channel_id}' (URL template: {api_url}). "
                         f"Expected a dict for post data, but got type {type(post_data).__name__}. "
                         f"Post data (truncated): {str(post_data)[:200]}"
                     )
@@ -277,9 +283,8 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
 
     @fallback_if_no_api
     @error_handling_wrapper
-    async def post(self, scrape_item: ScrapeItem, service: str, user_id: str, post_id: str) -> None:
-        path = f"{service}/user/{user_id}/post/{post_id}"
-        api_url = self.__make_api_url_w_offset(path, scrape_item.url)
+    async def post(self, scrape_item: ScrapeItem) -> None:
+        api_url = self.__make_api_url_w_offset(scrape_item.url)
         async with self.request_limiter:
             json_resp: dict[str, Any] = await self.client.get_json(self.DOMAIN, api_url)
 
@@ -294,17 +299,15 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 if previous_server := self.__known_attachment_servers.get(path):
                     if previous_server != server:
                         msg = f"[{self.NAME}] {path} found with multiple diferent servers: {server = } {previous_server = } "
-                        self.log_debug(msg)
+                        self.log(msg)
                     continue
                 self.__known_attachment_servers[path] = server
 
     @error_handling_wrapper
     async def handle_direct_link(self, scrape_item: ScrapeItem, url: AbsoluteHttpURL | None = None) -> None:
-        """Handles a direct link."""
-
         def clean_url(og_url: AbsoluteHttpURL) -> AbsoluteHttpURL:
             if "thumbnails" in og_url.parts:
-                return remove_parts(og_url, "thumbnails")
+                return og_url.with_path(og_url.path.replace("/thumbnails/", "/"), keep_query=True)
             return og_url
 
         scrape_item.url = clean_url(scrape_item.url)
@@ -312,10 +315,12 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         try:
             filename, ext = self.get_filename_and_ext(link.query.get("f") or link.name)
         except NoExtensionError:
-            # Some patreon URLs have another URL as the filename: https://kemono.su/data/7a...27ad7e40bd.jpg?f=https://www.patreon.com/media-u/Z0F..00672794_
+            # Some patreon URLs have another URL as the filename:
+            # ex: https://kemono.su/data/7a...27ad7e40bd.jpg?f=https://www.patreon.com/media-u/Z0F..00672794_
             filename, ext = self.get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)
 
+    @fallback_if_no_api
     @error_handling_wrapper
     async def favorites(self, scrape_item: ScrapeItem) -> None:
         if not self.session_cookie:
@@ -343,7 +348,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 url = self.PRIMARY_URL / service / "user" / user_id
 
             new_scrape_item = scrape_item.create_child(url)
-            self.manager.task_group.create_task(self.run(new_scrape_item))
+            self.create_task(self.run(new_scrape_item))
 
     # ~~~~~~~~ INTERNAL METHODS, not expected to be overriden, but could be ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -375,18 +380,17 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         if not post.content:
             return
 
-        def gen_yarl_urls() -> Generator[AbsoluteHttpURL]:
+        def parse_yarl_urls() -> Generator[AbsoluteHttpURL]:
             seen: set[str] = set()
             for match in _find_http_urls(post.content):
                 if (link := match.group().replace(".md.", ".")) not in seen:
                     seen.add(link)
                     try:
-                        url = self.parse_url(link)
-                        yield url
+                        yield self.parse_url(link)
                     except Exception:
                         pass
 
-        for link in gen_yarl_urls():
+        for link in parse_yarl_urls():
             if self.DOMAIN in link.host:
                 continue
             new_scrape_item = scrape_item.create_child(link)
@@ -414,10 +418,10 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         url = self.parse_url(server + f"/data{file['path']}")
         return url.with_query(f=file.get("name") or url.name)
 
-    def __make_api_url_w_offset(self, path: str, og_url: AbsoluteHttpURL) -> AbsoluteHttpURL:
-        api_url = self.API_ENTRYPOINT / path
-        offset = int(og_url.query.get("o", 0))
-        if query := og_url.query.get("q"):
+    def __make_api_url_w_offset(self, web_url: AbsoluteHttpURL, path: str | None = None) -> AbsoluteHttpURL:
+        api_url = self.API_ENTRYPOINT / (path or web_url.path)
+        offset = int(web_url.query.get("o", 0))
+        if query := web_url.query.get("q"):
             return api_url.update_query(o=offset, q=query)
         return api_url.update_query(o=offset)
 
@@ -427,6 +431,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             self._user_names = {User(u["service"], u["id"]): u["name"] for u in json_resp}
         except Exception:
             pass
+
         if not self._user_names:
             self.log(f"Unable to get list of creators from {self.NAME}. Crawler has been disabled")
             self.disabled = True
@@ -441,9 +446,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             async with self.request_limiter:
                 server_profile_json: dict[str, Any] = await self.client.get_json(self.DOMAIN, api_url_server_profile)
 
-            name = server_profile_json.get("name")
-            if not name:
-                name = f"Discord Server {server_id}"
+            name = server_profile_json.get("name") or f"Discord Server {server_id}"
             api_url_channels = self.API_ENTRYPOINT / "discord/channel/lookup" / server_id
             async with self.request_limiter:
                 channels_json_resp: list[dict] = await self.client.get_json(self.DOMAIN, api_url_channels)
@@ -459,6 +462,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             # From search results
             if isinstance(json_resp, dict):
                 posts = json_resp.get("posts", [])
+
             # From profile
             elif isinstance(json_resp, list):
                 posts: list[dict[str, Any]] = json_resp
@@ -478,45 +482,28 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             if n_posts < _MAX_OFFSET_PER_CALL:
                 break
 
-    async def __api_pager(self, url: AbsoluteHttpURL, step_size: int | None = None) -> AsyncGenerator[Any, None]:
-        """Yields JSON responses from API calls, with configurable increments."""
-        current_step_size = step_size if step_size is not None else _MAX_OFFSET_PER_CALL
+    async def __api_pager(self, url: AbsoluteHttpURL, step_size: int | None = None) -> AsyncGenerator[Any]:
+        """Yields JSON responses from API calls, or soup for web page calls, with configurable increments."""
+        current_step_size = step_size or _MAX_OFFSET_PER_CALL
         init_offset = int(url.query.get("o") or 0)
+        request = self.client.get_json if "api" in url.parts else self.client.get_soup
         for current_offset in itertools.count(init_offset, current_step_size):
             api_url = url.update_query(o=current_offset)
             async with self.request_limiter:
-                json_resp: Any = await self.client.get_json(self.DOMAIN, api_url)
-            yield json_resp
+                yield await request(self.DOMAIN, api_url)
 
     # ~~~~~~~~~~ NO API METHODS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    async def discord_w_no_api(self, scrape_item: ScrapeItem) -> Any:
-        raise NotImplementedError
-
-    async def search_w_no_api(self, scrape_item: ScrapeItem) -> Any:
-        raise NotImplementedError
-
     @error_handling_wrapper
-    async def profile_w_no_api(self, scrape_item: ScrapeItem, service: str, user_id: str) -> None:
-        async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_soup(self.DOMAIN, scrape_item.url)
-
-        path = f"{service}/user/{user_id}"
-        api_url = self.PRIMARY_URL / path
+    async def profile_w_no_api(self, scrape_item: ScrapeItem) -> None:
         scrape_item.setup_as_profile("")
-        init_offset = int(scrape_item.url.query.get("o") or 0)
-        for offset in itertools.count(init_offset, _MAX_OFFSET_PER_CALL):
+        soup: BeautifulSoup
+        async for soup in self.__api_pager(scrape_item.url):
             n_posts = 0
-            api_url = api_url.with_query(o=offset)
-            async with self.request_limiter:
-                soup: BeautifulSoup = await self.client.get_soup(self.DOMAIN, api_url)
 
-            for post in soup.select(_POST_SELECTOR):
+            for _, new_scrape_item in self.iter_children(scrape_item, soup, _POST_SELECTOR):
                 n_posts += 1
-                link = self.parse_url(css.get_attr(post, "href"))
-                new_scrape_item = scrape_item.create_child(link)
                 await self.post_w_no_api(new_scrape_item)
-                scrape_item.add_children()
 
             if n_posts < _MAX_OFFSET_PER_CALL:
                 break
@@ -524,7 +511,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
     @error_handling_wrapper
     async def post_w_no_api(self, scrape_item: ScrapeItem) -> None:
         async with self.request_limiter:
-            soup: BeautifulSoup = await self.client.get_soup(self.DOMAIN, scrape_item.url)
+            soup = await self.client.get_soup(self.DOMAIN, scrape_item.url)
 
         service, _, user_id, _, post_id = scrape_item.url.parts[1:5]
         post = PartialUserPost.from_soup(soup)

--- a/cyberdrop_dl/crawlers/_kemono_base.py
+++ b/cyberdrop_dl/crawlers/_kemono_base.py
@@ -6,7 +6,7 @@ import itertools
 import re
 from collections import defaultdict
 from datetime import datetime  # noqa: TC003
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, NamedTuple, NotRequired, cast
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, NamedTuple, NotRequired
 
 from pydantic import AliasChoices, BeforeValidator, Field
 from typing_extensions import TypedDict  # Import from typing is not compatible with pydantic
@@ -51,43 +51,6 @@ class PostSelectors:
 
 
 _POST = PostSelectors()
-
-
-class UserURL(NamedTuple):
-    # format: https://kemono.su/<service>/user/<user_id>/post/<post_id>
-    # ex: https://kemono.su/patreon/user/92916478/post/87864845
-    service: str
-    user_id: str
-    post_id: str | None = None
-
-    @staticmethod
-    def parse(url: AbsoluteHttpURL) -> UserURL:
-        if (n_parts := len(url.parts)) > 3:
-            post_id = url.parts[5] if n_parts > 5 else None
-            return UserURL(url.parts[1], url.parts[3], post_id)
-        msg = "Invalid user URL"
-        raise ValueError(msg)
-
-
-class UserPostURL(UserURL):
-    post_id: str
-
-    @staticmethod
-    def parse(url: AbsoluteHttpURL) -> UserPostURL:
-        result = UserURL.parse(url)
-        assert result.post_id, "Individual posts must have a post_id"
-        return cast("UserPostURL", result)
-
-
-class DiscordURL(NamedTuple):
-    # format: https://kemono.su/discord/server/<server_id>/<channel_id>
-    # ex: https://kemono.su/discord/server/891670433978531850/892624523034255371
-    server_id: str
-    channel_id: str | None = None  # Only present for individual channels URLs
-
-    @staticmethod
-    def parse(url: AbsoluteHttpURL) -> DiscordURL:
-        return DiscordURL(*url.parts[3:5])
 
 
 class DiscordChannel(NamedTuple):
@@ -198,7 +161,7 @@ def fallback_if_no_api(func: Callable[..., Coroutine[None, None, Any]]) -> Calla
 
 
 class KemonoBaseCrawler(Crawler, is_abc=True):
-    SUPPORTED_PATHS: ClassVar[dict[str, str]] = {
+    SUPPORTED_PATHS: ClassVar[dict[str, str]] = {  # type: ignore[reportIncompatibleVariableOverride]
         "Model": "/<service>/user/<user>",
         "Favorites": "/favorites/<user>",
         "Search": "/search?...",
@@ -237,22 +200,26 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         if "thumbnails" in scrape_item.url.parts:
             return await self.handle_direct_link(scrape_item)
-        if "post" in scrape_item.url.parts:
-            return await self.post(scrape_item)
-        if scrape_item.url.name == "posts":
-            if not scrape_item.url.query.get("q"):
-                raise ValueError
-            return await self.search(scrape_item)
-        if any(x in scrape_item.url.parts for x in self.SERVICES):
-            return await self.profile(scrape_item)
-        if "favorites" in scrape_item.url.parts:
-            return await self.favorites(scrape_item)
+
+        match scrape_item.url.parts[1:]:
+            case [service, "user", _, "post", _] if service in self.SERVICES:
+                return await self.post(scrape_item)
+            case [service, "user", _] if service in self.SERVICES:
+                return await self.profile(scrape_item)
+            case ["favorites"]:
+                return await self.favorites(scrape_item)
+            case ["posts"] if search_query := scrape_item.url.query.get("q"):
+                return await self.search(scrape_item, search_query)
+            case ["discord", "server", server_id]:
+                return await self.discord_server(scrape_item, server_id)
+            case ["discord", "server", _, channel_id]:
+                return await self.discord_channel(scrape_item, channel_id)
+
         await self.handle_direct_link(scrape_item)
 
     @fallback_if_no_api
     @error_handling_wrapper
-    async def search(self, scrape_item: ScrapeItem) -> None:
-        query = scrape_item.url.query["q"]
+    async def search(self, scrape_item: ScrapeItem, query: str) -> None:
         api_url = self.__make_api_url_w_offset("posts", scrape_item.url)
         title = self.create_title(f"{query} [search]")
         scrape_item.setup_as_profile(title)
@@ -260,21 +227,11 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
 
     @fallback_if_no_api
     @error_handling_wrapper
-    async def profile(self, scrape_item: ScrapeItem) -> None:
-        url_info = UserURL.parse(scrape_item.url)
-        path = f"{url_info.service}/user/{url_info.user_id}"
+    async def profile(self, scrape_item: ScrapeItem, service: str, user_id: str) -> None:
+        path = f"{service}/user/{user_id}"
         api_url = self.__make_api_url_w_offset(path, scrape_item.url)
         scrape_item.setup_as_profile("")
         await self.__iter_user_posts_from_url(scrape_item, api_url)
-
-    @fallback_if_no_api
-    @error_handling_wrapper
-    async def discord(self, scrape_item: ScrapeItem) -> None:
-        discord = DiscordURL.parse(scrape_item.url)
-        if discord.channel_id:
-            return await self.discord_channel(scrape_item, discord.channel_id)
-
-        await self.discord_server(scrape_item, discord.server_id)
 
     async def discord_server(self, scrape_item: ScrapeItem, server_id: str) -> None:
         scrape_item.setup_as_forum("")
@@ -320,9 +277,8 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
 
     @fallback_if_no_api
     @error_handling_wrapper
-    async def post(self, scrape_item: ScrapeItem) -> None:
-        url_info = UserPostURL.parse(scrape_item.url)
-        path = f"{url_info.service}/user/{url_info.user_id}/post/{url_info.post_id}"
+    async def post(self, scrape_item: ScrapeItem, service: str, user_id: str, post_id: str) -> None:
+        path = f"{service}/user/{user_id}/post/{post_id}"
         api_url = self.__make_api_url_w_offset(path, scrape_item.url)
         async with self.request_limiter:
             json_resp: dict[str, Any] = await self.client.get_json(self.DOMAIN, api_url)
@@ -541,12 +497,11 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         raise NotImplementedError
 
     @error_handling_wrapper
-    async def profile_w_no_api(self, scrape_item: ScrapeItem) -> None:
+    async def profile_w_no_api(self, scrape_item: ScrapeItem, service: str, user_id: str) -> None:
         async with self.request_limiter:
             soup: BeautifulSoup = await self.client.get_soup(self.DOMAIN, scrape_item.url)
 
-        url_info = UserURL.parse(scrape_item.url)
-        path = f"{url_info.service}/user/{url_info.user_id}"
+        path = f"{service}/user/{user_id}"
         api_url = self.PRIMARY_URL / path
         scrape_item.setup_as_profile("")
         init_offset = int(scrape_item.url.query.get("o") or 0)
@@ -568,10 +523,10 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
 
     @error_handling_wrapper
     async def post_w_no_api(self, scrape_item: ScrapeItem) -> None:
-        url_info = UserPostURL.parse(scrape_item.url)
         async with self.request_limiter:
             soup: BeautifulSoup = await self.client.get_soup(self.DOMAIN, scrape_item.url)
 
+        service, _, user_id, _, post_id = scrape_item.url.parts[1:5]
         post = PartialUserPost.from_soup(soup)
         if not post.title or not post.user_name:
             raise ScrapeError(422)
@@ -582,9 +537,9 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 files.append(self.parse_url(css.get_attr(file, "href")))
 
         full_post = UserPost(
-            user_id=url_info.user_id,
-            service=url_info.service,
-            id=url_info.post_id,
+            user_id=user_id,
+            service=service,
+            id=post_id,
             title=post.title,
             content=post.content,
             published_or_added=post.date,  # type: ignore[reportArgumentType]

--- a/cyberdrop_dl/crawlers/_kemono_base.py
+++ b/cyberdrop_dl/crawlers/_kemono_base.py
@@ -28,10 +28,10 @@ if TYPE_CHECKING:
     from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL, ScrapeItem
 
 
-MAX_OFFSET_PER_CALL = 50
-DISCORD_CHANNEL_PAGE_SIZE = 150
-LINK_REGEX = re.compile(r"(?:http(?!.*\.\.)[^ ]*?)(?=($|\n|\r\n|\r|\s|\"|\[/URL]|']\[|]\[|\[/img]|</|'))")
-POST_SELECTOR = "article.post-card a"
+_MAX_OFFSET_PER_CALL = 50
+_DISCORD_CHANNEL_PAGE_SIZE = 150
+_POST_SELECTOR = "article.post-card a"
+_find_http_urls = re.compile(r"(?:http(?!.*\.\.)[^ ]*?)(?=($|\n|\r\n|\r|\s|\"|\[/URL]|']\[|]\[|\[/img]|</|'))").finditer
 
 
 class PostSelectors:
@@ -288,7 +288,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
     async def discord_channel(self, scrape_item: ScrapeItem, channel_id: str) -> None:
         scrape_item.setup_as_profile("")
         api_url_template = self.__make_api_url_w_offset(f"discord/channel/{channel_id}", scrape_item.url)
-        async for json_response_list in self.__api_pager(api_url_template, step_size=DISCORD_CHANNEL_PAGE_SIZE):
+        async for json_response_list in self.__api_pager(api_url_template, step_size=_DISCORD_CHANNEL_PAGE_SIZE):
             if not isinstance(json_response_list, list):
                 error_msg = (
                     f"[{self.NAME}] Invalid API response for Discord channel '{channel_id}' posts (URL template: {api_url_template}). "
@@ -315,7 +315,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 await self._handle_discord_post(new_scrape_item_for_post, post)
                 scrape_item.add_children()
 
-            if num_posts_in_page < DISCORD_CHANNEL_PAGE_SIZE:
+            if num_posts_in_page < _DISCORD_CHANNEL_PAGE_SIZE:
                 break
 
     @fallback_if_no_api
@@ -420,16 +420,18 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             return
 
         def gen_yarl_urls() -> Generator[AbsoluteHttpURL]:
-            for match in re.finditer(LINK_REGEX, post.content):
-                link = match.group().replace(".md.", ".")
-                try:
-                    url = self.parse_url(link)
-                    yield url
-                except Exception:
-                    pass
+            seen: set[str] = set()
+            for match in _find_http_urls(post.content):
+                if (link := match.group().replace(".md.", ".")) not in seen:
+                    seen.add(link)
+                    try:
+                        url = self.parse_url(link)
+                        yield url
+                    except Exception:
+                        pass
 
         for link in gen_yarl_urls():
-            if not link.host or self.DOMAIN in link.host:
+            if self.DOMAIN in link.host:
                 continue
             new_scrape_item = scrape_item.create_child(link)
             self.handle_external_links(new_scrape_item)
@@ -517,12 +519,12 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 await self._handle_user_post(new_scrape_item, post)
                 scrape_item.add_children()
 
-            if n_posts < MAX_OFFSET_PER_CALL:
+            if n_posts < _MAX_OFFSET_PER_CALL:
                 break
 
     async def __api_pager(self, url: AbsoluteHttpURL, step_size: int | None = None) -> AsyncGenerator[Any, None]:
         """Yields JSON responses from API calls, with configurable increments."""
-        current_step_size = step_size if step_size is not None else MAX_OFFSET_PER_CALL
+        current_step_size = step_size if step_size is not None else _MAX_OFFSET_PER_CALL
         init_offset = int(url.query.get("o") or 0)
         for current_offset in itertools.count(init_offset, current_step_size):
             api_url = url.update_query(o=current_offset)
@@ -548,20 +550,20 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         api_url = self.PRIMARY_URL / path
         scrape_item.setup_as_profile("")
         init_offset = int(scrape_item.url.query.get("o") or 0)
-        for offset in itertools.count(init_offset, MAX_OFFSET_PER_CALL):
+        for offset in itertools.count(init_offset, _MAX_OFFSET_PER_CALL):
             n_posts = 0
             api_url = api_url.with_query(o=offset)
             async with self.request_limiter:
                 soup: BeautifulSoup = await self.client.get_soup(self.DOMAIN, api_url)
 
-            for post in soup.select(POST_SELECTOR):
+            for post in soup.select(_POST_SELECTOR):
                 n_posts += 1
                 link = self.parse_url(css.get_attr(post, "href"))
                 new_scrape_item = scrape_item.create_child(link)
                 await self.post_w_no_api(new_scrape_item)
                 scrape_item.add_children()
 
-            if n_posts < MAX_OFFSET_PER_CALL:
+            if n_posts < _MAX_OFFSET_PER_CALL:
                 break
 
     @error_handling_wrapper

--- a/cyberdrop_dl/crawlers/_kemono_base.py
+++ b/cyberdrop_dl/crawlers/_kemono_base.py
@@ -252,7 +252,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
     @error_handling_wrapper
     async def discord_channel(self, scrape_item: ScrapeItem, channel_id: str) -> None:
         scrape_item.setup_as_profile("")
-        api_url = self.__make_api_url_w_offset(scrape_item.url)
+        api_url = self.__make_api_url_w_offset(scrape_item.url, f"discord/channel/{channel_id}")
         async for json_response_list in self.__api_pager(api_url, step_size=_DISCORD_CHANNEL_PAGE_SIZE):
             if not isinstance(json_response_list, list):
                 error_msg = (
@@ -277,7 +277,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 post = DiscordPost.model_validate(post_data)
                 post_web_url = self.parse_url(post.web_path_qs)
                 new_scrape_item_for_post = scrape_item.create_child(post_web_url)
-                await self._handle_discord_post(new_scrape_item_for_post, post)
+                self.create_task(self._handle_discord_post(new_scrape_item_for_post, post))
                 scrape_item.add_children()
 
             if num_posts_in_page < _DISCORD_CHANNEL_PAGE_SIZE:
@@ -421,7 +421,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         return url.with_query(f=file.get("name") or url.name)
 
     def __make_api_url_w_offset(self, web_url: AbsoluteHttpURL, path: str | None = None) -> AbsoluteHttpURL:
-        api_url = self.API_ENTRYPOINT / (path or web_url.path)
+        api_url = self.API_ENTRYPOINT / (path or web_url.path).removeprefix("/")
         offset = int(web_url.query.get("o", 0))
         if query := web_url.query.get("q"):
             return api_url.update_query(o=offset, q=query)
@@ -478,7 +478,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 n_posts += 1
                 link = self.parse_url(post.web_path_qs)
                 new_scrape_item = scrape_item.create_child(link)
-                await self._handle_user_post(new_scrape_item, post)
+                self.create_task(self._handle_user_post(new_scrape_item, post))
                 scrape_item.add_children()
 
             if n_posts < _MAX_OFFSET_PER_CALL:

--- a/cyberdrop_dl/crawlers/_kemono_base.py
+++ b/cyberdrop_dl/crawlers/_kemono_base.py
@@ -139,14 +139,13 @@ class PartialUserPost(NamedTuple):
 
     @staticmethod
     def from_soup(soup: BeautifulSoup) -> PartialUserPost:
-        info = {}
-        names = "title", "content", "user_name", "date"
+        params = {}
         selectors = (_POST.TITLE, _POST.ALL_CONTENT, _POST.USERNAME, _POST.DATE)
-        for name, selector in zip(names, selectors, strict=True):
+        for name, selector in zip(PartialUserPost._fields, selectors, strict=True):
             if tag := soup.select_one(selector):
-                info[name] = tag.text.strip()
+                params[name] = tag.text.strip()
 
-        return PartialUserPost(**info)
+        return PartialUserPost(**params)
 
 
 def fallback_if_no_api(func: Callable[_P, Coroutine[None, None, Any]]) -> Callable[_P, Coroutine[None, None, Any]]:
@@ -155,7 +154,7 @@ def fallback_if_no_api(func: Callable[_P, Coroutine[None, None, Any]]) -> Callab
     @functools.wraps(func)
     async def wrapper(*args, **kwargs) -> Any:
         self: KemonoBaseCrawler = args[0]
-        if hasattr(self, "API_ENTRYPOINT"):
+        if getattr(self, "API_ENTRYPOINT", None):
             return await func(*args, **kwargs)
 
         if fallback_func := getattr(self, f"{func.__name__}_w_no_api", None):
@@ -187,7 +186,10 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         self.__known_discord_servers: dict[str, DiscordServer] = {}
         self.__known_attachment_servers: dict[str, str] = {}
         self.__discord_servers_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
-        self.session_cookie = self.manager.config_manager.authentication_data.kemono.session
+
+    @property
+    def session_cookie(self) -> str:
+        return ""
 
     async def async_startup(self) -> None:
         def check_kemono_page(response: AnyResponse) -> bool:

--- a/cyberdrop_dl/crawlers/_kemono_base.py
+++ b/cyberdrop_dl/crawlers/_kemono_base.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Annotated, Any, ClassVar, NamedTuple, NotRequi
 from pydantic import AliasChoices, BeforeValidator, Field
 from typing_extensions import TypedDict  # Import from typing is not compatible with pydantic
 
-from cyberdrop_dl.crawlers.crawler import Crawler
+from cyberdrop_dl.crawlers.crawler import Crawler, auto_task_id
 from cyberdrop_dl.exceptions import NoExtensionError, ScrapeError
 from cyberdrop_dl.models import AliasModel
 from cyberdrop_dl.models.validators import falsy_as_none
@@ -154,7 +154,7 @@ def fallback_if_no_api(func: Callable[_P, Coroutine[None, None, Any]]) -> Callab
     @functools.wraps(func)
     async def wrapper(self: KemonoBaseCrawler, *args, **kwargs) -> Any:
         if getattr(self, "API_ENTRYPOINT", None):
-            return await func(self, *args, **kwargs)  # pyright: ignore[reportCallIssue]
+            return await func(self, *args, **kwargs)  # type: ignore[reportCallIssue]
 
         if fallback_func := getattr(self, f"{func.__name__}_w_no_api", None):
             return await fallback_func(*args, **kwargs)
@@ -276,7 +276,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 post = DiscordPost.model_validate(post_data)
                 post_web_url = self.parse_url(post.web_path_qs)
                 new_scrape_item_for_post = scrape_item.create_child(post_web_url)
-                self.create_task(self._handle_discord_post(new_scrape_item_for_post, post))
+                self.create_task(self._handle_discord_post_task(new_scrape_item_for_post, post))
                 scrape_item.add_children()
 
             if num_posts_in_page < _DISCORD_CHANNEL_PAGE_SIZE:
@@ -306,14 +306,14 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
 
     @error_handling_wrapper
     async def handle_direct_link(self, scrape_item: ScrapeItem, url: AbsoluteHttpURL | None = None) -> None:
-        def clean_url(og_url: AbsoluteHttpURL) -> AbsoluteHttpURL:
-            url = remove_parts(og_url, "thumbnail", "thumbnail").with_query(None)
+        def thumbanil_to_src(og_url: AbsoluteHttpURL) -> AbsoluteHttpURL:
+            url = remove_parts(og_url, "thumbnails", "thumbnail").with_query(None)
             if f := og_url.query.get("f"):
                 return url.with_query(f=f)
             return url
 
-        scrape_item.url = clean_url(scrape_item.url)
-        link = clean_url(url or scrape_item.url)
+        scrape_item.url = thumbanil_to_src(scrape_item.url)
+        link = thumbanil_to_src(url or scrape_item.url)
         try:
             filename, ext = self.get_filename_and_ext(link.query.get("f") or link.name)
         except NoExtensionError:
@@ -376,6 +376,9 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         scrape_item.add_to_parent_title(post_title)
 
         await self.__handle_post(scrape_item, post)
+
+    _handle_user_post_task = auto_task_id(_handle_user_post)
+    _handle_discord_post_task = auto_task_id(_handle_discord_post)
 
     def _handle_post_content(self, scrape_item: ScrapeItem, post: Post) -> None:
         """Gets links out of content in post ans sends them to a new crawler."""
@@ -478,7 +481,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 n_posts += 1
                 link = self.parse_url(post.web_path_qs)
                 new_scrape_item = scrape_item.create_child(link)
-                self.create_task(self._handle_user_post(new_scrape_item, post))
+                self.create_task(self._handle_user_post_task(new_scrape_item, post))
                 scrape_item.add_children()
 
             if n_posts < _MAX_OFFSET_PER_CALL:

--- a/cyberdrop_dl/crawlers/_kemono_base.py
+++ b/cyberdrop_dl/crawlers/_kemono_base.py
@@ -17,7 +17,7 @@ from cyberdrop_dl.models import AliasModel
 from cyberdrop_dl.models.validators import falsy_as_none
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.dates import to_timestamp
-from cyberdrop_dl.utils.utilities import error_handling_wrapper
+from cyberdrop_dl.utils.utilities import error_handling_wrapper, remove_parts
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable, Coroutine, Generator
@@ -152,13 +152,12 @@ def fallback_if_no_api(func: Callable[_P, Coroutine[None, None, Any]]) -> Callab
     """Calls a fallback method is the current instance does not define an API"""
 
     @functools.wraps(func)
-    async def wrapper(*args, **kwargs) -> Any:
-        self: KemonoBaseCrawler = args[0]
+    async def wrapper(self: KemonoBaseCrawler, *args, **kwargs) -> Any:
         if getattr(self, "API_ENTRYPOINT", None):
-            return await func(*args, **kwargs)
+            return await func(self, *args, **kwargs)  # pyright: ignore[reportCallIssue]
 
         if fallback_func := getattr(self, f"{func.__name__}_w_no_api", None):
-            return await fallback_func(self, *args, **kwargs)
+            return await fallback_func(*args, **kwargs)
 
         raise ValueError
 
@@ -171,7 +170,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         "Favorites": "/favorites/<user_id>",
         "Search": "/search?q=...",
         "Individual Post": "/<service>/user/<user_id>/post/<post_id>",
-        "Direct links": "/(data|thumbnails)/...",
+        "Direct links": "/(data|thumbnail)/...",
     }
     DEFAULT_POST_TITLE_FORMAT: ClassVar[str] = "{date} - {title}"
     API_ENTRYPOINT: ClassVar[AbsoluteHttpURL]
@@ -217,7 +216,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 return await self.discord_server(scrape_item, server_id)
             case ["discord", "server", _, channel_id]:
                 return await self.discord_channel(scrape_item, channel_id)
-            case ["thumbnails" | "data", _, *_]:
+            case ["thumbnail" | "thumbnails" | "data", _, *_]:
                 return await self.handle_direct_link(scrape_item)
             case _:
                 raise ValueError
@@ -308,9 +307,10 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
     @error_handling_wrapper
     async def handle_direct_link(self, scrape_item: ScrapeItem, url: AbsoluteHttpURL | None = None) -> None:
         def clean_url(og_url: AbsoluteHttpURL) -> AbsoluteHttpURL:
-            if "thumbnails" in og_url.parts:
-                return og_url.with_path(og_url.path.replace("/thumbnails/", "/"), keep_query=True)
-            return og_url
+            url = remove_parts(og_url, "thumbnail", "thumbnail").with_query(None)
+            if f := og_url.query.get("f"):
+                return url.with_query(f=f)
+            return url
 
         scrape_item.url = clean_url(scrape_item.url)
         link = clean_url(url or scrape_item.url)
@@ -515,7 +515,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         async with self.request_limiter:
             soup = await self.client.get_soup(self.DOMAIN, scrape_item.url)
 
-        service, _, user_id, _, post_id = scrape_item.url.parts[1:5]
+        service, _, user_id, _, post_id = scrape_item.url.parts[1:6]
         post = PartialUserPost.from_soup(soup)
         if not post.title or not post.user_name:
             raise ScrapeError(422)

--- a/cyberdrop_dl/crawlers/coomer.py
+++ b/cyberdrop_dl/crawlers/coomer.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from aiolimiter import AsyncLimiter
-
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 
 from ._kemono_base import KemonoBaseCrawler, Post
@@ -21,10 +19,9 @@ class CoomerCrawler(KemonoBaseCrawler):
     SERVICES = "onlyfans", "fansly"
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = "coomer.party", "coomer.su"
 
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        self.request_limiter = AsyncLimiter(4, 1)
-        self.session_cookie = self.manager.config_manager.authentication_data.coomer.session
+    @property
+    def session_cookie(self) -> str:
+        return self.manager.config_manager.authentication_data.coomer.session
 
     async def async_startup(self) -> None:
         await super().async_startup()

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -123,6 +123,12 @@ class Crawler(ABC):
 
     def __post_init__(self) -> None: ...  # noqa: B027
 
+    @final
+    @staticmethod
+    def _assert_fields_overrides(subclass: type[Crawler], *fields: str):
+        for field_name in fields:
+            assert getattr(subclass, field_name, None), f"Subclass {subclass.__name__} must override: {field_name}"
+
     def __init_subclass__(
         cls, is_abc: bool = False, is_generic: bool = False, generic_name: str = "", **kwargs
     ) -> None:
@@ -150,9 +156,7 @@ class Crawler(ABC):
             return
 
         if not (cls.IS_FALLBACK_GENERIC or cls.IS_REAL_DEBRID):
-            REQUIRED_FIELDS = "PRIMARY_URL", "DOMAIN", "SUPPORTED_PATHS"
-            for field_name in REQUIRED_FIELDS:
-                assert getattr(cls, field_name, None), f"Subclass {cls.__name__} must override: {field_name}"
+            Crawler._assert_fields_overrides(cls, "PRIMARY_URL", "DOMAIN", "SUPPORTED_PATHS")
 
         if cls.OLD_DOMAINS:
             cls.REPLACE_OLD_DOMAINS_REGEX = re.compile("|".join(cls.OLD_DOMAINS))

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL, ScrapeItem
+from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 
 from ._kemono_base import KemonoBaseCrawler
 
@@ -10,7 +10,7 @@ from ._kemono_base import KemonoBaseCrawler
 class KemonoCrawler(KemonoBaseCrawler):
     SUPPORTED_PATHS: ClassVar = KemonoBaseCrawler.SUPPORTED_PATHS | {
         "Discord Server": "/discord/<server_id>",
-        "Discord Server Channel": "/discord/server/...#...",
+        "Discord Server Channel": "/discord/server/<server_id>/<channel_id>#...",
     }
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://kemono.cr")
     API_ENTRYPOINT: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://kemono.cr/api/v1")
@@ -26,8 +26,3 @@ class KemonoCrawler(KemonoBaseCrawler):
         "subscribestar",
     )
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = "kemono.party", "kemono.su"
-
-    async def fetch(self, scrape_item: ScrapeItem) -> None:
-        if "discord" in scrape_item.url.parts:
-            return await self.discord(scrape_item)
-        return await super().fetch(scrape_item)

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -26,3 +26,7 @@ class KemonoCrawler(KemonoBaseCrawler):
         "subscribestar",
     )
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = "kemono.party", "kemono.su"
+
+    @property
+    def session_cookie(self):
+        return self.manager.config_manager.authentication_data.kemono.session

--- a/cyberdrop_dl/crawlers/nekohouse.py
+++ b/cyberdrop_dl/crawlers/nekohouse.py
@@ -1,33 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 
 from ._kemono_base import KemonoBaseCrawler
 
-if TYPE_CHECKING:
-    from cyberdrop_dl.data_structures.url_objects import ScrapeItem
-
 
 class NekohouseCrawler(KemonoBaseCrawler):
     SUPPORTED_PATHS: ClassVar[dict[str, str]] = {
-        "Model": "/<service>/user/<user>",
-        "Individual Post": "/<service>/<user>/post/...",
-        "Direct links": "",
+        "Model": "/<service>/user/<user_id>",
+        "Individual Post": "/<service>/user/<user_id>/post/<post_id>",
+        "Direct links": "/(data|thumbnails)/...",
     }
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://nekohouse.su")
     DOMAIN: ClassVar[str] = "nekohouse"
     SERVICES = "fanbox", "fantia", "fantia_products", "subscribestar", "twitter"
-
-    async def fetch(self, scrape_item: ScrapeItem) -> None:
-        if "thumbnails" in scrape_item.url.parts:
-            return await self.handle_direct_link(scrape_item)
-        if "post" in scrape_item.url.parts:
-            return await self.post_w_no_api(scrape_item)
-        if any(x in scrape_item.url.parts for x in self.SERVICES):
-            return await self.profile_w_no_api(scrape_item)
-        if any(x in scrape_item.url.parts for x in ("posts", "discord")):
-            raise ValueError
-
-        await self.handle_direct_link(scrape_item)

--- a/tests/crawlers/test_cases/kemono.py
+++ b/tests/crawlers/test_cases/kemono.py
@@ -4,12 +4,53 @@ TEST_CASES = [
         "https://kemono.su/patreon/user/27174868/post/133667042",
         [
             {
-                "url": "https://kemono.su/data/0d/c3/0dc3ecec556918b882674c5dd63f8fa1867867157ce1ca675b0bf79e6b73fb04.jpg?f=Birthday_Kim.jpg",
+                "url": "https://kemono.cr/data/0d/c3/0dc3ecec556918b882674c5dd63f8fa1867867157ce1ca675b0bf79e6b73fb04.jpg?f=Birthday_Kim.jpg",
                 "filename": "Birthday_Kim.jpg",
-                "referer": "https://kemono.su/patreon/user/27174868/post/133667042",
+                "referer": "https://kemono.cr/patreon/user/27174868/post/133667042",
+                "download_folder": r"re:Manueillustrations \(Kemono\)",
                 "album_id": "27174868",
                 "datetime": 1752004344,
             }
         ],
-    )
+    ),
+    (
+        "https://kemono.cr/data/49/83/49830d8d281ad9a508f88b081b3a112aa4011a1af3bb2539f88f4e635edf98a1.png?f=june_Schedule.png",
+        [
+            {
+                "url": "https://kemono.cr/data/49/83/49830d8d281ad9a508f88b081b3a112aa4011a1af3bb2539f88f4e635edf98a1.png?f=june_Schedule.png",
+                "filename": "june_Schedule.png",
+                "referer": "https://kemono.cr/data/49/83/49830d8d281ad9a508f88b081b3a112aa4011a1af3bb2539f88f4e635edf98a1.png?f=june_Schedule.png",
+                "album_id": None,
+                "datetime": None,
+            },
+        ],
+    ),
+    (
+        "https://kemono.cr/discord/server/794379082535927828/921981855706796032",
+        [
+            {
+                "url": "https://kemono.cr/data/49/83/49830d8d281ad9a508f88b081b3a112aa4011a1af3bb2539f88f4e635edf98a1.png?f=june_Schedule.png",
+                "filename": "june_Schedule.png",
+                "referer": "https://kemono.cr/discord/server/794379082535927828/921981855706796032#1257906262025175090",
+                "download_folder": r"re:Schpicy-s server \[discord\] \(Kemono\)\/\#schedule",
+                "album_id": "794379082535927828",
+                "datetime": 1719996623,
+            },
+        ],
+        3,
+    ),
+    (
+        "https://kemono.su/patreon/user/16573132",
+        [
+            {
+                "url": "https://kemono.cr/data/01/1e/011e7a27eca93eba99ab223553d6079495a55c87106fa0e36efb8810048da92f.jpg?f=httpswww.patreon.commedia-uZ0FBQUFBQmdWWnhiV0xoYnpvV0Nnd0ZvMnM5UnkyTVF1LXd4MEpNYmVRWGNMNEZhUE1wWWJreVBqS1F2UzB3R2lYaXpDaXBWUy14M2l1WGtITWJBX0Q4ZDRoQzBtOG5nd3JIYThERTRWNDIxeUY4RHBXaERxWkRJNS1xRXRPS2lFM3pLSEVTSW5oNVRzeU9yc21SMmo5MkJrYXVXVzFCVUtRPT0",
+                "filename": "011e7a27eca93eba99ab223553d6079495a55c87106fa0e36efb8810048da92f.jpg",
+                "referer": "https://kemono.cr/patreon/user/16573132/post/42836761",
+                "download_folder": r"re:EUNSONGS \(Kemono\)",
+                "album_id": "16573132",
+                "datetime": 1602954002,
+            }
+        ],
+        212,
+    ),
 ]

--- a/tests/crawlers/test_cases/nekohouse.py
+++ b/tests/crawlers/test_cases/nekohouse.py
@@ -1,0 +1,42 @@
+DOMAIN = "nekohouse"
+TEST_CASES = [
+    (
+        "https://nekohouse.su/fanbox/user/705370/post/9605906",
+        [
+            {
+                "url": "https://nekohouse.su/data/33/7f/337f1f97e0414358092fe9de88046614e35aab417d030da820e4816e3cab3e42.jpg",
+                "filename": "337f1f97e0414358092fe9de88046614e35aab417d030da820e4816e3cab3e42.jpg",
+                "referer": "https://nekohouse.su/fanbox/user/705370/post/9605906",
+                "download_folder": r"re:shiratamaco \(Nekohouse\)",
+                "album_id": "705370",
+                "datetime": 1743063817,
+            },
+            {
+                "url": "https://nekohouse.su/data/ec/7b/ec7bf13520488ea9ed19e766eeac6033547e69eca88e395f12c9e503feaa71a5.jpg",
+                "filename": "ec7bf13520488ea9ed19e766eeac6033547e69eca88e395f12c9e503feaa71a5.jpg",
+                "referer": "https://nekohouse.su/fanbox/user/705370/post/9605906",
+                "album_id": "705370",
+                "datetime": 1743063817,
+            },
+            {
+                "url": "https://nekohouse.su/data/fa/66/fa66c78e0fefaa748baeee23dafc5392236b3a194aa0f2b3040dced30a617b7f.jpg",
+                "filename": "fa66c78e0fefaa748baeee23dafc5392236b3a194aa0f2b3040dced30a617b7f.jpg",
+                "referer": "https://nekohouse.su/fanbox/user/705370/post/9605906",
+                "album_id": "705370",
+                "datetime": 1743063817,
+            },
+        ],
+    ),
+    (
+        "https://nekohouse.su/thumbnail/data/33/7f/337f1f97e0414358092fe9de88046614e35aab417d030da820e4816e3cab3e42.jpg?type=preview",
+        [
+            {
+                "url": "https://nekohouse.su/data/33/7f/337f1f97e0414358092fe9de88046614e35aab417d030da820e4816e3cab3e42.jpg",
+                "filename": "337f1f97e0414358092fe9de88046614e35aab417d030da820e4816e3cab3e42.jpg",
+                "referer": "https://nekohouse.su/data/33/7f/337f1f97e0414358092fe9de88046614e35aab417d030da820e4816e3cab3e42.jpg",
+                "album_id": None,
+                "datetime": None,
+            },
+        ],
+    ),
+]


### PR DESCRIPTION
- Skip duplicate URLs while parsing text in posts
- Remove helper URL parse funcs. Match URLs exactly
- Add missing error_handling_wrapper for discord methods
- Add missing no API fallbacks for favorites
- Fix no API post scraping (nekohouse)
- Fix thumbnails being downloaded as is instead of full resolution
- Add tests
- Use default limiter for coomer
- Send new posts to the queue instead of awaiting them

## TODO
- [ ] Add tests for search
- [ ] Add tests for profiles w no API (nekohouse)