### PR TITLE
ci: start testing in python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.11, 3.12, 3.13]
+        python-version: [3.11, 3.12, 3.13, 3.14]
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
python 3.14 is in alpha 4 right now.

Final release is expected to be out on 2025-10-07
https://peps.python.org/pep-0745/