### PR TITLE
fix: handle shared folders with loose files (Yetishare)

### DIFF
--- a/cyberdrop_dl/crawlers/_yetishare.py
+++ b/cyberdrop_dl/crawlers/_yetishare.py
@@ -114,8 +114,9 @@ class YetiShareCrawler(Crawler, is_abc=True):
 
             for file in ajax_soup.select(Selector.FILES):
                 file_url = self.parse_url(css.get_attr(file, "dtfullurl"))
-                content_id = css.get_attr(file, "fileid")
+                content_id = int(css.get_attr(file, "fileid"))
                 new_scrape_item = scrape_item.create_child(file_url)
+                new_scrape_item.part_of_album = not is_shared
                 self.create_task(self._handle_content_id_task(new_scrape_item, content_id))
                 scrape_item.add_children()
 

--- a/tests/crawlers/test_cases/cyberfile.py
+++ b/tests/crawlers/test_cases/cyberfile.py
@@ -127,4 +127,17 @@ TEST_CASES = [
             }
         ],
     ),
+    (  # Shared folder w only 1 file should be "loose files"
+        "https://cyberfile.me/shared/2c96uzj717",
+        [
+            {
+                "url": r"re:\?download_token\=",
+                "filename": "Scene 1 From Its A Mommy Thing 14 - 1080p.mp4",
+                "referer": "https://cyberfile.me/7tko",
+                "download_folder": r"re:Loose Files \(Cyberfile\)",
+                "album_id": "2c96uzj717",
+                "datetime": 1710334967,
+            }
+        ],
+    ),
 ]


### PR DESCRIPTION
Files inside the root of a shared folder are loose files

Fixes this: https://github.com/jbsparrow/CyberDropDownloader/issues/1227#issuecomment-3231368956