### PR TITLE
fix: some exceptions not being logged

### DIFF
--- a/cyberdrop_dl/director.py
+++ b/cyberdrop_dl/director.py
@@ -15,15 +15,20 @@ from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 import browser_cookie3
 from pydantic import ValidationError
-from rich import print as rich_print
 
 from cyberdrop_dl import constants, env
-from cyberdrop_dl.exceptions import InvalidYamlError
 from cyberdrop_dl.managers.manager import Manager
 from cyberdrop_dl.scraper.scrape_mapper import ScrapeMapper
 from cyberdrop_dl.ui.program_ui import ProgramUI
 from cyberdrop_dl.utils.apprise import send_apprise_notifications
-from cyberdrop_dl.utils.logger import LogHandler, QueuedLogger, log, log_spacer, log_with_color
+from cyberdrop_dl.utils.logger import (
+    LogHandler,
+    QueuedLogger,
+    log,
+    log_spacer,
+    log_with_color,
+    startup_logger,
+)
 from cyberdrop_dl.utils.sorting import Sorter
 from cyberdrop_dl.utils.updates import check_latest_pypi
 from cyberdrop_dl.utils.utilities import check_partials_and_empty_folders
@@ -31,21 +36,10 @@ from cyberdrop_dl.utils.webhook import send_webhook_message
 from cyberdrop_dl.utils.yaml import handle_validation_error
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Generator
+    from collections.abc import Callable, Coroutine
 
 P = ParamSpec("P")
 R = TypeVar("R")
-
-startup_logger = logging.getLogger("cyberdrop_dl_startup")
-
-
-def new_startup_log_file() -> Path:
-    file = Path.cwd().joinpath("startup.log")
-    file.unlink(missing_ok=True)
-    return file
-
-
-STARTUP_LOGGER_FILE = new_startup_log_file()
 
 
 class ExitCode(IntEnum):
@@ -182,18 +176,16 @@ def _setup_debug_logger(manager: Manager) -> Path | None:
     settings_data.runtime_options.log_level = log_level
     debug_logger.setLevel(log_level)
     debug_log_file_path = Path(__file__).parents[1] / "cyberdrop_dl_debug.log"
-    with _startup_logging():
-        if env.DEBUG_LOG_FOLDER:
-            debug_log_folder = Path(env.DEBUG_LOG_FOLDER)
-            if not debug_log_folder.is_dir():
-                msg = "Value of env var 'CDL_DEBUG_LOG_FOLDER' is invalid."
-                msg += f" Folder '{debug_log_folder}' does not exists"
-                startup_logger.error(msg)
-                sys.exit(_C.ERROR)
-            date = datetime.now().strftime("%Y%m%d_%H%M%S")
-            debug_log_file_path = debug_log_folder / f"cyberdrop_dl_debug_{date}.log"
+    if env.DEBUG_LOG_FOLDER:
+        debug_log_folder = Path(env.DEBUG_LOG_FOLDER)
+        if not debug_log_folder.is_dir():
+            msg = "Value of env var 'CDL_DEBUG_LOG_FOLDER' is invalid."
+            msg += f" Folder '{debug_log_folder}' does not exists"
+            raise FileNotFoundError(None, msg, env.DEBUG_LOG_FOLDER)
+        date = datetime.now().strftime("%Y%m%d_%H%M%S")
+        debug_log_file_path = debug_log_folder / f"cyberdrop_dl_debug_{date}.log"
 
-        file_io = debug_log_file_path.open("w", encoding="utf8")
+    file_io = debug_log_file_path.open("w", encoding="utf8")
 
     file_handler = LogHandler(level=log_level, file=file_io, width=settings_data.logs.log_line_width, debug=True)
     queued_logger = QueuedLogger(manager, file_handler, "debug")
@@ -213,17 +205,16 @@ def _setup_debug_logger(manager: Manager) -> Path | None:
 def _setup_main_logger(manager: Manager, config_name: str) -> None:
     logger = logging.getLogger("cyberdrop_dl")
     queued_logger = manager.loggers.pop("main", None)
-    with _startup_logging():
-        if manager.multiconfig and queued_logger:
-            log(f"Picking new config: '{config_name}' ...", 20)
-            try:
-                manager.config_manager.change_config(config_name)
-                log(f"Changed config to '{config_name}'...", 20)
-            finally:
-                logger.removeHandler(queued_logger.handler)
-                queued_logger.stop()
+    if manager.multiconfig and queued_logger:
+        log(f"Picking new config: '{config_name}' ...", 20)
+        try:
+            manager.config_manager.change_config(config_name)
+            log(f"Changed config to '{config_name}'...", 20)
+        finally:
+            logger.removeHandler(queued_logger.handler)
+            queued_logger.stop()
 
