### PR TITLE
feat: add `ignore_coomer_post_content` option

### DIFF
--- a/cyberdrop_dl/config/config_model.py
+++ b/cyberdrop_dl/config/config_model.py
@@ -160,6 +160,7 @@ class IgnoreOptions(BaseModel):
     exclude_videos: bool = False
     filename_regex_filter: NonEmptyStrOrNone = None
     ignore_coomer_ads: bool = False
+    ignore_coomer_post_content: bool = True
     only_hosts: ListNonEmptyStr = []
     skip_hosts: ListNonEmptyStr = []
     exclude_files_with_no_extension: bool = True

--- a/cyberdrop_dl/crawlers/coomer.py
+++ b/cyberdrop_dl/crawlers/coomer.py
@@ -4,12 +4,10 @@ from typing import TYPE_CHECKING, ClassVar
 
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 
-from .kemono import KemonoBaseCrawler, Post
+from .kemono import KemonoBaseCrawler
 
 if TYPE_CHECKING:
     from aiohttp_client_cache.response import AnyResponse
-
-    from cyberdrop_dl.data_structures.url_objects import ScrapeItem
 
 
 class CoomerCrawler(KemonoBaseCrawler):
@@ -32,10 +30,3 @@ class CoomerCrawler(KemonoBaseCrawler):
             return True
 
         self.register_cache_filter(self.PRIMARY_URL, check_coomer_page)
-
-    def _handle_post_content(self, scrape_item: ScrapeItem, post: Post) -> None:
-        """Handles the content of a post."""
-        if "#ad" in post.content and self.manager.config_manager.settings_data.ignore_options.ignore_coomer_ads:
-            return
-
-        return super()._handle_post_content(scrape_item, post)

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -245,7 +245,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         scrape_item.setup_as_profile("")
         if self.ignore_ads:
             user = scrape_item.url.parts[3]
-            self.log(f"[{self.FOLDER_DOMAIN}] filtering out all ad poss for {user}. This could take a while")
+            self.log(f"[{self.FOLDER_DOMAIN}] filtering out all ad posts for {user}. This could take a while")
             await self.__iter_user_posts(scrape_item, api_url.update_query(tag="ad"))
         await self.__iter_user_posts(scrape_item, api_url)
 
@@ -484,7 +484,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                 for post in (UserPost.model_validate(entry) for entry in posts):
                     post_web_url = self.parse_url(post.web_path_qs)
                     new_scrape_item = scrape_item.create_child(post_web_url)
-                    if (self.ignore_content and not self.ignore_ads) or post.content:
+                    if self.ignore_content or post.content:
                         self._handle_user_post(new_scrape_item, post)
                     else:
                         self.create_task(self.run(new_scrape_item))

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -488,6 +488,8 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                     new_scrape_item = scrape_item.create_child(post_web_url)
                     if self.ignore_content or post.content:
                         self._handle_user_post(new_scrape_item, post)
+                    elif self.ignore_ads and self.__has_ads(post):
+                        continue
                     else:
                         self.create_task(self.run(new_scrape_item))
                     scrape_item.add_children()

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -412,17 +412,19 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
                     if self.DOMAIN not in url.host:
                         yield url
 
+    def __has_ads(self, post: Post) -> bool:
+        if "#ad" in post.content or post.id in self.__ad_posts:
+            return True
+
+        ci_tags = {tag.casefold() for tag in post.tags}
+        if ci_tags.intersection({"ad", "#ad", "ads", "#ads"}):
+            return True
+
+        return False
+
     def __handle_post(self, scrape_item: ScrapeItem, post: Post) -> None:
-        if self.ignore_ads:
-            if post.id in self.__ad_posts:
-                return
-
-            if "#ad" in post.content:
-                return
-
-            ci_tags = {tag.casefold() for tag in post.tags}
-            if ci_tags.intersection({"ad", "#ad", "ads", "#ads"}):
-                return
+        if self.ignore_ads and self.__has_ads(post):
+            return
 
         files = (self.__make_file_url(file) for file in post.all_files)
 

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -412,7 +412,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             if "#ad" in post.content:
                 return
             ci_tags = {tag.casefold() for tag in post.tags}
-            if "ad" in ci_tags or "ads" in ci_tags:
+            if ci_tags.intersection({"ad", "#ad", "ads", "#ads"}):
                 return
 
         for file in post.all_files:

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -15,7 +15,7 @@ from cyberdrop_dl.crawlers.crawler import Crawler, auto_task_id
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import NoExtensionError, ScrapeError
 from cyberdrop_dl.models import AliasModel
