### PR TITLE
refactor: always use GET for redirects

### DIFF
--- a/cyberdrop_dl/clients/scraper_client.py
+++ b/cyberdrop_dl/clients/scraper_client.py
@@ -35,7 +35,7 @@ class ScraperClient:
         self._max_html_stem_len = 245 - min_html_file_path_len
 
     @contextlib.asynccontextmanager
-    async def _limiter(self, domain: str):
+    async def _limiter(self, domain: str) -> AsyncGenerator[None]:
         with self.client_manager.request_context(domain):
             domain_limiter = self.client_manager.get_rate_limiter(domain)
             async with self.client_manager.global_rate_limiter, domain_limiter:

--- a/cyberdrop_dl/crawlers/_forum.py
+++ b/cyberdrop_dl/crawlers/_forum.py
@@ -243,7 +243,7 @@ class MessageBoardCrawler(Crawler, is_abc=True):
                 return await self.thread(scrape_item, thread)
             case ["goto" | "posts", _, *_]:
                 self.check_thread_recursion(scrape_item)
-                return await self.follow_redirect_w_get(scrape_item)
+                return await self.follow_redirect(scrape_item)
             case _:
                 raise ValueError
 
@@ -595,7 +595,7 @@ class HTMLMessageBoardCrawler(MessageBoardCrawler, is_abc=True):
         link = link or scrape_item.url
         slug = link.name or link.parent.name
         if slug.isdigit():
-            return await self.follow_redirect_w_head(scrape_item.create_new(link))
+            return await self.follow_redirect(scrape_item.create_new(link))
 
         await super().handle_internal_link(scrape_item, link)
 


### PR DESCRIPTION
from: https://github.com/jbsparrow/CyberDropDownloader/pull/1281#discussion_r2325436621

The new request method allow us to make a request without consuming it. That's means making a GET request has the same performance as a HEAD request.

Using GET allows to automatically follow all redirects until the final destination, which is what we want in most cases.