### PR TITLE
Fix tiktok profile scraping loop return

### DIFF
--- a/cyberdrop_dl/crawlers/tiktok.py
+++ b/cyberdrop_dl/crawlers/tiktok.py
@@ -91,7 +91,6 @@ class TikTokCrawler(Crawler):
                 if item.get("images"):
                     await self.handle_image_post(scrape_item, item)
                     continue
-                
                 if post_url.path.endswith("mp3"):
                     continue
 

--- a/cyberdrop_dl/crawlers/tiktok.py
+++ b/cyberdrop_dl/crawlers/tiktok.py
@@ -89,8 +89,9 @@ class TikTokCrawler(Crawler):
 
                 post_url = self.parse_url(item["play"], trim=False)
                 if item.get("images"):
-                    return await self.handle_image_post(scrape_item, item)
-
+                    await self.handle_image_post(scrape_item, item)
+                    continue
+                
                 if post_url.path.endswith("mp3"):
                     continue
 


### PR DESCRIPTION
## What's the problem?

Tiktok profile scraping returns exiting the loop when finding an image post, but I believe this is not intended, since we want to crawl all the videos/images of the profile, instead of leaving when we find one image post.

## What does this PR do?

Fix exiting the loop when finding an image post and letting it crawl the entire user profile.