### PR TITLE
refactor: add twitter/x to blocked domains

### DIFF
--- a/cyberdrop_dl/constants.py
+++ b/cyberdrop_dl/constants.py
@@ -59,22 +59,26 @@ class CustomHTTPStatus(IntEnum):
     DDOS_GUARD = 429
 
 
-BLOCKED_DOMAINS = (
-    "facebook",
-    "instagram",
-    "fbcdn",
-    "gfycat",
-    "ko-fi.com",
-    "paypal.me",
-    "amazon.com",
-    "throne.com",
-    "youtu.be",
-    "youtube.com",
-    "linktr.ee",
-    "beacons.page",
-    "beacons.ai",
-    "allmylinks.com",
-)
+class BlockedDomains:
+    partial_match = (
+        "facebook",
+        "twitter.com",
+        "instagram",
+        "fbcdn",
+        "gfycat",
+        "ko-fi.com",
+        "paypal.me",
+        "amazon.com",
+        "throne.com",
+        "youtu.be",
+        "youtube.com",
+        "linktr.ee",
+        "beacons.page",
+        "beacons.ai",
+        "allmylinks.com",
+        ".x.com",
+    )
+    exact_match = ("x.com",)
 
 
 DEFAULT_APP_STORAGE = Path("./AppData")

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Literal, Self
 import aiofiles
 from yarl import URL
 
-from cyberdrop_dl.constants import BLOCKED_DOMAINS, REGEX_LINKS
+from cyberdrop_dl.constants import REGEX_LINKS, BlockedDomains
 from cyberdrop_dl.crawlers import CRAWLERS
 from cyberdrop_dl.crawlers._chevereto import CheveretoCrawler
 from cyberdrop_dl.crawlers.crawler import Crawler, create_crawlers
@@ -291,7 +291,10 @@ class ScrapeMapper:
             return False
         _seen_urls.add(scrape_item.url)
 
-        if is_in_domain_list(scrape_item, BLOCKED_DOMAINS):
+        if (
+            is_in_domain_list(scrape_item, BlockedDomains.partial_match)
+            or scrape_item.url.host in BlockedDomains.exact_match
+        ):
             log(f"Skipping {scrape_item.url} as it is a blocked domain", 10)
             return False
 


### PR DESCRIPTION
Needs to be hardcoded as a special case because the domain `x.com` is too generic and could match several other sites using `--skip-hosts` option