### PR TITLE
ci/cd: update start scripts for v8.0.0 release

### DIFF
--- a/scripts/release/start_linux.sh
+++ b/scripts/release/start_linux.sh
@@ -1,123 +1,42 @@
 #!/bin/sh
-
 # User defined variables
-
-PYTHON=""
-VENV_DIR=""
 COMMANDLINE_ARGS=""
 AUTO_UPDATE=true
-AUTO_UPDATE_PIP=true
-CDL_VERSION=">=7.0,<8.0"
 
-# Parse arguments
-HELP=false
-SKIP_UPDATE=false
-for arg in "$@"
-do
-    case "$arg" in
-        --no-update)
-            SKIP_UPDATE=true
-            ;;
-        -h|--help)
-            HELP=true
-            ;;
-    esac
-done
+# ----------------------------------------------------------
+PACKAGE_NAME="cyberdrop-dl-patched"
+PACKAGE_VERSION=">=8.0,<9.0"
 
-# Define help message
-HELP_TEXT=$(cat << EOF
+is_installed() {
+    command -v "$1" >/dev/null 2>&1
+}
 
-Usage:
-  $0 [OPTIONS]
+if ! is_installed uv; then
+    echo "uv not found, installing..."
 
-Options:
-  --no-update       Skip updating Cyberdrop-DL.
-  -h, --help        Show this help message and exit.
+    if is_installed curl; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    elif is_installed wget; then
+        wget -qO- https://astral.sh/uv/install.sh | sh
+    elif is_installed pip; then
+        pip install uv
+    else
+        echo "Error: Unable to install uv (curl, wget and pip not found)"
+        exit 1
+    fi
 
-Description:
-  This script sets up a virtual environment and runs Cyberdrop-DL.
-  By default, it ensures that Cyberdrop-DL is installed and up to date.
-
-EOF
-)
-# Display help message
-if [ "$HELP" = true ]; then
-    echo "$HELP_TEXT"
-    exit 0
-fi
-
-# Check the installed Python version
-MIN_PYTHON_VER="3.11"
-MAX_PYTHON_VER="3.14"
-
-if [ -z "$PYTHON" ]
-then
-    PYTHON=python3
-fi
-
-"$PYTHON" -c "
-import sys
-
-MIN_PYTHON_VER = tuple(map(int, '$MIN_PYTHON_VER'.split('.')))
-MAX_PYTHON_VER = tuple(map(int, '$MAX_PYTHON_VER'.split('.')))
-current_version = sys.version_info
-
-exit(0 if (current_version >= MIN_PYTHON_VER and current_version < MAX_PYTHON_VER) else 1)
-"
-
-if [ $? -ne 0 ]; then
-    "$PYTHON" -V
-    echo "Unsupported Python version installed. Needs version >= $MIN_PYTHON_VER and < $MAX_PYTHON_VER"
-    exit 1
-fi
-
-
-# Create and activate venv
-
-if [ -z "$VENV_DIR" ]
-then
-    VENV_DIR="${0%/*}/venv"
-fi
-
-if [ ! -f "${VENV_DIR}/bin/activate" ]
-then
-    echo Creating virtual environment
-    "$PYTHON" -m venv "${VENV_DIR}"
-    echo
-fi
-
-
-echo Attempting to start venv
-. "${VENV_DIR}/bin/activate"
-echo
-
-if [ "$AUTO_UPDATE_PIP" = true ]; then
-    echo Updating PIP
-    "$PYTHON" -m pip install --upgrade pip
-    echo
-fi
-
-pip uninstall -y -qq cyberdrop-dl
-# Ensure Cyberdrop-DL is installed
-if ! command -v cyberdrop-dl >/dev/null 2>&1; then
-    echo Cyberdrop-DL is not installed, installing...
-    pip install "cyberdrop-dl-patched${CDL_VERSION}"
-    echo
     if [ $? -ne 0 ]; then