-from cyberdrop_dl.models.validators import falsy_as_none
+from cyberdrop_dl.models.validators import falsy_as, falsy_as_none
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.dates import to_timestamp
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, remove_parts
@@ -76,6 +76,7 @@ class File(TypedDict):
 
 
 FileOrNone = Annotated[File | None, BeforeValidator(falsy_as_none)]
+Tags = Annotated[list[str], BeforeValidator(lambda x: falsy_as(x, []))]
 
 
 class Post(AliasModel):
@@ -85,7 +86,7 @@ class Post(AliasModel):
     attachments: list[File] = []  # noqa: RUF012
     published_or_added: datetime | None = Field(None, validation_alias=AliasChoices("published", "added"))
     date: int | None = None
-    tags: list[str] = []  # noqa: RUF012
+    tags: Tags = []  # noqa: RUF012
 
     # `Any` to skip validation, but these are `yarl.URL`. We generate them internally so no validation is needed
     soup_attachments: list[Any] = []  # noqa: RUF012

--- a/docs/reference/configuration-options/settings/ignore_options.md
+++ b/docs/reference/configuration-options/settings/ignore_options.md
@@ -58,7 +58,28 @@ Any download with a filename that matches this regex expression will be skipped
 | ------ | ------- |
 | `bool` | `false` |
 
-When this is set to `true`, the program will skip post marked as ads by models in coomer profiles.
+When this is set to `true`, CDL will skip posts marked as `#ad` by models.
+
+Despite the name, this option affects all kemono based sites (Nekohouse, Kemono and Coomer)
+
+{% hint style="warning" %}
+This requires making x50 more requests when downloading an entire profile. Only enable this option if you actually need it
+{% endhint %}
+
+## `ignore_coomer_post_content`
+
+| Type   | Default |
+| ------ | ------- |
+| `bool` | `true` |
+
+When this is set to `false`, CDL will scan the text inside each post for URLs and proccess them.
+
+Despite the name, this option affects all kemono based sites (Nekohouse, Kemono and Coomer)
+
+{% hint style="warning" %}
+This requires making x50 more requests when downloading an entire profile. Only enable this option if you actually need it
+{% endhint %}
+
 
 ## `only_hosts`
 

--- a/docs/reference/configuration-options/settings/ignore_options.md
+++ b/docs/reference/configuration-options/settings/ignore_options.md
@@ -62,8 +62,9 @@ When this is set to `true`, CDL will skip posts marked as `#ad` by models.
 
 Despite the name, this option affects all kemono based sites (Nekohouse, Kemono and Coomer)
 
-{% hint style="warning" %}
-This requires making x50 more requests when downloading an entire profile. Only enable this option if you actually need it
+{% hint style="info" %}
+This requires fetching all posts with the tag `#ad` first and them filter them out from the normal ones.
+This means at least 1 additional request per profile is needed, depending on how many ads the profile has.
 {% endhint %}
 
 ## `ignore_coomer_post_content`

--- a/docs/reference/configuration-options/settings/ignore_options.md
+++ b/docs/reference/configuration-options/settings/ignore_options.md
@@ -81,7 +81,6 @@ Despite the name, this option affects all kemono based sites (Nekohouse, Kemono 
 This requires making x50 more requests when downloading an entire profile. Only enable this option if you actually need it
 {% endhint %}
 
-
 ## `only_hosts`
 
 | Type                | Default | Additional Info                                                     |

--- a/tests/crawlers/test_cases/kemono.py
+++ b/tests/crawlers/test_cases/kemono.py
@@ -50,7 +50,7 @@ TEST_CASES = [
                 "datetime": 1602954002,
             }
         ],
-        212,
+        199,
     ),
     (
         "https://kemono.cr/posts?q=dandadan%20s2%20episode%208%20reaction",
@@ -60,6 +60,6 @@ TEST_CASES = [
                 "download_folder": r"re:dandadan s2 episode 8 reaction \[search\] \(Kemono\)",
             }
         ],
-        43,
+        41,
     ),
 ]


### PR DESCRIPTION
The new `/posts`  endpoint they added a few weeks back does not return the text content of the posts. 

This PR adds a config option to make a new request per post to get it.

It also modifies the `ignore_coomer_ads` option to work on any of the kemono based crawlers