### PR TITLE
feat: add support for exclude posts by date

### DIFF
--- a/cyberdrop_dl/config/config_model.py
+++ b/cyberdrop_dl/config/config_model.py
@@ -164,6 +164,8 @@ class IgnoreOptions(BaseModel):
     only_hosts: ListNonEmptyStr = []
     skip_hosts: ListNonEmptyStr = []
     exclude_files_with_no_extension: bool = True
+    exclude_posts_before: datetime | None = None
+    exclude_posts_after: datetime | None = None
 
     @field_validator("filename_regex_filter")
     @classmethod

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -21,6 +21,7 @@ from cyberdrop_dl.exceptions import (
     DurationError,
     ErrorLogMessage,
     InvalidContentTypeError,
+    RestrictedDateRangeError,
     RestrictedFiletypeError,
     TooManyCrawlerErrors,
 )
@@ -309,6 +310,8 @@ class Downloader:
             raise RestrictedFiletypeError(origin=media_item)
         if not self.manager.client_manager.pre_check_duration(media_item):
             raise DurationError(origin=media_item)
+        if not self.manager.client_manager.check_allowed_date_range(media_item):
+            raise RestrictedDateRangeError(origin=media_item)
 
     async def set_file_datetime(self, media_item: MediaItem, complete_file: Path) -> None:
         """Sets the file's datetime."""
@@ -432,6 +435,16 @@ class Downloader:
                 log(f"Download skip {media_item.url} due to ignore_extension config ({media_item.ext})", 10)
                 self.manager.progress_manager.download_progress.add_skipped()
                 self.attempt_task_removal(media_item)
+
+        except RestrictedDateRangeError:
+            timestamp_str = (
+                datetime.fromtimestamp(media_item.datetime).strftime("%Y-%m-%d %H:%M:%S")
+                if media_item.datetime
+                else "unknown date"
+            )
+            log(f"Download skip {media_item.url} due to exclude_posts_date config ({timestamp_str})", 10)
+            self.manager.progress_manager.download_progress.add_skipped()
+            self.attempt_task_removal(media_item)
 
         except (DownloadError, ClientResponseError, InvalidContentTypeError):
             raise

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -440,7 +440,7 @@ class Downloader:
             timestamp_str = (
                 datetime.fromtimestamp(media_item.datetime).strftime("%Y-%m-%d %H:%M:%S")
                 if media_item.datetime
-                else "unknown date"
+                else "Unknown date"
             )
             log(f"Download skip {media_item.url} due to exclude_posts_date config ({timestamp_str})", 10)
             self.manager.progress_manager.download_progress.add_skipped()

--- a/cyberdrop_dl/exceptions.py
+++ b/cyberdrop_dl/exceptions.py
@@ -222,6 +222,13 @@ class InvalidYamlError(CDLBaseError):
         super().__init__(ui_failure, message=msg, origin=file)
 
 
+class RestrictedDateRangeError(CDLBaseError):
+    def __init__(self, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
+        """This error will be thrown when the publication date of the media item is not allowed by config."""
+        ui_failure = "Restricted DateRange"
+        super().__init__(ui_failure, origin=origin)
+
+
 def create_error_msg(error: int | str) -> str:
     if isinstance(error, str):
         return error

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -6,6 +6,7 @@ import ssl
 import weakref
 from base64 import b64encode
 from collections import defaultdict
+from datetime import datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Literal, Self, overload
 
@@ -250,6 +251,19 @@ class ClientManager:
             return True
 
         return self.check_file_duration(media_item)
+
+    def check_allowed_date_range(self, media_item: MediaItem) -> bool:
+        """Checks if the file is published within the date range configured."""
+        if not media_item.datetime:
+            return True
+
+        ignore_options = self.manager.config_manager.settings_data.ignore_options
+        post_datetime = datetime.fromtimestamp(media_item.datetime)
+        if ignore_options.exclude_posts_before and post_datetime < ignore_options.exclude_posts_before:
+            return False
+        if ignore_options.exclude_posts_after and post_datetime > ignore_options.exclude_posts_after:
+            return False
+        return True
 
     def filter_cookies_by_word_in_domain(self, word: str) -> Iterable[tuple[str, BaseCookie[str]]]:
         """Yields pairs of `[domain, BaseCookie]` for every cookie with a domain that has `word` in it"""

--- a/docs/reference/cli-arguments.md
+++ b/docs/reference/cli-arguments.md
@@ -314,6 +314,8 @@ ignore_options:
   --only-hosts [ONLY_HOSTS ...]
   --skip-hosts [SKIP_HOSTS ...]
   --exclude-files-with-no-extension, --no-exclude-files-with-no-extension
+  --exclude-posts-before EXCLUDE_POSTS_BEFORE
+  --exclude-posts-after EXCLUDE_POSTS_AFTER
 
 logs:
   --download-error-urls DOWNLOAD_ERROR_URLS

--- a/docs/reference/configuration-options/settings/ignore_options.md
+++ b/docs/reference/configuration-options/settings/ignore_options.md
@@ -96,3 +96,19 @@ You can supply hosts that you'd like the program to exclusively scrape/download 
 | `list[NonEmptyStr]` | `[]`    | This is an [`AdditiveArg`](../special_setting_types.md#additiveargs) |
 
 You can supply hosts that you'd like the program to skip, to not scrape/download from them. This setting accepts any domain, even if they are no supported.
+
+## `exclude_posts_before`
+
+| Type                 | Default | Additional Info                                                    |
+| -------------------- | ------- | ------------------------------------------------------------------ |
+| `datetime` or `null` | `null`  | The `datetime` value should be in the `YYYY-MM-DD HH:MM:SS` format |
+
+When a valid datetime value is provided, this excludes all posts published before that particular datetime.
+
+## `exclude_posts_after`
+
+| Type                 | Default | Additional Info                                                    |
+| -------------------- | ------- | ------------------------------------------------------------------ |
+| `datetime` or `null` | `null`  | The `datetime` value should be in the `YYYY-MM-DD HH:MM:SS` format |
+
+When a valid datetime value is provided, this excludes all posts published after that particular datetime.


### PR DESCRIPTION
Implemented following configs in `ignore_options`
- exclude_posts_before : excludes posts published before this date (default value: null)
- exclude_posts_after : excludes posts published after this date (default value: null)

Fixes #1394 