### PR TITLE
ci: add new ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,14 @@ unfixable = [
     "ERA"  # do not autoremove commented out code
 ]
 
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "parents"
+
+[tool.ruff.lint.flake8-type-checking]
+# Add quotes around type annotations, if doing so would allow
+# an import to be moved into a type-checking block.
+quote-annotations = true
+
 [tool.ruff.lint.per-file-ignores]
 "**/{tests,docs}/*" = [
     "E402",  # imports not at the top of the file.


### PR DESCRIPTION
<details>
<summary>Current violations</summary>

```shell
733	D102   	[ ] undocumented-public-method
424	D101   	[ ] undocumented-public-class
320	D103   	[ ] undocumented-public-function
254	S101   	[ ] assert
248	D100   	[ ] undocumented-public-module
231	COM812 	[*] missing-trailing-comma
112	E501   	[ ] line-too-long
 93	D415   	[ ] missing-terminal-punctuation
 87	PLR2004	[ ] magic-value-comparison
 77	RET503 	[ ] implicit-return
 69	SLF001 	[ ] private-member-access
 64	FBT001 	[ ] boolean-type-hint-positional-argument
 58	INP001 	[ ] implicit-namespace-package
 58	RET502 	[*] implicit-return-value
 56	D107   	[ ] undocumented-public-init
 54	ANN201 	[ ] missing-return-type-undocumented-public-function
 54	D105   	[ ] undocumented-magic-method
 54	FBT002 	[ ] boolean-default-value-positional-argument
 51	ANN202 	[ ] missing-return-type-private-function
 51	D202   	[*] blank-line-after-function
 47	ANN401 	[ ] any-type
 44	ANN003 	[ ] missing-type-kwargs
 43	FIX002 	[ ] line-contains-todo
 43	TD002  	[ ] missing-todo-author
 43	TD003  	[ ] missing-todo-link
 38	PGH003 	[ ] blanket-type-ignore
 34	TRY003 	[ ] raise-vanilla-args
 33	BLE001 	[ ] blind-except
 32	ANN002 	[ ] missing-type-args
 32	ERA001 	[ ] commented-out-code
 30	D209   	[*] new-line-after-last-paragraph
 24	ANN001 	[ ] missing-type-function-argument
 24	EM101  	[ ] raw-string-in-exception
 20	TC001  	[*] typing-only-first-party-import
 19	D104   	[ ] undocumented-public-package
 19	PLC0415	[ ] import-outside-top-level
 17	D212   	[*] multi-line-summary-first-line
 16	PLW2901	[ ] redefined-loop-name
 15	FBT003 	[ ] boolean-positional-value-in-call
 15	SIM108 	[ ] if-else-block-instead-of-if-exp
 13	A002   	[ ] builtin-argument-shadowing
 13	C901   	[ ] complex-structure
 12	A001   	[ ] builtin-variable-shadowing
 12	PT006  	[ ] pytest-parametrize-names-wrong-type
 12	PT007  	[ ] pytest-parametrize-values-wrong-type
 11	ARG002 	[ ] unused-method-argument
 11	DTZ005 	[ ] call-datetime-now-without-tzinfo
 11	EM102  	[ ] f-string-in-exception
 10	D205   	[ ] missing-blank-line-after-summary
 10	EXE002 	[ ] shebang-missing-executable-file
 10	SIM105 	[ ] suppressible-exception
 10	TC003  	[*] typing-only-standard-library-import
 10	TRY300 	[ ] try-consider-else
  9	N806   	[ ] non-lowercase-variable-in-function
  9	PLR0911	[ ] too-many-return-statements
  8	ANN204 	[ ] missing-return-type-special-method
  8	DTZ006 	[ ] call-datetime-fromtimestamp
  8	RET505 	[*] superfluous-else-return
  7	PLR0913	[ ] too-many-arguments
  7	RET504 	[ ] unnecessary-assign
  6	D403   	[*] first-word-uncapitalized
  6	D417   	[ ] undocumented-param
  6	PLW0603	[ ] global-statement
  6	PT014  	[ ] pytest-duplicate-parametrize-test-cases
  6	TC002  	[*] typing-only-third-party-import
  5	PT011  	[ ] pytest-raises-too-broad
  5	S311   	[ ] suspicious-non-cryptographic-random-usage
  5	SIM103 	[ ] needless-bool
  4	PT018  	[ ] pytest-composite-assertion
  4	PYI018 	[ ] unused-private-type-var
  4	S110   	[ ] try-except-pass
  4	S603   	[ ] subprocess-without-shell-equals-true
  4	SIM102 	[ ] collapsible-if
  4	TRY201 	[ ] verbose-raise
  3	ANN205 	[ ] missing-return-type-static-method
  3	ANN206 	[ ] missing-return-type-class-method
  3	ARG001 	[ ] unused-function-argument
  3	DTZ001 	[ ] call-datetime-without-tzinfo
  3	S112   	[ ] try-except-continue
  3	SIM300 	[*] yoda-conditions
  3	TRY203 	[ ] useless-try-except
  2	A004   	[ ] builtin-import-shadowing
  2	ARG003 	[ ] unused-class-method-argument
  2	D200   	[ ] unnecessary-multiline-docstring
  2	PERF401	[ ] manual-list-comprehension
  2	PLE0302	[ ] unexpected-special-method-signature
  2	PLR0402	[*] manual-from-import
  2	PLR0912	[ ] too-many-branches
  2	PT003  	[ ] pytest-extraneous-scope-function
  2	S607   	[ ] start-process-with-partial-path
  1	D210   	[ ] surrounding-whitespace
  1	D300   	[*] triple-single-quotes
  1	D405   	[*] non-capitalized-section-name
  1	D411   	[*] no-blank-line-before-section
  1	DTZ007 	[ ] call-datetime-strptime-without-zone
  1	FURB177	[ ] implicit-cwd
  1	ICN001 	[ ] unconventional-import-alias
  1	PIE790 	[*] unnecessary-placeholder
  1	PIE810 	[ ] multiple-starts-ends-with
  1	PLE0604	[ ] invalid-all-object
  1	PLR0915	[ ] too-many-statements
  1	PLR1733	[*] unnecessary-dict-index-lookup
  1	PLR2044	[*] empty-comment
  1	PLR5501	[*] collapsible-else-if
  1	PLW0602	[ ] global-variable-not-assigned
  1	PLW0642	[ ] self-or-cls-assignment
  1	PYI006 	[ ] bad-version-info-comparison
  1	PYI034 	[ ] non-self-return-type
  1	RET506 	[*] superfluous-else-raise
  1	RET507 	[*] superfluous-else-continue
  1	S105   	[ ] hardcoded-password-string
  1	S605   	[ ] start-process-with-a-shell
  1	SIM117 	[*] multiple-with-statements
  1	SIM118 	[ ] in-dict-keys
  1	SIM201 	[ ] negate-equal-op
  1	SIM910 	[*] dict-get-with-none-default
  1	TD004  	[ ] missing-todo-colon
  1	TRY004 	[ ] type-check-without-type-error
  1	TRY400 	[ ] error-instead-of-exception
  1	TRY401 	[ ] verbose-log-message
Found 4075 errors.
[*] 453 fixable with the `--fix` option (343 hidden fixes can be enabled with the `--unsafe-fixes` option).

```

</details>