### PR TITLE
fix: suppress wmi syntax warning

### DIFF
--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 
 def main() -> None:
@@ -7,6 +8,7 @@ def main() -> None:
 
 def run(args: tuple[str, ...] | None = None) -> str | int:
     try:
+        warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence.*")
         from cyberdrop_dl.director import Director
 
         director = Director(args)


### PR DESCRIPTION
`wmi` is used by `shadowcopy` which is used by `browsercookie3`.

They have an invalid docstring that creates a warning on python 3.12+

Upstream issue: https://github.com/tjguk/wmi/issues/32