-        file_io = manager.path_manager.main_log.open("w", encoding="utf8")
+    file_io = manager.path_manager.main_log.open("w", encoding="utf8")
 
     settings_data = manager.config_manager.settings_data
     log_level = settings_data.runtime_options.log_level
@@ -240,98 +231,34 @@ def _setup_main_logger(manager: Manager, config_name: str) -> None:
     logger.addHandler(queued_logger.handler)
 
 
-def _setup_startup_logger(*, first_time_setup: bool = False) -> None:
-    global STARTUP_LOGGER_FILE
-    if first_time_setup:
-        # Get startup logger again in case the CWD changed after the module was imported (for pytest)
-        STARTUP_LOGGER_FILE = new_startup_log_file()
-    _destroy_startup_logger()
-    startup_logger.setLevel(10)
-    console_handler = LogHandler(level=10)
-    startup_logger.addHandler(console_handler)
-
-    file_io = STARTUP_LOGGER_FILE.open("a", encoding="utf8")
-    file_handler = LogHandler(level=10, file=file_io, width=constants.DEFAULT_CONSOLE_WIDTH)
-    startup_logger.addHandler(file_handler)
-
-
-def _destroy_startup_logger(remove_all_handlers: bool = True) -> None:
-    handlers: list[LogHandler] = startup_logger.handlers  # type: ignore
-    for handler in handlers[:]:  # create copy
-        if not (handler.console._file or remove_all_handlers):
-            continue
-        if handler.console._file:
-            handler.console._file.close()
-        startup_logger.removeHandler(handler)
-        handler.close()
-
-    if STARTUP_LOGGER_FILE.is_file() and STARTUP_LOGGER_FILE.stat().st_size > 0:
-        return
-    STARTUP_LOGGER_FILE.unlink(missing_ok=True)
-
-
-@contextlib.contextmanager
-def _startup_logging(*, first_time_setup: bool = False) -> Generator:
-    exit_code = _C.ERROR
-    try:
-        _setup_startup_logger(first_time_setup=first_time_setup)
-        yield
-
-    except InvalidYamlError as e:
-        startup_logger.error(e.message)
-
-    except browser_cookie3.BrowserCookieError:
-        startup_logger.exception("")
-
-    except OSError as e:
-        startup_logger.exception(str(e))
-
-    except KeyboardInterrupt:
-        startup_logger.info("Exiting...")
-        exit_code = _C.OK
-
-    except Exception:
-        msg = "An error occurred, please report this to the developer with your logs file:"
-        startup_logger.exception(msg)
-
-    else:
-        return
-
-    finally:
-        _destroy_startup_logger()
-
-    sys.exit(exit_code)
-
-
 def _setup_manager(args: tuple[str, ...] | None = None) -> Manager:
     """Starts the program and returns the manager.
 
     This will also run the UI for the program
     After this function returns, the manager will be ready to use and scraping / downloading can begin.
     """
-    with _startup_logging(first_time_setup=True):
-        manager = Manager(args)
-        try:
-            manager.startup()
-            if manager.parsed_args.cli_only_args.multiconfig:
-                startup_logger.info("validating all configs, please wait...")
-                manager.validate_all_configs()
 
-            if not manager.parsed_args.cli_only_args.download:
-                ProgramUI(manager)
+    manager = Manager(args)
+    try:
+        manager.startup()
+        if manager.parsed_args.cli_only_args.multiconfig:
+            startup_logger.info("validating all configs, please wait...")
+            manager.validate_all_configs()
 
-        except ValidationError as e:
-            sources = {
-                "GlobalSettings": manager.config_manager.global_settings,
-                "ConfigSettings": manager.config_manager.settings,
-                "AuthSettings": manager.config_manager.authentication_settings,
-            }
+        if not manager.parsed_args.cli_only_args.download:
+            ProgramUI(manager)
 
-            file = sources.get(e.title)
-            handle_validation_error(e, file=file)
-            sys.exit(_C.ERROR)
+    except ValidationError as e:
+        file = {
+            "GlobalSettings": manager.config_manager.global_settings,
+            "ConfigSettings": manager.config_manager.settings,
+            "AuthSettings": manager.config_manager.authentication_settings,
+        }.get(e.title)
 
-        return manager
+        handle_validation_error(e, file=file)
+        sys.exit(_C.ERROR)
+
+    return manager
 
 
 class Director:
