### PR TITLE
fix: Duration Limit Skips Remain in Queue

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -277,6 +277,12 @@ class DownloadClient:
                     await asyncio.to_thread(media_item.complete_file.unlink)
                     await self.mark_incomplete(media_item, domain)
                     self.manager.progress_manager.download_progress.add_skipped()
+                    if media_item.task_id is not None:
+                        try:
+                            self.manager.progress_manager.file_progress.remove_task(media_item.task_id)
+                        except ValueError:
+                            pass
+                        media_item.set_task_id(None)
                     return False
                 await self.process_completed(media_item, domain)
                 await self.handle_media_item_completion(media_item, downloaded=True)

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -277,12 +277,6 @@ class DownloadClient:
                     await asyncio.to_thread(media_item.complete_file.unlink)
                     await self.mark_incomplete(media_item, domain)
                     self.manager.progress_manager.download_progress.add_skipped()
-                    if media_item.task_id is not None:
-                        try:
-                            self.manager.progress_manager.file_progress.remove_task(media_item.task_id)
-                        except ValueError:
-                            pass
-                        media_item.set_task_id(None)
                     return False
                 await self.process_completed(media_item, domain)
                 await self.handle_media_item_completion(media_item, downloaded=True)

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -427,7 +427,7 @@ class Downloader:
                     await self.set_file_datetime(media_item, media_item.complete_file)
                     self.manager.progress_manager.download_progress.add_completed()
                     log(f"Download finished: {media_item.url}", 20)
-                self.attempt_task_removal(media_item)
+            self.attempt_task_removal(media_item)
             return downloaded
 
         except RestrictedFiletypeError:

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -425,9 +425,9 @@ class Downloader:
                 await asyncio.to_thread(Path.chmod, media_item.complete_file, 0o666)
                 if not media_item.is_segment:
                     await self.set_file_datetime(media_item, media_item.complete_file)
-                    self.attempt_task_removal(media_item)
                     self.manager.progress_manager.download_progress.add_completed()
                     log(f"Download finished: {media_item.url}", 20)
+                self.attempt_task_removal(media_item)
             return downloaded
 
         except RestrictedFiletypeError:


### PR DESCRIPTION
This fixes files that were skipped for media duration limits remaining in the download queue.

Closes #1101. 