### PR TITLE
fix: keep at least 1 reference for new file locks

### DIFF
--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -133,8 +133,9 @@ class FileLocksVault:
         log_debug(f"Checking lock for '{filename}'", 20)
         if filename not in self._locked_files:
             log_debug(f"Lock for '{filename}' does not exists", 20)
+            lock = asyncio.Lock()
+            self._locked_files[filename] = lock
 
-        self._locked_files[filename] = self._locked_files.get(filename, asyncio.Lock())
         async with self._locked_files[filename]:
             log_debug(f"Lock for '{filename}' acquired", 20)
             yield


### PR DESCRIPTION
If we don't, the lock may get garbage collected by the weak ref dict before we use it, which gets us a `keyError` on the `async with` line .