### PR TITLE
fix: incorrect hash being logged when deleting files

### DIFF
--- a/cyberdrop_dl/clients/hash_client.py
+++ b/cyberdrop_dl/clients/hash_client.py
@@ -187,10 +187,12 @@ class HashClient:
         except OSError as e:
             log(f"Unable to remove '{file}' ({hash_string}): {e}", 40)
         else:
-            if deleted:
-                msg = f"Removed new download '{file}' [{self._deleted_file_suffix}]. File hash matches with a previous download ({hash_string})"
-                log(msg, 10)
-                self.manager.progress_manager.hash_progress.add_removed_file()
+            if not deleted:
+                return
+
+            msg = f"Removed new download '{file}' [{self._deleted_file_suffix}]. File hash matches with a previous download ({hash_string})"
+            log(msg, 10)
+            self.manager.progress_manager.hash_progress.add_removed_file()
 
         finally:
             self._sem.release()

--- a/cyberdrop_dl/clients/hash_client.py
+++ b/cyberdrop_dl/clients/hash_client.py
@@ -190,7 +190,10 @@ class HashClient:
             if not deleted:
                 return
 
-            msg = f"Removed new download '{file}' [{self._deleted_file_suffix}]. File hash matches with a previous download ({hash_string})"
+            msg = (
+                f"Removed new download '{file}' [{self._deleted_file_suffix}]. "
+                f"File hash matches with a previous download ({hash_string})"
+            )
             log(msg, 10)
             self.manager.progress_manager.hash_progress.add_removed_file()
 

--- a/cyberdrop_dl/clients/hash_client.py
+++ b/cyberdrop_dl/clients/hash_client.py
@@ -168,12 +168,12 @@ class HashClient:
             try:
                 deleted = await delete_file(file, to_trash)
                 if deleted:
-                    msg = f"Removed new download '{file}' with hash {hash_value} [{suffix}]"
+                    msg = f"Removed new download '{file}' with hash xxh128:{hash_value} [{suffix}]"
                     log(msg, 10)
                     self.manager.progress_manager.hash_progress.add_removed_file()
 
             except OSError as e:
-                log(f"Unable to remove '{file}' with hash {hash_value}: {e}", 40)
+                log(f"Unable to remove '{file}' with hash xxh128:{hash_value}: {e}", 40)
             finally:
                 sem.release()
 


### PR DESCRIPTION
The UI will go too fast while deleting cause it was designed to only show 1 file at a time but now we process them asynchronously