### PR TITLE
fix: HLS subtitles downloads

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -193,7 +193,8 @@ class DownloadClient:
 
             await self.client_manager.check_http_status(resp, download=True)
 
-            _ = get_content_type(media_item.ext, resp.headers)
+            if not media_item.is_segment:
+                _ = get_content_type(media_item.ext, resp.headers)
 
             media_item.filesize = int(resp.headers.get("Content-Length", "0")) or None
             if not media_item.complete_file and not media_item.is_segment:

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -15,7 +15,7 @@ from videoprops import get_audio_properties, get_video_properties
 from cyberdrop_dl.constants import FILE_FORMATS
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, InvalidContentTypeError, SlowDownloadError
-from cyberdrop_dl.utils.logger import log
+from cyberdrop_dl.utils.logger import log, log_debug
 from cyberdrop_dl.utils.utilities import get_size_or_none
 
 if TYPE_CHECKING:
@@ -197,13 +197,17 @@ class DownloadClient:
                 _ = get_content_type(media_item.ext, resp.headers)
 
             media_item.filesize = int(resp.headers.get("Content-Length", "0")) or None
-            if not media_item.complete_file and not media_item.is_segment:
+            if not media_item.complete_file:
                 proceed, skip = await self.get_final_file_info(media_item, domain)
                 self.client_manager.check_content_length(resp.headers)
                 if skip:
+                    if media_item.is_segment:
+                        return True
                     self.manager.progress_manager.download_progress.add_skipped()
                     return False
                 if not proceed:
+                    if media_item.is_segment:
+                        return True
                     log(f"Skipping {media_item.url} as it has already been downloaded", 10)
                     self.manager.progress_manager.download_progress.add_previously_completed(False)
                     await self.process_completed(media_item, domain)
@@ -423,6 +427,9 @@ class DownloadClient:
         expected_size = media_item.filesize
         proceed = True
         skip = False
+
+        if not TYPE_CHECKING:
+            log = log_debug if media_item.is_segment else globals()["log"]
 
         while True:
             if expected_size:

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -177,7 +177,7 @@ class Downloader:
         self.update_queued_files()
         task_id = self.manager.progress_manager.file_progress.add_task(domain=self.domain, filename=media_item.filename)
         media_item.set_task_id(task_id)
-        video, audio, subtitles = await self._process_m3u8_rendition_group(media_item, m3u8_group)
+        video, audio, subtitles = await self._download_rendition_group(media_item, m3u8_group)
         if not subtitles and not audio:
             await asyncio.to_thread(video.rename, media_item.complete_file)
         else:
@@ -191,16 +191,12 @@ class Downloader:
         await self.client.handle_media_item_completion(media_item, downloaded=True)
         await self.finalize_download(media_item, downloaded=True)
 
-    async def _process_m3u8_rendition_group(
+    async def _download_rendition_group(
         self, media_item: MediaItem, m3u8_group: RenditionGroup
     ) -> tuple[Path, Path | None, Path | None]:
-        results: list[Path | None] = []
-        for media_type, m3u8 in zip(("video", "audio", "subtitles"), m3u8_group, strict=True):
-            if not m3u8:
-                results.append(None)
-                continue
-
-            download_folder = media_item.complete_file.with_suffix(".cdl_hls") / media_type
+        async def download(m3u8: M3U8):
+            assert m3u8.media_type
+            download_folder = media_item.complete_file.with_suffix(".cdl_hls") / m3u8.media_type
             items, tasks = self._make_hls_tasks(media_item, m3u8, download_folder)
             tasks_results = await asyncio.gather(*tasks)
             n_segmets = len(tasks_results)
@@ -211,17 +207,22 @@ class Downloader:
                 raise DownloadError("HLS Seg Error", msg, media_item)
 
             seg_paths = [item.complete_file for item in items if item.complete_file]
-            output = media_item.complete_file.with_suffix(f".{media_type}.ts")
+            output = media_item.complete_file.with_suffix(f".{m3u8.media_type}.ts")
             if n_segmets > 1:
                 ffmpeg_result = await ffmpeg.concat(seg_paths, output)
                 if not ffmpeg_result.success:
                     raise DownloadError("FFmpeg Concat Error", ffmpeg_result.stderr, media_item)
             else:
+                output = output.with_suffix(items[0].url.suffix)
                 await asyncio.to_thread(seg_paths[0].rename, output)
-            results.append(output)
+            return output
 
-        video, audio, subtitles = results
-        assert video
+        audio = subtitles = None
+        if m3u8_group.subtitle:
+            subtitles = await download(m3u8_group.subtitle)
+        if m3u8_group.audio:
+            audio = await download(m3u8_group.audio)
+        video = await download(m3u8_group.video)
         return video, audio, subtitles
 
     def _make_hls_tasks(
@@ -230,7 +231,7 @@ class Downloader:
         seg_media_items: list[MediaItem] = []
         padding = max(5, len(str(len(m3u8.segments))))
 
-        semaphore_hls = asyncio.Semaphore(10 if download_folder.name == "video" else 50)
+        semaphore_hls = asyncio.Semaphore(10 if m3u8.media_type == "video" else 50)
 
         def create_segments() -> Generator[HlsSegment]:
             for index, segment in enumerate(m3u8.segments, 1):

--- a/cyberdrop_dl/utils/m3u8.py
+++ b/cyberdrop_dl/utils/m3u8.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from enum import StrEnum
 from fractions import Fraction
 from functools import cached_property
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from m3u8 import M3U8 as _M3U8
 from m3u8 import Media, Playlist
@@ -192,13 +192,21 @@ class RenditionGroupDetails:
 
 
 class M3U8(_M3U8):
-    def __init__(self, content: str, base_uri: AbsoluteHttpURL | None = None) -> None:
+    def __init__(
+        self,
+        content: str,
+        base_uri: AbsoluteHttpURL | None = None,
+        media_type: Literal["video", "audio", "subtitles"] | None = None,
+    ) -> None:
         if base_uri and base_uri.suffix.casefold() == ".m3u8":
             base_uri = base_uri.parent
+        self.media_type: Literal["video", "audio", "subtitles"] | None = media_type
         super().__init__(content, base_uri=str(base_uri) if base_uri else None)
 
     def __repr__(self) -> str:
-        return f"M3U8(base_uri='{self.base_uri}',is_variant={self.is_variant})"
+        return (
+            f"{type(self)}(media_type={self.media_type!r}, base_uri={self.base_uri!r}, is_variant={self.is_variant!r})"
+        )
 
     @cached_property
     def total_duration(self) -> timedelta:


### PR DESCRIPTION
- Fix CDL not detecting previously downloaded HLS fragments
- Fix subtitle downloads always failing (content type check was failing because they are text)
- Do not try to merge subtitles, leave them as separate files
- Increase concurrent audio fragments downloads from 10 to 50