@@ -349,15 +276,17 @@ class Director:
     def run(self) -> int:
         return self._run()
 
+    async def async_run(self) -> None:
+        try:
+            await _run_manager(self.manager)
+        finally:
+            await self.manager.close()
+
     def _run(self) -> int:
         exit_code = _C.ERROR
         with contextlib.suppress(Exception):
-            try:
-                asyncio.run(_run_manager(self.manager))
-                exit_code = _C.OK
-            except KeyboardInterrupt:
-                rich_print("Trying to Exit ...")
-            finally:
-                asyncio.run(self.manager.close())
+            asyncio.run(self.async_run())
+            exit_code = _C.OK
+
         self.loop.close()
         return exit_code

--- a/cyberdrop_dl/director.py
+++ b/cyberdrop_dl/director.py
@@ -36,7 +36,7 @@ from cyberdrop_dl.utils.webhook import send_webhook_message
 from cyberdrop_dl.utils.yaml import handle_validation_error
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
+    from collections.abc import Callable, Coroutine, Sequence
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -231,7 +231,7 @@ def _setup_main_logger(manager: Manager, config_name: str) -> None:
     logger.addHandler(queued_logger.handler)
 
 
-def _setup_manager(args: tuple[str, ...] | None = None) -> Manager:
+def _setup_manager(args: Sequence[str] | None = None) -> Manager:
     """Starts the program and returns the manager.
 
     This will also run the UI for the program
@@ -264,7 +264,7 @@ def _setup_manager(args: tuple[str, ...] | None = None) -> Manager:
 class Director:
     """Creates a manager and runs it"""
 
-    def __init__(self, args: tuple[str, ...] | None = None) -> None:
+    def __init__(self, args: Sequence[str] | None = None) -> None:
         if os.name == "nt":
             asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
         self.loop = asyncio.new_event_loop()

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -1,19 +1,29 @@
 import sys
 import warnings
+from collections.abc import Sequence
+
+from cyberdrop_dl.director import Director
 
 
-def main() -> None:
+def main(args: Sequence[str] | None = None) -> None:
+    sys.exit(run(args))
+
+
+def run(args: Sequence[str] | None = None) -> str | int | None:
     from cyberdrop_dl.utils.logger import catch_exceptions
 
-    sys.exit(catch_exceptions(run)())
+    @catch_exceptions
+    def run_() -> int:
+        return _create_director(args).run()
+
+    return run_()
 
 
-def run(args: tuple[str, ...] | None = None) -> str | int | None:
+def _create_director(args: Sequence[str] | None = None) -> Director:
     warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence.*")
     from cyberdrop_dl.director import Director
 
-    director = Director(args)
-    return director.run()
+    return Director(args)
 
 
 if __name__ == "__main__":

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -3,18 +3,17 @@ import warnings
 
 
 def main() -> None:
-    sys.exit(run())
+    from cyberdrop_dl.utils.logger import catch_exceptions
+
+    sys.exit(catch_exceptions(run)())
 
 
-def run(args: tuple[str, ...] | None = None) -> str | int:
-    try:
-        warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence.*")
-        from cyberdrop_dl.director import Director
+def run(args: tuple[str, ...] | None = None) -> str | int | None:
+    warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence.*")
+    from cyberdrop_dl.director import Director
 
-        director = Director(args)
-        return director.run()
-    except KeyboardInterrupt:
-        return "\nKeyboardInterrupt"
+    director = Director(args)
+    return director.run()
 
 
 if __name__ == "__main__":

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -27,6 +27,7 @@ from cyberdrop_dl.utils.utilities import close_if_defined, get_system_informatio
 
 if TYPE_CHECKING:
     from asyncio import TaskGroup
+    from collections.abc import Sequence
 
     from cyberdrop_dl.scraper.scrape_mapper import ScrapeMapper
 
@@ -37,7 +38,10 @@ class AsyncioEvents(NamedTuple):
 
 
 class Manager:
-    def __init__(self, args: tuple[str, ...] | None = None) -> None:
+    def __init__(self, args: Sequence[str] | None = None) -> None:
+        if isinstance(args, str):
+            args = [args]
+
         self.parsed_args: ParsedArgs = field(init=False)
         self.cache_manager: CacheManager = CacheManager(self)
         self.path_manager: PathManager = field(init=False)


### PR DESCRIPTION
Make startup logger a global wrapper to catch every possible exception before the log file is ready

Fixes some critical exceptions not being logged