-        echo "Failed to install Cyberdrop-DL."
+        echo "Error: Failed to install uv."
         exit 1
     fi
-    if ! command -v cyberdrop-dl >/dev/null 2>&1; then
-        echo Cyberdrop-DL was successfully installed, but could not be found in the virtual environment.
-        exit 1
-    fi
-else
-    if [ "$AUTO_UPDATE" = true ] && [ "$SKIP_UPDATE" = false ]; then
-        echo Updating Cyberdrop-DL...
-        pip install --upgrade "cyberdrop-dl-patched${CDL_VERSION}"
-        echo
-    fi
+    uv tool update-shell
 fi
 
+if [ "$AUTO_UPDATE" = true ] || ! is_installed "${PACKAGE_NAME}"; then
+    echo Installing / Updating ${PACKAGE_NAME}...
+    uv tool install --upgrade "${PACKAGE_NAME}${PACKAGE_VERSION}" || exit 1
+fi
 
-clear && cyberdrop-dl $COMMANDLINE_ARGS
+clear
+echo Starting ${PACKAGE_NAME}...
+uvx -p ">=3.12" "${PACKAGE_NAME}" $COMMANDLINE_ARGS

--- a/scripts/release/start_macOS.command
+++ b/scripts/release/start_macOS.command
@@ -1,123 +1,32 @@
 #!/bin/sh
-
 # User defined variables
-
-PYTHON=""
-VENV_DIR=""
 COMMANDLINE_ARGS=""
 AUTO_UPDATE=true
-AUTO_UPDATE_PIP=true
-CDL_VERSION=">=7.0,<8.0"
 
-# Parse arguments
-HELP=false
-SKIP_UPDATE=false
-for arg in "$@"
-do
-    case "$arg" in
-        --no-update)
-            SKIP_UPDATE=true
-            ;;
-        -h|--help)
-            HELP=true
-            ;;
-    esac
-done
+# ----------------------------------------------------------
+PACKAGE_NAME="cyberdrop-dl-patched"
+PACKAGE_VERSION=">=8.0,<9.0"
 
-# Define help message
-HELP_TEXT=$(cat << EOF
+is_installed() {
+    command -v "$1" >/dev/null 2>&1
+}
 
-Usage:
-  $0 [OPTIONS]
-
-Options:
-  --no-update       Skip updating Cyberdrop-DL.
-  -h, --help        Show this help message and exit.
-
-Description:
-  This script sets up a virtual environment and runs Cyberdrop-DL.
-  By default, it ensures that Cyberdrop-DL is installed and up to date.
-
-EOF
-)
-# Display help message
-if [ "$HELP" = true ]; then
-    echo "$HELP_TEXT"
-    exit 0
-fi
-
-# Check the installed Python version
-MIN_PYTHON_VER="3.11"
-MAX_PYTHON_VER="3.14"
-
-if [ -z "$PYTHON" ]
-then
-    PYTHON=python3
-fi
-
-"$PYTHON" -c "
-import sys
-
-MIN_PYTHON_VER = tuple(map(int, '$MIN_PYTHON_VER'.split('.')))
-MAX_PYTHON_VER = tuple(map(int, '$MAX_PYTHON_VER'.split('.')))
-current_version = sys.version_info
-
-exit(0 if (current_version >= MIN_PYTHON_VER and current_version < MAX_PYTHON_VER) else 1)
-"
-
-if [ $? -ne 0 ]; then
-    "$PYTHON" -V
-    echo "Unsupported Python version installed. Needs version >= $MIN_PYTHON_VER and < $MAX_PYTHON_VER"
-    exit 1
-fi
-
-
-# Create and activate venv
-
-if [ -z "$VENV_DIR" ]
-then
-    VENV_DIR="${0%/*}/venv"
-fi
-
-if [ ! -f "${VENV_DIR}/bin/activate" ]
-then
-    echo Creating virtual environment
-    "$PYTHON" -m venv "${VENV_DIR}"
-    echo
-fi
-
-
-echo Attempting to start venv
-. "${VENV_DIR}/bin/activate"
-echo
-
-if [ "$AUTO_UPDATE_PIP" = true ]; then
-    echo Updating PIP
-    "$PYTHON" -m pip install --upgrade pip
-    echo
-fi
-
-pip uninstall -y -qq cyberdrop-dl
-# Ensure Cyberdrop-DL is installed
-if ! command -v cyberdrop-dl >/dev/null 2>&1; then
-    echo Cyberdrop-DL is not installed, installing...
-    pip install "cyberdrop-dl-patched${CDL_VERSION}"
-    echo
+# curl is always preinstalled on macOS
+if ! is_installed uv; then
+    echo "uv not found, installing..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
     if [ $? -ne 0 ]; then
-        echo "Failed to install Cyberdrop-DL."
+        echo "Error: Failed to install uv."
         exit 1
     fi
-    if ! command -v cyberdrop-dl >/dev/null 2>&1; then
-        echo Cyberdrop-DL was successfully installed, but could not be found in the virtual environment.
-        exit 1
-    fi
-else
-    if [ "$AUTO_UPDATE" = true ] && [ "$SKIP_UPDATE" = false ]; then
-        echo Updating Cyberdrop-DL...
-        pip install --upgrade "cyberdrop-dl-patched${CDL_VERSION}"
-        echo
-    fi
+    uv tool update-shell
 fi
 
+if [ "$AUTO_UPDATE" = true ] || ! is_installed "${PACKAGE_NAME}"; then
+    echo Installing / Updating ${PACKAGE_NAME}...
+    uv tool install --upgrade "${PACKAGE_NAME}${PACKAGE_VERSION}" || exit 1
+fi
 
-clear && cyberdrop-dl $COMMANDLINE_ARGS
+clear
+echo Starting ${PACKAGE_NAME}...
+uvx -p ">=3.12" "${PACKAGE_NAME}" $COMMANDLINE_ARGS

--- a/scripts/release/start_windows.bat
+++ b/scripts/release/start_windows.bat
@@ -1,106 +1,50 @@
 @echo off
-setlocal enabledelayedexpansion
-
-rem User defined variables
-
-set "PYTHON="
-set "VENV_DIR="
+REM User defined variables
 set "COMMANDLINE_ARGS="
 set "AUTO_UPDATE=true"
-set "AUTO_UPDATE_PIP=true"
-set "CDL_VERSION=>=7.0,<8.0"
 
-rem Parse arguments
-set "HELP=false"
-set "SKIP_UPDATE=false"
-for %%a in (%*) do (
-    if "%%a"=="--no-update" (
-        set "SKIP_UPDATE=true"
-    ) else if "%%a"=="-h" (
-        set "HELP=true"
-    ) else if "%%a"=="--help" (
-        set "HELP=true"
-    )
-)
+REM ----------------------------------------------------------
+set "PACKAGE_NAME=cyberdrop-dl-patched"
+set "PACKAGE_VERSION=>=8.0,<9.0"
 
-if "%HELP%"=="true" goto :HELP
-
-rem Check the installed Python version
-chcp 65001 > nul
-set MIN_PYTHON_VER=3.11
-set MAX_PYTHON_VER=3.14
-if not defined PYTHON (set PYTHON=python)
-"%PYTHON%" -c "import sys; MIN_PYTHON_VER = tuple(map(int, '%MIN_PYTHON_VER%'.split('.'))); MAX_PYTHON_VER = tuple(map(int, '%MAX_PYTHON_VER%'.split('.'))); current_version = sys.version_info; exit(0 if (current_version >= MIN_PYTHON_VER and current_version < MAX_PYTHON_VER) else 1)"
-
-if %ERRORLEVEL% equ 1 (
-    "%PYTHON%" -V
-    echo Unsupported Python version installed. Needs version ^>=%MIN_PYTHON_VER% and ^<%MAX_PYTHON_VER%
-    pause
+if /i "%PROCESSOR_ARCHITECTURE%"=="x86" (
+    echo ERROR: 32-bit Windows is not supported.
     exit /b 1
 )
 
-rem Create and activate venv
-if not defined VENV_DIR (set "VENV_DIR=%~dp0venv")
-
-if not exist "%VENV_DIR%" (
-    mkdir "%VENV_DIR%"
-)
-
-if not exist "%VENV_DIR%\Scripts\activate.bat" (
-    echo Creating virtual environment
-    "%PYTHON%" -m venv "%VENV_DIR%"
-    echo:
-)
-
-echo Attempting to start venv
-call "%VENV_DIR%\Scripts\activate.bat"
-echo:
-
-if "%AUTO_UPDATE_PIP%" == "true" (
-  echo Updating pip...
-  python -m pip install --upgrade pip
-)
-
-pip uninstall -y -qq cyberdrop-dl
-rem Ensure Cyberdrop-DL is installed
-where cyberdrop-dl >nul 2>&1
-if %ERRORLEVEL% neq 0 (
-    echo Cyberdrop-DL is not installed, installing...
-    pip install "cyberdrop-dl-patched%CDL_VERSION%"
-    if %ERRORLEVEL% neq 0 (
-        echo Failed to install Cyberdrop-DL.
-        pause
+where uv >nul 2>&1
+if errorlevel 1 (
+    echo uv not found, installing...
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    if errorlevel 1 (
+        echo Error: Failed to install uv.
         exit /b 1
     )
-    where cyberdrop-dl >nul 2>&1
-    if %ERRORLEVEL% neq 0 (
-        echo Cyberdrop-DL was successfully installed, but could not be found in the virtual environment.
-        pause
-        exit /b 1
-    )
-) else (
-    if "%AUTO_UPDATE%"=="true" if "%SKIP_UPDATE%"=="false" (
-        echo Updating Cyberdrop-DL...
-        pip install --upgrade "cyberdrop-dl-patched%CDL_VERSION%"
-    )
+    uv tool update-shell
 )
 
+set "PACKAGE_INSTALLED=false"
+where %PACKAGE_NAME% >nul 2>&1
+if %errorlevel%==0 (
+    set "PACKAGE_INSTALLED=true"
+)
 
+if "%AUTO_UPDATE%"=="true" (
+    goto :INSTALL_OR_UPDATE
+)
+
+if "%PACKAGE_INSTALLED%"=="false" (
+    goto :INSTALL_OR_UPDATE
+)
+goto :RUN
+
+:INSTALL_OR_UPDATE
+echo Installing / Updating %PACKAGE_NAME%...
+uv tool install --upgrade "%PACKAGE_NAME%%PACKAGE_VERSION%"
+if errorlevel 1 exit /b 1
+
+:RUN
 cls
-cyberdrop-dl %COMMANDLINE_ARGS%
+echo Starting %PACKAGE_NAME%...
+uvx --managed-python -p ">=3.12" %PACKAGE_NAME% %COMMANDLINE_ARGS%
 pause
-
-:HELP
-echo.
-echo Usage:
-echo   %~nx0 [OPTIONS]
-echo.
-echo Options:
-echo   --no-update       Skip updating Cyberdrop-DL.
-echo   -h, --help        Show this help message and exit.
-echo.
-echo Description:
-echo   This script sets up a virtual environment and runs Cyberdrop-DL.
-echo   By default, it ensures that Cyberdrop-DL is installed and up to date.
-echo.
-exit /b 0


### PR DESCRIPTION
- Remove python version checks and manual env logic. Use `uv` to simplify scripts
- Drop 32bit support to use `curl-cffi` >=11.0
- Resolves #1113