### PR TITLE
feat: add rumble support

### DIFF
--- a/cyberdrop_dl/constants.py
+++ b/cyberdrop_dl/constants.py
@@ -184,6 +184,8 @@ FILE_FORMATS = {
         ".md",
         ".nfo",
         ".txt",
+        ".vtt",
+        ".sub",
     },
     "7z": {
         ".7z",

--- a/cyberdrop_dl/crawlers/__init__.py
+++ b/cyberdrop_dl/crawlers/__init__.py
@@ -90,6 +90,7 @@ from .rule34vault import Rule34VaultCrawler
 from .rule34video import Rule34VideoCrawler
 from .rule34xxx import Rule34XXXCrawler
 from .rule34xyz import Rule34XYZCrawler
+from .rumble import RumbleCrawler
 from .safe_soul import SafeSoulCrawler
 from .saint import SaintCrawler
 from .scrolller import ScrolllerCrawler

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -856,7 +856,7 @@ class Crawler(ABC):
         counter = Counter()
         video_stem = Path(video_filename).stem
         for sub in subtitles:
-            link = self.parse_url(sub.url)
+            link = self.parse_url(sub.url) if isinstance(sub.url, str) else sub.url
             counter[sub.lang_code] += 1
             if (count := counter[sub.lang_code]) > 1:
                 suffix = f"{sub.lang_code}.{count}{link.suffix}"

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -377,7 +377,7 @@ class Crawler(ABC):
     ) -> None:
         """Finishes handling the file and hands it off to the downloader."""
         if not ext:
-            _, ext = filename.rsplit(".", 1)
+            ext = Path(filename).suffix
         if custom_filename:
             original_filename, filename = filename, custom_filename
         elif self.DOMAIN in ["cyberdrop"]:

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -7,6 +7,7 @@ import inspect
 import re
 import warnings
 from abc import ABC, abstractmethod
+from collections import Counter
 from dataclasses import dataclass, field
 from functools import partial, wraps
 from pathlib import Path
@@ -18,7 +19,7 @@ from yarl import URL
 
 from cyberdrop_dl import constants
 from cyberdrop_dl.clients.scraper_client import ScraperClient
-from cyberdrop_dl.data_structures.mediaprops import Resolution
+from cyberdrop_dl.data_structures.mediaprops import ISO639Subtitle, Resolution
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL, MediaItem, ScrapeItem, copy_signature
 from cyberdrop_dl.downloader.downloader import Downloader
 from cyberdrop_dl.exceptions import MaxChildrenError, NoExtensionError, ScrapeError
@@ -849,6 +850,30 @@ class Crawler(ABC):
 
         if newest := max(get_morsels_by_name(), key=lambda x: int(x["max-age"] or 0), default=None):
             return newest.value
+
+    @final
+    def handle_subs(self, scrape_item: ScrapeItem, video_filename: str, subtitles: Iterable[ISO639Subtitle]) -> None:
+        counter = Counter()
+        video_stem = Path(video_filename).stem
+        for sub in subtitles:
+            link = self.parse_url(sub.url)
+            counter[sub.lang_code] += 1
+            if (count := counter[sub.lang_code]) > 1:
+                suffix = f"{sub.lang_code}.{count}{link.suffix}"
+            else:
+                suffix = f"{sub.lang_code}{link.suffix}"
+
+            sub_name, ext = self.get_filename_and_ext(f"{video_stem}.{suffix}")
+            new_scrape_item = scrape_item.create_new(scrape_item.url.with_fragment(sub_name))
+            self.create_task(
+                self.handle_file(
+                    link,
+                    new_scrape_item,
+                    sub.name or link.name,
+                    ext,
+                    custom_filename=sub_name,
+                )
+            )
 
 
 def _make_scrape_mapper_keys(cls: type[Crawler] | Crawler) -> tuple[str, ...]:

--- a/cyberdrop_dl/crawlers/megacloud.py
+++ b/cyberdrop_dl/crawlers/megacloud.py
@@ -100,10 +100,9 @@ class MegaCloudCrawler(Crawler):
                 if track["kind"] != "captions":
                     continue
 
-                url: str = track["file"]
-                name = self.parse_url(url).name
+                url = self.parse_url(track["file"])
                 label: str = track["label"]
-                lang_code = _parse_lang_code(name, label)
+                lang_code = _parse_lang_code(url.name, label)
 
                 yield Subtitle(url, lang_code, label)
 

--- a/cyberdrop_dl/crawlers/megacloud.py
+++ b/cyberdrop_dl/crawlers/megacloud.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import dataclasses
 import re
-from collections import Counter
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import Crawler
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
+from cyberdrop_dl.data_structures.mediaprops import Subtitle
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.utils.utilities import error_handling_wrapper
@@ -19,20 +19,12 @@ _V3_SOURCES_URL = _PRIMARY_URL / "embed-2/v3/e-1/getSources"
 _HEADERS = {"Origin": str(_PRIMARY_URL), "Referer": str(_PRIMARY_URL) + "/"}
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
-class MegaCloudSubtitle:
-    label: str
-    lang_code: str
-    suffix: str
-    url: AbsoluteHttpURL
-
-
 @dataclasses.dataclass(slots=True)
 class MegaCloudVideo:
     id: str
     embed_url: AbsoluteHttpURL
     sources: tuple[AbsoluteHttpURL, ...]
-    subtitles: tuple[MegaCloudSubtitle, ...]
+    subtitles: tuple[Subtitle, ...]
     title: str = ""
 
 
@@ -42,7 +34,7 @@ _find_v3_client_key = re.compile(
 
 
 class MegaCloudCrawler(Crawler):
-    SUPPORTED_PATHS: ClassVar[dict[str, str]] = {
+    SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Embed v3": "/embed-2/v3",
     }
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = _PRIMARY_URL
@@ -69,7 +61,7 @@ class MegaCloudCrawler(Crawler):
         m3u8_url = video.sources[0]
         m3u8, info = await self.get_m3u8_from_playlist_url(m3u8_url, headers=_HEADERS)
         filename, ext = self.get_filename_and_ext(video.id + ".mp4")
-        custom_filename = self.create_custom_filename(
+        video_name = self.create_custom_filename(
             video.title or video.id, ext, file_id=video.id, resolution=info.resolution
         )
         self.create_task(
@@ -79,21 +71,11 @@ class MegaCloudCrawler(Crawler):
                 filename,
                 ext,
                 m3u8=m3u8,
-                custom_filename=custom_filename,
+                custom_filename=video_name,
             )
         )
-        video_stem = custom_filename.removesuffix(ext)
-        for sub in video.subtitles:
-            sub_name, ext = self.get_filename_and_ext(f"{video_stem}.{sub.suffix}")
-            self.create_task(
-                self.handle_file(
-                    sub.url,
-                    scrape_item,
-                    sub.label,
-                    ext,
-                    custom_filename=sub_name,
-                )
-            )
+
+        self.handle_subs(scrape_item, video_name, video.subtitles)
 
     async def _get_client_key(self: Crawler, embed_url: AbsoluteHttpURL) -> str:
         content = await self.request_text(embed_url, headers=_HEADERS)
@@ -114,21 +96,16 @@ class MegaCloudCrawler(Crawler):
             raise ScrapeError(403, "Video is encrypted")
 
         def parse_subs():
-            counter = Counter()
             for track in resp["tracks"]:
                 if track["kind"] != "captions":
                     continue
 
-                url = self.parse_url(track["file"])
+                url: str = track["file"]
+                name = self.parse_url(url).name
                 label: str = track["label"]
-                lang_code = _parse_lang_code(url.name, label)
-                counter[lang_code] += 1
-                if (count := counter[lang_code]) > 1:
-                    suffix = f"{lang_code}.{count}{url.suffix}"
-                else:
-                    suffix = f"{lang_code}{url.suffix}"
+                lang_code = _parse_lang_code(name, label)
 
-                yield MegaCloudSubtitle(label, lang_code, suffix, url)
+                yield Subtitle(url, lang_code, label)
 
         return MegaCloudVideo(
             id=video_id,

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
 import dataclasses
-from collections import Counter
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
-from cyberdrop_dl.data_structures.mediaprops import Resolution
+from cyberdrop_dl.data_structures.mediaprops import Resolution, Subtitle
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.utilities import error_handling_wrapper
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
 
 
@@ -56,22 +52,7 @@ class RumbleCrawler(Crawler):
         scrape_item.possible_datetime = self.parse_iso_date(video.upload_date)
         scrape_item.url = self.parse_url(video.url)
         self.create_task(self.handle_file(link, scrape_item, link.name, ext, custom_filename=custom_filename))
-        self._handle_subs(scrape_item, custom_filename, video.subtitles)
-
-    def _handle_subs(self, scrape_item: ScrapeItem, video_filename: str, subtitles: Iterable[Subtitle]) -> None:
-        counter = Counter()
-        video_stem = Path(video_filename).stem
-        for sub in subtitles:
-            link = self.parse_url(sub.url)
-            counter[sub.lang_code] += 1
-            if (count := counter[sub.lang_code]) > 1:
-                suffix = f"{sub.lang_code}.{count}{link.suffix}"
-            else:
-                suffix = f"{sub.lang_code}{link.suffix}"
-
-            sub_name, ext = self.get_filename_and_ext(f"{video_stem}.{suffix}")
-            new_scrape_item = scrape_item.create_new(scrape_item.url.with_fragment(sub_name))
-            self.create_task(self.handle_file(link, new_scrape_item, link.name, ext, custom_filename=sub_name))
+        self.handle_subs(scrape_item, custom_filename, video.subtitles)
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -87,11 +68,6 @@ class Format(NamedTuple):
     resolution: Resolution
     bitrate: int
     url: str
-
-
-class Subtitle(NamedTuple):
-    url: str
-    lang_code: str
 
 
 def _parse_video(video: dict[str, Any]) -> Video:

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -160,7 +160,7 @@ class Video:
     subtitles: tuple[Subtitle, ...]
 
     @staticmethod
-    def parse_formats(formats: dict[str, list[dict[str, Any]]]) -> Generator[Format]:
+    def parse_formats(formats: dict[str, list[dict[str, Any]] | dict[str, dict[str, Any]]]) -> Generator[Format]:
         for name, format_options in formats.items():
             if name in ("audio", "tar", "timeline"):
                 continue
@@ -168,13 +168,15 @@ class Video:
             if name not in ("hls", "mp4", "webm"):
                 raise ScrapeError(422, f"Unknown format type: {name} ()")
 
-            if isinstance(format_options, dict):
-                format_options = format_options.values()
+            if isinstance(format_options, list):
+                pairs = ((None, f) for f in format_options)
+            else:
+                pairs = format_options.items()
 
-            for format in format_options:
+            for height, format in pairs:
                 url = parse_url(format["url"])
                 meta = Metadata(**(format.get("meta") or {}))
-                res = Resolution(meta.w, meta.h) if meta.w and meta.h else Resolution.unknown()
+                res = Resolution(meta.w, meta.h) if meta.w and meta.h else Resolution.parse(height)
                 yield Format(res, name, meta.bitrate, meta.size, url)
 
     @staticmethod

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
+import itertools
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, override
 
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.data_structures.mediaprops import Resolution, Subtitle
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
-from cyberdrop_dl.exceptions import ScrapeError
-from cyberdrop_dl.utils import css
-from cyberdrop_dl.utils.utilities import error_handling_wrapper
+from cyberdrop_dl.exceptions import DownloadError, ScrapeError
+from cyberdrop_dl.utils import aio, css, m3u8
+from cyberdrop_dl.utils.utilities import error_handling_wrapper, parse_url
 
 if TYPE_CHECKING:
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
@@ -28,8 +29,36 @@ class RumbleCrawler(Crawler):
                 return await self.embed(scrape_item, video_id)
             case [slug] if slug.startswith("v") and slug.endswith(".html"):
                 return await self.video(scrape_item)
+            case ["c" | "user", user_name, "videos"]:
+                return await self.channel(scrape_item, user_name)
             case _:
                 raise ValueError
+
+    @classmethod
+    @override
+    def transform_url(cls, url: AbsoluteHttpURL) -> AbsoluteHttpURL:
+        match url.parts[1:]:
+            case [slug] if slug.startswith("v") and slug.endswith(".html"):
+                return url.with_query(None)
+            case ["c" | "user", _]:
+                return url / "videos"
+            case _:
+                return url
+
+    @error_handling_wrapper
+    async def channel(self, scrape_item: ScrapeItem, name: str) -> None:
+        scrape_item.setup_as_album(self.create_title(name))
+        init_page = int(scrape_item.url.query.get("page") or 1)
+        try:
+            for page in itertools.count(init_page):
+                soup = await self.request_soup(scrape_item.url.update_query(page=page))
+                for _, new_scrape_item in self.iter_children(scrape_item, soup, "a.videostream__link"):
+                    self.create_task(self.run(new_scrape_item))
+
+        except DownloadError as e:
+            if e.status == 404:
+                return
+            raise
 
     @error_handling_wrapper
     async def video(self, scrape_item: ScrapeItem) -> None:
@@ -43,58 +72,91 @@ class RumbleCrawler(Crawler):
     @error_handling_wrapper
     async def embed(self, scrape_item: ScrapeItem, embed_id: str) -> None:
         api_url = (self.PRIMARY_URL / "embedJS/u3").with_query(request="video", ver=2, v=embed_id)
-        video = _parse_video(await self.request_json(api_url))
-        link = self.parse_url(video.format.url)
-        _, ext = self.get_filename_and_ext(link.name)
-        video_name = self.create_custom_filename(video.title, ext, file_id=embed_id, resolution=video.format.resolution)
+        video = await self._parse_video(await self.request_json(api_url))
+        ext = ".mp4"
+        video_name = self.create_custom_filename(
+            video.title, ext, file_id=embed_id, resolution=video.best_format.resolution
+        )
         scrape_item.possible_datetime = self.parse_iso_date(video.upload_date)
-        scrape_item.url = self.parse_url(video.url)
-        self.create_task(self.handle_file(link, scrape_item, link.name, ext, custom_filename=video_name))
+        scrape_item.url = video.url
+        self.create_task(  # pyright: ignore[reportUnusedCallResult]
+            self.handle_file(
+                video.best_format.url,
+                scrape_item,
+                video.best_format.url.name,
+                ext,
+                custom_filename=video_name,
+                m3u8=video.best_format.m3u8,
+            )
+        )
         self.handle_subs(scrape_item, video_name, video.subtitles)
+
+    async def _parse_video(self, video: dict[str, Any]) -> Video:
+        if video.get("live"):
+            raise ScrapeError(422, "live videos are not supported")
+
+        formats = tuple(Video.parse_formats(video.get("ua") or {}))
+
+        async def resolve_m3u8(format: Format) -> Format:
+            if format.resolution != Resolution.unknown():
+                m3u8 = await self.get_m3u8_from_index_url(format.url)
+                return Format(format.resolution, "hls", 0, format.url, m3u8)
+
+            m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
+            return Format(info.resolution, "hls", 0, format.url, m3u8)
+
+        hls_formats = [f for f in formats if f.type == "hls"]
+        if hls_formats:
+            hls_formats = await aio.gather([resolve_m3u8(f) for f in hls_formats])
+
+        resolved_formats = *hls_formats, *(f for f in formats if f.type == "mp4")
+
+        return Video(
+            upload_date=video["pubDate"],
+            title=video["title"],
+            url=self.parse_url(video["l"]),
+            best_format=max(resolved_formats),
+            subtitles=tuple(Video.parse_subs(video.get("cc") or {})),
+        )
+
+
+@dataclasses.dataclass(slots=True, frozen=True, order=True)
+class Format:
+    resolution: Resolution
+    type: Literal["hls", "mp4"]  # mp4 > hls
+    bitrate: int
+    url: AbsoluteHttpURL
+    m3u8: m3u8.RenditionGroup | None = None
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class Video:
     upload_date: str
     title: str
-    url: str
-    format: Format
+    url: AbsoluteHttpURL
+    best_format: Format
     subtitles: tuple[Subtitle, ...]
 
-
-class Format(NamedTuple):
-    resolution: Resolution
-    bitrate: int
-    url: str
-
-
-def _parse_video(video: dict[str, Any]) -> Video:
-    if video.get("live"):
-        raise ScrapeError(422, "live videos are not supported")
-
-    formats: dict[str, dict[str, dict[str, Any]]] = video.get("ua") or {}
-    subs: dict[str, dict[str, str]] = video.get("cc") or {}
-
-    def parse_formats():
+    @staticmethod
+    def parse_formats(formats: dict[str, dict[str, dict[str, Any]]]):
         for name, format_options in formats.items():
-            if name in ("tar", "hls"):
+            if name not in ("hls", "mp4"):
                 continue
 
-            for format in format_options.values():
+            for res, format in format_options.items():
+                url = parse_url(format["url"])
+                if name == "hls":
+                    resolution = Resolution.parse(res) if res != "auto" else Resolution.unknown()
+                    yield Format(resolution, name, 0, url)
+                    continue
+
                 meta: dict[str, Any] = format["meta"]
                 resolution = Resolution(meta["w"], meta["h"])
-                yield Format(resolution, meta["bitrate"], format["url"])
+                yield Format(resolution, name, meta["bitrate"], url)
 
-    def parse_subs():
+    @staticmethod
+    def parse_subs(subs: dict[str, dict[str, str]]):
         for lang_code, sub in subs.items():
             if url := sub.get("path"):
                 name = sub.get("language")
                 yield Subtitle(url, lang_code, name)
-
-    return Video(
-        upload_date=video["pubDate"],
-        title=video["title"],
-        url=video["l"],
-        format=max(parse_formats()),
-        subtitles=tuple(parse_subs()),
-    )

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -144,7 +144,7 @@ class RumbleCrawler(Crawler):
         if best_format.m3u8:
             ext = ".mp4"
         else:
-            _, ext = self.get_filename_and_ext(video.url.name)
+            _, ext = self.get_filename_and_ext(best_format.url.name)
 
         video_name = self.create_custom_filename(video.title, ext, file_id=embed_id, resolution=best_format.resolution)
         scrape_item.possible_datetime = self.parse_iso_date(video.upload_date)
@@ -173,7 +173,7 @@ class RumbleCrawler(Crawler):
 
         return Video(
             upload_date=video["pubDate"],
-            title=BeautifulSoup(video["title"]).get_text(),
+            title=BeautifulSoup(video["title"], "html.parser").get_text(),
             url=self.parse_url(video["l"]),
             best_format=await self._get_best_format(formats),
             subtitles=tuple(subs),

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -14,7 +14,7 @@ from cyberdrop_dl.utils import aio, css, m3u8
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, parse_url
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterable
 
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
 
@@ -102,36 +102,45 @@ class RumbleCrawler(Crawler):
         if video.get("live"):
             raise ScrapeError(422, "live videos are not supported")
 
-        formats = tuple(Video.parse_formats(video.get("ua") or {}))
-        subs = tuple(Video.parse_subs(video.get("cc") or {}))
-
-        async def resolve_m3u8(format: Format) -> Format:
-            if format.resolution != Resolution.unknown():
-                m3u8 = await self.get_m3u8_from_index_url(format.url)
-                return Format(format.resolution, "hls", 0, format.url, m3u8)
-
-            m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
-            return Format(info.resolution, "hls", 0, format.url, m3u8)
-
-        hls_formats = [f for f in formats if f.type == "hls"]
-        if hls_formats:
-            hls_formats = await aio.gather([resolve_m3u8(f) for f in hls_formats])
-
-        resolved_formats = *hls_formats, *(f for f in formats if f.type == "mp4")
+        formats = Video.parse_formats(video.get("ua") or {})
+        subs = Video.parse_subs(video.get("cc") or {})
 
         return Video(
             upload_date=video["pubDate"],
             title=BeautifulSoup(video["title"]).get_text(),
             url=self.parse_url(video["l"]),
-            best_format=max(resolved_formats),
-            subtitles=subs,
+            best_format=await self._get_best_format(formats),
+            subtitles=tuple(subs),
         )
+
+    async def _get_best_format(self, formats: Iterable[Format]) -> Format:
+        hls_formats: list[Format] = []
+        other_formats: list[Format] = []
+
+        for f in formats:
+            group = hls_formats if f.type == "hls" else other_formats
+            group.append(f)
+
+        if hls_formats:
+            hls_formats = await aio.gather([self._resolve_m3u8(f) for f in hls_formats])
+
+        return max(*hls_formats, *other_formats)
+
+    async def _resolve_m3u8(self, format: Format) -> Format:
+        resolution = format.resolution
+        if resolution != Resolution.unknown():
+            m3u8 = await self.get_m3u8_from_index_url(format.url)
+        else:
+            m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
+            resolution = info.resolution
+
+        return Format(resolution, format.type, 0, format.url, m3u8)
 
 
 @dataclasses.dataclass(slots=True, frozen=True, order=True)
 class Format:
     resolution: Resolution
-    type: Literal["hls", "mp4"]  # mp4 > hls
+    type: Literal["hls", "mp4", "webm"]  # if resolution is the same, prefer: webm > mp4 > hls
     bitrate: int
     url: AbsoluteHttpURL
     m3u8: m3u8.RenditionGroup | None = None
@@ -148,8 +157,11 @@ class Video:
     @staticmethod
     def parse_formats(formats: dict[str, dict[str, dict[str, Any]]]) -> Generator[Format]:
         for name, format_options in formats.items():
-            if name not in ("hls", "mp4"):
+            if name in ("audio", "tar", "timeline"):
                 continue
+
+            if name not in ("hls", "mp4", "webm"):
+                raise ScrapeError(422, f"Unknown format type: {name} ()")
 
             for res, format in format_options.items():
                 url = parse_url(format["url"])

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -100,7 +100,7 @@ class RumbleCrawler(Crawler):
                 return await self.embed(scrape_item, video_id)
             case [slug] if slug.startswith("v") and slug.endswith(".html"):
                 return await self.video(scrape_item)
-            case ["c" | "user", user_name, "videos"]:
+            case ["c" | "user", user_name, *_]:
                 return await self.channel(scrape_item, user_name)
             case _:
                 raise ValueError
@@ -110,8 +110,6 @@ class RumbleCrawler(Crawler):
         match url.parts[1:]:
             case [slug] if slug.startswith("v") and slug.endswith(".html"):
                 return url.with_query(None)
-            case ["c" | "user", _]:
-                return url / "videos"
             case _:
                 return url
 

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import dataclasses
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
+
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
+from cyberdrop_dl.data_structures.mediaprops import Resolution
+from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
+from cyberdrop_dl.exceptions import ScrapeError
+from cyberdrop_dl.utils import css
+from cyberdrop_dl.utils.utilities import error_handling_wrapper
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from cyberdrop_dl.data_structures.url_objects import ScrapeItem
+
+
+class RumbleCrawler(Crawler):
+    SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
+        "Video": "<video_id>-<video-title>.html",
+        "Embed": "/embed/<video_id>",
+    }
+    PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://rumble.com")
+    DOMAIN: ClassVar[str] = "rumble"
+
+    async def fetch(self, scrape_item: ScrapeItem) -> None:
+        match scrape_item.url.parts[1:]:
+            case ["embed", video_id] if video_id.startswith("v"):
+                return await self.embed(scrape_item, video_id)
+            case [slug] if slug.startswith("v") and slug.endswith(".html"):
+                return await self.video(scrape_item)
+            case _:
+                raise ValueError
+
+    @error_handling_wrapper
+    async def video(self, scrape_item: ScrapeItem) -> None:
+        if await self.check_complete_from_referer(scrape_item):
+            return
+
+        soup = await self.request_soup(scrape_item.url)
+        embed_id = self.parse_url(css.get_json_ld_value(soup, "embedUrl")).name
+        await self.embed(scrape_item, embed_id)
+
+    @error_handling_wrapper
+    async def embed(self, scrape_item: ScrapeItem, embed_id: str) -> None:
+        api_url = (self.PRIMARY_URL / "embedJS/u3").with_query(request="video", ver=2, v=embed_id)
+        video = _parse_video(await self.request_json(api_url))
+        link = self.parse_url(video.format.url)
+        _, ext = self.get_filename_and_ext(link.name)
+        custom_filename = self.create_custom_filename(
+            video.title, ext, file_id=embed_id, resolution=video.format.resolution
+        )
+        scrape_item.possible_datetime = self.parse_iso_date(video.upload_date)
+        scrape_item.url = self.parse_url(video.url)
+        self.create_task(self.handle_file(link, scrape_item, link.name, ext, custom_filename=custom_filename))
+        self.handle_subs(scrape_item, custom_filename, video.subtitles)
+
+    def handle_subs(self, scrape_item: ScrapeItem, video_filename: str, subtitles: Iterable[Subtitle]) -> None:
+        counter = Counter()
+        video_stem = Path(video_filename).stem
+        for sub in subtitles:
+            link = self.parse_url(sub.url)
+            counter[sub.lang_code] += 1
+            if (count := counter[sub.lang_code]) > 1:
+                suffix = f"{sub.lang_code}.{count}{link.suffix}"
+            else:
+                suffix = f"{sub.lang_code}{link.suffix}"
+
+            sub_name, ext = self.get_filename_and_ext(f"{video_stem}.{suffix}")
+            self.create_task(self.handle_file(link, scrape_item, link.name, ext, custom_filename=sub_name))
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class Video:
+    upload_date: str
+    title: str
+    format: Format
+    subtitles: list[Subtitle]
+    url: str
+
+
+class Format(NamedTuple):
+    resolution: Resolution
+    bitrate: int
+    url: str
+
+
+class Subtitle(NamedTuple):
+    url: str
+    lang_code: str
+
+
+def _parse_video(video: dict[str, Any]) -> Video:
+    if video.get("live"):
+        raise ScrapeError(422, "live videos are not supported")
+
+    formats: dict[str, dict[str, dict[str, Any]]] = video.get("ua") or {}
+    subs: dict[str, dict[str, str]] = video.get("cc") or {}
+
+    def parse_formats():
+        for name, format_options in formats.items():
+            if name in ("tar", "hls"):
+                continue
+
+            for format in format_options.values():
+                meta: dict[str, Any] = format["meta"]
+                resolution = Resolution(meta["w"], meta["h"])
+                yield Format(resolution, meta["bitrate"], format["url"])
+
+    def parse_subs():
+        for lang_code, sub_info in subs.items():
+            if url := sub_info.get("path"):
+                yield Subtitle(url, lang_code)
+
+    return Video(
+        upload_date=video["pubDate"],
+        title=video["title"],
+        format=max(parse_formats()),
+        subtitles=list(parse_subs()),
+        url=video["l"],
+    )

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple
 
 from bs4 import BeautifulSoup
 
@@ -77,7 +77,11 @@ class RumbleCrawler(Crawler):
     @error_handling_wrapper
     async def embed(self, scrape_item: ScrapeItem, embed_id: str) -> None:
         video = await self._get_video_info(embed_id)
-        ext = ".mp4"
+        if video.best_format.m3u8:
+            ext = ".mp4"
+        else:
+            _, ext = self.get_filename_and_ext(video.url.name)
+
         video_name = self.create_custom_filename(
             video.title, ext, file_id=embed_id, resolution=video.best_format.resolution
         )
@@ -127,21 +131,22 @@ class RumbleCrawler(Crawler):
         return max(*hls_formats, *other_formats)
 
     async def _resolve_m3u8(self, format: Format) -> Format:
-        resolution = format.resolution
-        if resolution != Resolution.unknown():
-            m3u8 = await self.get_m3u8_from_index_url(format.url)
-        else:
-            m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
-            resolution = info.resolution
-
-        return Format(resolution, format.type, 0, format.url, m3u8)
+        m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
+        return format._replace(resolution=info.resolution, m3u8=m3u8)
 
 
-@dataclasses.dataclass(slots=True, frozen=True, order=True)
-class Format:
+class Metadata(NamedTuple):
+    bitrate: int = 0
+    size: int = 0
+    w: int = 0
+    h: int = 0
+
+
+class Format(NamedTuple):
     resolution: Resolution
     type: Literal["hls", "mp4", "webm"]  # if resolution is the same, prefer: webm > mp4 > hls
     bitrate: int
+    size: int
     url: AbsoluteHttpURL
     m3u8: m3u8.RenditionGroup | None = None
 
@@ -155,7 +160,7 @@ class Video:
     subtitles: tuple[Subtitle, ...]
 
     @staticmethod
-    def parse_formats(formats: dict[str, dict[str, dict[str, Any]]]) -> Generator[Format]:
+    def parse_formats(formats: dict[str, list[dict[str, Any]]]) -> Generator[Format]:
         for name, format_options in formats.items():
             if name in ("audio", "tar", "timeline"):
                 continue
@@ -163,16 +168,14 @@ class Video:
             if name not in ("hls", "mp4", "webm"):
                 raise ScrapeError(422, f"Unknown format type: {name} ()")
 
-            for res, format in format_options.items():
-                url = parse_url(format["url"])
-                if name == "hls":
-                    resolution = Resolution.parse(res) if res != "auto" else Resolution.unknown()
-                    yield Format(resolution, name, 0, url)
-                    continue
+            if isinstance(format_options, dict):
+                format_options = format_options.values()
 
-                meta: dict[str, Any] = format["meta"]
-                resolution = Resolution(meta["w"], meta["h"])
-                yield Format(resolution, name, meta["bitrate"], url)
+            for format in format_options:
+                url = parse_url(format["url"])
+                meta = Metadata(**(format.get("meta") or {}))
+                res = Resolution(meta.w, meta.h) if meta.w and meta.h else Resolution.unknown()
+                yield Format(res, name, meta.bitrate, meta.size, url)
 
     @staticmethod
     def parse_subs(subs: dict[str, dict[str, str]]) -> Generator[Subtitle]:

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -37,7 +37,7 @@ class RumbleCrawler(Crawler):
             return
 
         soup = await self.request_soup(scrape_item.url)
-        embed_id = self.parse_url(css.get_json_ld_value(soup, "embedUrl")).name
+        embed_id = self.parse_url(css.get_json_ld(soup)["embedUrl"]).name
         await self.embed(scrape_item, embed_id)
 
     @error_handling_wrapper
@@ -46,22 +46,20 @@ class RumbleCrawler(Crawler):
         video = _parse_video(await self.request_json(api_url))
         link = self.parse_url(video.format.url)
         _, ext = self.get_filename_and_ext(link.name)
-        custom_filename = self.create_custom_filename(
-            video.title, ext, file_id=embed_id, resolution=video.format.resolution
-        )
+        video_name = self.create_custom_filename(video.title, ext, file_id=embed_id, resolution=video.format.resolution)
         scrape_item.possible_datetime = self.parse_iso_date(video.upload_date)
         scrape_item.url = self.parse_url(video.url)
-        self.create_task(self.handle_file(link, scrape_item, link.name, ext, custom_filename=custom_filename))
-        self.handle_subs(scrape_item, custom_filename, video.subtitles)
+        self.create_task(self.handle_file(link, scrape_item, link.name, ext, custom_filename=video_name))
+        self.handle_subs(scrape_item, video_name, video.subtitles)
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class Video:
     upload_date: str
     title: str
-    format: Format
-    subtitles: list[Subtitle]
     url: str
+    format: Format
+    subtitles: tuple[Subtitle, ...]
 
 
 class Format(NamedTuple):
@@ -88,14 +86,15 @@ def _parse_video(video: dict[str, Any]) -> Video:
                 yield Format(resolution, meta["bitrate"], format["url"])
 
     def parse_subs():
-        for lang_code, sub_info in subs.items():
-            if url := sub_info.get("path"):
-                yield Subtitle(url, lang_code)
+        for lang_code, sub in subs.items():
+            if url := sub.get("path"):
+                name = sub.get("language")
+                yield Subtitle(url, lang_code, name)
 
     return Video(
         upload_date=video["pubDate"],
         title=video["title"],
-        format=max(parse_formats()),
-        subtitles=list(parse_subs()),
         url=video["l"],
+        format=max(parse_formats()),
+        subtitles=tuple(parse_subs()),
     )

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -64,7 +64,7 @@ class Video:
             try:
                 type_ = FormatType[type_.upper()]
             except KeyError:
-                raise ScrapeError(422, f"Video has an unknown format types: {type_}") from None
+                raise ScrapeError(422, f"Video has an unknown format type: {type_}") from None
 
             if isinstance(format_options, list):
                 pairs = ((None, f) for f in format_options)
@@ -199,7 +199,11 @@ class RumbleCrawler(Crawler):
 
         async def resolve_m3u8(format: Format) -> Format:
             m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
-            return format._replace(resolution=info.resolution, m3u8=m3u8)
+            return format._replace(
+                resolution=info.resolution,
+                m3u8=m3u8,
+                bitrate=info.stream_info.bandwidth or 0,
+            )
 
         if hls_formats:
             hls_formats = await aio.gather([resolve_m3u8(f) for f in hls_formats])

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple
-
-from bs4 import BeautifulSoup
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from cyberdrop_dl.compat import IntEnum
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
@@ -26,6 +24,12 @@ class LiveStatus(IntEnum):
     CURRENTLY_LIVE = 2
 
 
+class FormatType(IntEnum):
+    HLS = 1
+    WEBM = 2
+    MP4 = 3
+
+
 class Metadata(NamedTuple):
     bitrate: int = 0
     size: int = 0
@@ -35,9 +39,10 @@ class Metadata(NamedTuple):
 
 class Format(NamedTuple):
     resolution: Resolution
-    type: Literal["hls", "mp4", "webm"]  # if resolution is the same, prefer: webm > mp4 > hls
-    bitrate: int  # For hls formats with the same resolution, choose the bigger bitrate (this is 0 on mp4/webm)
-    size: int  # For mp4/webm formats with the same resolution, choose the bigger size (this is 0 on hls)
+    is_single_file: bool  # for formats with the same resolution, give priority to non hls
+    bitrate: int
+    size: int
+    type: FormatType  #  On formats where everything else is the same, choose mp4 over webm
     url: AbsoluteHttpURL
     m3u8: m3u8.RenditionGroup | None = None
 
@@ -56,32 +61,41 @@ class Video:
             if type_ in ("audio", "tar", "timeline"):
                 continue
 
-            if type_ not in ("hls", "mp4", "webm"):
-                raise ScrapeError(422, f"Video has unknown format types: {type_}")
+            try:
+                type_ = FormatType[type_.upper()]
+            except KeyError:
+                raise ScrapeError(422, f"Video has an unknown format types: {type_}") from None
 
             if isinstance(format_options, list):
                 pairs = ((None, f) for f in format_options)
             else:
                 pairs = format_options.items()
 
+            is_single_file = type_ is not FormatType.HLS
+
             for height, format in pairs:
                 url = parse_url(format["url"])
                 meta = Metadata(**(format.get("meta") or {}))
 
-                if height == "auto":
-                    resolution = Resolution.unknown()
-                elif meta.w and meta.h:
+                if meta.w and meta.h:
                     resolution = Resolution(meta.w, meta.h)
-                else:
+
+                elif height and height != "auto":
                     resolution = Resolution.parse(height)
-                yield Format(resolution, type_, meta.bitrate, meta.size, url)
+
+                else:
+                    resolution = Resolution.unknown()
+
+                yield Format(resolution, is_single_file, meta.bitrate, meta.size, type_, url)
 
     @staticmethod
     def parse_subs(subs: dict[str, dict[str, str]]) -> Generator[Subtitle]:
-        for lang_code, sub in subs.items():
-            if url := sub.get("path"):
-                name = sub.get("language")
-                yield Subtitle(url, lang_code.replace("-auto", ".auto"), name)
+        for code, sub in subs.items():
+            yield Subtitle(
+                url=sub["path"],
+                lang_code=code.replace("-auto", ".auto"),
+                name=sub.get("language"),
+            )
 
 
 class RumbleCrawler(Crawler):
@@ -153,7 +167,7 @@ class RumbleCrawler(Crawler):
             self.handle_file(
                 best_format.url,
                 scrape_item,
-                best_format.url.name,
+                f"{video.title}{ext}",
                 ext,
                 custom_filename=video_name,
                 m3u8=best_format.m3u8,
@@ -173,7 +187,7 @@ class RumbleCrawler(Crawler):
 
         return Video(
             upload_date=video["pubDate"],
-            title=BeautifulSoup(video["title"], "html.parser").get_text(),
+            title=css.unescape(video["title"]),
             url=self.parse_url(video["l"]),
             best_format=await self._get_best_format(formats),
             subtitles=tuple(subs),
@@ -181,7 +195,7 @@ class RumbleCrawler(Crawler):
 
     async def _get_best_format(self, formats: Iterable[Format]) -> Format:
         hls_formats: list[Format] = []
-        other_formats: list[Format] = [fmt for fmt in formats if fmt.type != "hls" or hls_formats.append(fmt)]
+        other_formats: list[Format] = [fmt for fmt in formats if fmt.is_single_file or hls_formats.append(fmt)]
 
         async def resolve_m3u8(format: Format) -> Format:
             m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
@@ -190,4 +204,4 @@ class RumbleCrawler(Crawler):
         if hls_formats:
             hls_formats = await aio.gather([resolve_m3u8(f) for f in hls_formats])
 
-        return max(*hls_formats, *other_formats)
+        return max((*hls_formats, *other_formats))

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple
 
 from bs4 import BeautifulSoup
 
+from cyberdrop_dl.compat import IntEnum
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.data_structures.mediaprops import Resolution, Subtitle
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
@@ -17,6 +18,64 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
 
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
+
+
+class LiveStatus(IntEnum):
+    NOT_LIVE = 0
+    LIVE_ENDED = 1
+    CURRENTLY_LIVE = 2
+
+
+class Metadata(NamedTuple):
+    bitrate: int = 0
+    size: int = 0
+    w: int = 0
+    h: int = 0
+
+
+class Format(NamedTuple):
+    resolution: Resolution
+    type: Literal["hls", "mp4", "webm"]  # if resolution is the same, prefer: webm > mp4 > hls
+    bitrate: int  # For hls formats with the same resolution, choose the bigger bitrate (this is 0 on mp4s)
+    size: int  # For mp4 formats with the same resolution, choose the bigger size (this is 0 on hls)
+    url: AbsoluteHttpURL
+    m3u8: m3u8.RenditionGroup | None = None
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class Video:
+    title: str
+    upload_date: str
+    url: AbsoluteHttpURL
+    best_format: Format
+    subtitles: tuple[Subtitle, ...]
+
+    @staticmethod
+    def parse_formats(formats: dict[str, list[dict[str, Any]] | dict[str, dict[str, Any]]]) -> Generator[Format]:
+        for name, format_options in formats.items():
+            if name in ("audio", "tar", "timeline"):
+                continue
+
+            if name not in ("hls", "mp4", "webm"):
+                raise ScrapeError(422, f"Video has unknown format types: {name}")
+
+            if isinstance(format_options, list):
+                pairs = ((None, f) for f in format_options)
+            else:
+                pairs = format_options.items()
+
+            for height, format in pairs:
+                url = parse_url(format["url"])
+                meta = Metadata(**(format.get("meta") or {}))
+                res = Resolution(meta.w, meta.h) if meta.w and meta.h else Resolution.parse(height)
+                yield Format(res, name, meta.bitrate, meta.size, url)
+
+    @staticmethod
+    def parse_subs(subs: dict[str, dict[str, str]]) -> Generator[Subtitle]:
+        for lang_code, sub in subs.items():
+            if url := sub.get("path"):
+                name = sub.get("language")
+                yield Subtitle(url, lang_code.replace("-auto", ".auto"), name)
 
 
 class RumbleCrawler(Crawler):
@@ -77,24 +136,23 @@ class RumbleCrawler(Crawler):
     @error_handling_wrapper
     async def embed(self, scrape_item: ScrapeItem, embed_id: str) -> None:
         video = await self._get_video_info(embed_id)
-        if video.best_format.m3u8:
+        best_format = video.best_format
+        if best_format.m3u8:
             ext = ".mp4"
         else:
             _, ext = self.get_filename_and_ext(video.url.name)
 
-        video_name = self.create_custom_filename(
-            video.title, ext, file_id=embed_id, resolution=video.best_format.resolution
-        )
+        video_name = self.create_custom_filename(video.title, ext, file_id=embed_id, resolution=best_format.resolution)
         scrape_item.possible_datetime = self.parse_iso_date(video.upload_date)
         scrape_item.url = video.url
         self.create_task(
             self.handle_file(
-                video.best_format.url,
+                best_format.url,
                 scrape_item,
-                video.best_format.url.name,
+                best_format.url.name,
                 ext,
                 custom_filename=video_name,
-                m3u8=video.best_format.m3u8,
+                m3u8=best_format.m3u8,
             )
         )
         self.handle_subs(scrape_item, video_name, video.subtitles)
@@ -103,7 +161,7 @@ class RumbleCrawler(Crawler):
         api_url = (self.PRIMARY_URL / "embedJS/u3").with_query(request="video", ver=2, v=embed_id)
         video: dict[str, Any] = await self.request_json(api_url)
 
-        if video.get("live"):
+        if video.get("live") == LiveStatus.CURRENTLY_LIVE:
             raise ScrapeError(422, "live videos are not supported")
 
         formats = Video.parse_formats(video.get("ua") or {})
@@ -119,69 +177,13 @@ class RumbleCrawler(Crawler):
 
     async def _get_best_format(self, formats: Iterable[Format]) -> Format:
         hls_formats: list[Format] = []
-        other_formats: list[Format] = []
+        other_formats: list[Format] = [fmt for fmt in formats if fmt.type != "hls" or hls_formats.append(fmt)]
 
-        for f in formats:
-            group = hls_formats if f.type == "hls" else other_formats
-            group.append(f)
+        async def resolve_m3u8(format: Format) -> Format:
+            m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
+            return format._replace(resolution=info.resolution, m3u8=m3u8)
 
         if hls_formats:
-            hls_formats = await aio.gather([self._resolve_m3u8(f) for f in hls_formats])
+            hls_formats = await aio.gather([resolve_m3u8(f) for f in hls_formats])
 
         return max(*hls_formats, *other_formats)
-
-    async def _resolve_m3u8(self, format: Format) -> Format:
-        m3u8, info = await self.get_m3u8_from_playlist_url(format.url)
-        return format._replace(resolution=info.resolution, m3u8=m3u8)
-
-
-class Metadata(NamedTuple):
-    bitrate: int = 0
-    size: int = 0
-    w: int = 0
-    h: int = 0
-
-
-class Format(NamedTuple):
-    resolution: Resolution
-    type: Literal["hls", "mp4", "webm"]  # if resolution is the same, prefer: webm > mp4 > hls
-    bitrate: int
-    size: int
-    url: AbsoluteHttpURL
-    m3u8: m3u8.RenditionGroup | None = None
-
-
-@dataclasses.dataclass(slots=True, frozen=True)
-class Video:
-    title: str
-    upload_date: str
-    url: AbsoluteHttpURL
-    best_format: Format
-    subtitles: tuple[Subtitle, ...]
-
-    @staticmethod
-    def parse_formats(formats: dict[str, list[dict[str, Any]] | dict[str, dict[str, Any]]]) -> Generator[Format]:
-        for name, format_options in formats.items():
-            if name in ("audio", "tar", "timeline"):
-                continue
-
-            if name not in ("hls", "mp4", "webm"):
-                raise ScrapeError(422, f"Unknown format type: {name} ()")
-
-            if isinstance(format_options, list):
-                pairs = ((None, f) for f in format_options)
-            else:
-                pairs = format_options.items()
-
-            for height, format in pairs:
-                url = parse_url(format["url"])
-                meta = Metadata(**(format.get("meta") or {}))
-                res = Resolution(meta.w, meta.h) if meta.w and meta.h else Resolution.parse(height)
-                yield Format(res, name, meta.bitrate, meta.size, url)
-
-    @staticmethod
-    def parse_subs(subs: dict[str, dict[str, str]]) -> Generator[Subtitle]:
-        for lang_code, sub in subs.items():
-            if url := sub.get("path"):
-                name = sub.get("language")
-                yield Subtitle(url, lang_code.removesuffix("-auto"), name)

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -56,9 +56,9 @@ class RumbleCrawler(Crawler):
         scrape_item.possible_datetime = self.parse_iso_date(video.upload_date)
         scrape_item.url = self.parse_url(video.url)
         self.create_task(self.handle_file(link, scrape_item, link.name, ext, custom_filename=custom_filename))
-        self.handle_subs(scrape_item, custom_filename, video.subtitles)
+        self._handle_subs(scrape_item, custom_filename, video.subtitles)
 
-    def handle_subs(self, scrape_item: ScrapeItem, video_filename: str, subtitles: Iterable[Subtitle]) -> None:
+    def _handle_subs(self, scrape_item: ScrapeItem, video_filename: str, subtitles: Iterable[Subtitle]) -> None:
         counter = Counter()
         video_stem = Path(video_filename).stem
         for sub in subtitles:
@@ -70,7 +70,8 @@ class RumbleCrawler(Crawler):
                 suffix = f"{sub.lang_code}{link.suffix}"
 
             sub_name, ext = self.get_filename_and_ext(f"{video_stem}.{suffix}")
-            self.create_task(self.handle_file(link, scrape_item, link.name, ext, custom_filename=sub_name))
+            new_scrape_item = scrape_item.create_new(scrape_item.url.with_fragment(sub_name))
+            self.create_task(self.handle_file(link, new_scrape_item, link.name, ext, custom_filename=sub_name))
 
 
 @dataclasses.dataclass(slots=True, frozen=True)

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -36,8 +36,8 @@ class Metadata(NamedTuple):
 class Format(NamedTuple):
     resolution: Resolution
     type: Literal["hls", "mp4", "webm"]  # if resolution is the same, prefer: webm > mp4 > hls
-    bitrate: int  # For hls formats with the same resolution, choose the bigger bitrate (this is 0 on mp4s)
-    size: int  # For mp4 formats with the same resolution, choose the bigger size (this is 0 on hls)
+    bitrate: int  # For hls formats with the same resolution, choose the bigger bitrate (this is 0 on mp4/webm)
+    size: int  # For mp4/webm formats with the same resolution, choose the bigger size (this is 0 on hls)
     url: AbsoluteHttpURL
     m3u8: m3u8.RenditionGroup | None = None
 
@@ -52,12 +52,12 @@ class Video:
 
     @staticmethod
     def parse_formats(formats: dict[str, list[dict[str, Any]] | dict[str, dict[str, Any]]]) -> Generator[Format]:
-        for name, format_options in formats.items():
-            if name in ("audio", "tar", "timeline"):
+        for type_, format_options in formats.items():
+            if type_ in ("audio", "tar", "timeline"):
                 continue
 
-            if name not in ("hls", "mp4", "webm"):
-                raise ScrapeError(422, f"Video has unknown format types: {name}")
+            if type_ not in ("hls", "mp4", "webm"):
+                raise ScrapeError(422, f"Video has unknown format types: {type_}")
 
             if isinstance(format_options, list):
                 pairs = ((None, f) for f in format_options)
@@ -67,8 +67,14 @@ class Video:
             for height, format in pairs:
                 url = parse_url(format["url"])
                 meta = Metadata(**(format.get("meta") or {}))
-                res = Resolution(meta.w, meta.h) if meta.w and meta.h else Resolution.parse(height)
-                yield Format(res, name, meta.bitrate, meta.size, url)
+
+                if height == "auto":
+                    resolution = Resolution.unknown()
+                elif meta.w and meta.h:
+                    resolution = Resolution(meta.w, meta.h)
+                else:
+                    resolution = Resolution.parse(height)
+                yield Format(resolution, type_, meta.bitrate, meta.size, url)
 
     @staticmethod
     def parse_subs(subs: dict[str, dict[str, str]]) -> Generator[Subtitle]:
@@ -162,7 +168,7 @@ class RumbleCrawler(Crawler):
         video: dict[str, Any] = await self.request_json(api_url)
 
         if video.get("live") == LiveStatus.CURRENTLY_LIVE:
-            raise ScrapeError(422, "live videos are not supported")
+            raise ScrapeError(422, "livestreams are not supported")
 
         formats = Video.parse_formats(video.get("ua") or {})
         subs = Video.parse_subs(video.get("cc") or {})

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -12,6 +12,8 @@ from cyberdrop_dl.utils import aio, css, m3u8
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, parse_url
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
 
 
@@ -71,8 +73,7 @@ class RumbleCrawler(Crawler):
 
     @error_handling_wrapper
     async def embed(self, scrape_item: ScrapeItem, embed_id: str) -> None:
-        api_url = (self.PRIMARY_URL / "embedJS/u3").with_query(request="video", ver=2, v=embed_id)
-        video = await self._parse_video(await self.request_json(api_url))
+        video = await self._get_video_info(embed_id)
         ext = ".mp4"
         video_name = self.create_custom_filename(
             video.title, ext, file_id=embed_id, resolution=video.best_format.resolution
@@ -91,11 +92,15 @@ class RumbleCrawler(Crawler):
         )
         self.handle_subs(scrape_item, video_name, video.subtitles)
 
-    async def _parse_video(self, video: dict[str, Any]) -> Video:
+    async def _get_video_info(self, embed_id: str) -> Video:
+        api_url = (self.PRIMARY_URL / "embedJS/u3").with_query(request="video", ver=2, v=embed_id)
+        video: dict[str, Any] = await self.request_json(api_url)
+
         if video.get("live"):
             raise ScrapeError(422, "live videos are not supported")
 
         formats = tuple(Video.parse_formats(video.get("ua") or {}))
+        subs = tuple(Video.parse_subs(video.get("cc") or {}))
 
         async def resolve_m3u8(format: Format) -> Format:
             if format.resolution != Resolution.unknown():
@@ -116,7 +121,7 @@ class RumbleCrawler(Crawler):
             title=video["title"],
             url=self.parse_url(video["l"]),
             best_format=max(resolved_formats),
-            subtitles=tuple(Video.parse_subs(video.get("cc") or {})),
+            subtitles=subs,
         )
 
 
@@ -131,14 +136,14 @@ class Format:
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class Video:
-    upload_date: str
     title: str
+    upload_date: str
     url: AbsoluteHttpURL
     best_format: Format
     subtitles: tuple[Subtitle, ...]
 
     @staticmethod
-    def parse_formats(formats: dict[str, dict[str, dict[str, Any]]]):
+    def parse_formats(formats: dict[str, dict[str, dict[str, Any]]]) -> Generator[Format]:
         for name, format_options in formats.items():
             if name not in ("hls", "mp4"):
                 continue
@@ -155,7 +160,7 @@ class Video:
                 yield Format(resolution, name, meta["bitrate"], url)
 
     @staticmethod
-    def parse_subs(subs: dict[str, dict[str, str]]):
+    def parse_subs(subs: dict[str, dict[str, str]]) -> Generator[Subtitle]:
         for lang_code, sub in subs.items():
             if url := sub.get("path"):
                 name = sub.get("language")

--- a/cyberdrop_dl/crawlers/rumble.py
+++ b/cyberdrop_dl/crawlers/rumble.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, override
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+from bs4 import BeautifulSoup
 
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.data_structures.mediaprops import Resolution, Subtitle
@@ -19,6 +21,8 @@ if TYPE_CHECKING:
 
 class RumbleCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
+        "Channel": "/c/<name>",
+        "User": "/user/<name>",
         "Video": "<video_id>-<video-title>.html",
         "Embed": "/embed/<video_id>",
     }
@@ -37,7 +41,6 @@ class RumbleCrawler(Crawler):
                 raise ValueError
 
     @classmethod
-    @override
     def transform_url(cls, url: AbsoluteHttpURL) -> AbsoluteHttpURL:
         match url.parts[1:]:
             case [slug] if slug.startswith("v") and slug.endswith(".html"):
@@ -80,7 +83,7 @@ class RumbleCrawler(Crawler):
         )
         scrape_item.possible_datetime = self.parse_iso_date(video.upload_date)
         scrape_item.url = video.url
-        self.create_task(  # pyright: ignore[reportUnusedCallResult]
+        self.create_task(
             self.handle_file(
                 video.best_format.url,
                 scrape_item,
@@ -118,7 +121,7 @@ class RumbleCrawler(Crawler):
 
         return Video(
             upload_date=video["pubDate"],
-            title=video["title"],
+            title=BeautifulSoup(video["title"]).get_text(),
             url=self.parse_url(video["l"]),
             best_format=max(resolved_formats),
             subtitles=subs,
@@ -164,4 +167,4 @@ class Video:
         for lang_code, sub in subs.items():
             if url := sub.get("path"):
                 name = sub.get("language")
-                yield Subtitle(url, lang_code, name)
+                yield Subtitle(url, lang_code.removesuffix("-auto"), name)

--- a/cyberdrop_dl/data_structures/mediaprops.py
+++ b/cyberdrop_dl/data_structures/mediaprops.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 
     import yarl
 
+    from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
+
 
 VIDEO_CODECS = "avc1", "avc2", "avc3", "avc4", "av1", "hevc", "hev1", "hev2", "hvc1", "hvc2", "vp8", "vp9", "vp10"
 AUDIO_CODECS = "ac-3", "ec-3", "mp3", "mp4a", "opus", "vorbis"
@@ -138,7 +140,7 @@ COMMON_RESOLUTIONS: Final = tuple(
 class ISO639Subtitle(NamedTuple):
     """`lang_code` MUST be a valid ISO639 code (ex: en, eng, fra)"""
 
-    url: str
+    url: AbsoluteHttpURL | str
     lang_code: str
     name: str | None = None
 

--- a/cyberdrop_dl/data_structures/mediaprops.py
+++ b/cyberdrop_dl/data_structures/mediaprops.py
@@ -133,3 +133,14 @@ COMMON_RESOLUTIONS: Final = tuple(
         (256, 144),
     )
 )
+
+
+class ISO639Subtitle(NamedTuple):
+    """`lang_code` MUST be a valid ISO639 code (ex: en, eng, fra)"""
+
+    url: str
+    lang_code: str
+    name: str | None = None
+
+
+Subtitle = ISO639Subtitle

--- a/cyberdrop_dl/utils/css.py
+++ b/cyberdrop_dl/utils/css.py
@@ -5,6 +5,7 @@ import json
 from typing import TYPE_CHECKING, Any, NamedTuple, ParamSpec, TypeVar
 
 import bs4.css
+from bs4 import BeautifulSoup
 
 from cyberdrop_dl.exceptions import ScrapeError
 
@@ -163,6 +164,14 @@ def get_json_ld(soup: Tag, /, contains: str | None = None) -> dict[str, Any]:
 def get_json_ld_value(soup: Tag, key: str) -> Any:
     ld_json = get_json_ld(soup, key)
     return ld_json[key]
+
+
+def unescape(html: str) -> str:
+    return make_soup(html).get_text()
+
+
+def make_soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "html.parser")
 
 
 iframes = CssAttributeSelector("iframe", "src")

--- a/tests/crawlers/test_cases/rumble.py
+++ b/tests/crawlers/test_cases/rumble.py
@@ -1,12 +1,33 @@
 DOMAIN = "rumble"
 TEST_CASES = [
     (
+        "https://rumble.com/v71komc-home-alone-1990.html",
+        [
+            {
+                "url": "https://rumble.com/hls-vod/6ze0m4/playlist.m3u8",
+                "filename": "Home Alone (1990) [v6ze0m4][1384p].mp4",
+                "original_filename": "Home Alone (1990).mp4",
+                "referer": "https://rumble.com/v71komc-home-alone-1990.html",
+                "album_id": None,
+                "datetime": 1762902545,
+            },
+            {
+                "url": "https://1a-1791.com/video/fww1/4d/s8/11/K/A/T/y/KATyz.fn8Si.vtt",
+                "filename": "Home Alone (1990) [v6ze0m4][1384p].en.auto.vtt",
+                "original_filename": "English (auto)",
+                "referer": "https://rumble.com/v71komc-home-alone-1990.html#Home Alone (1990) [v6ze0m4][1384p].en.auto.vtt",
+                "album_id": None,
+                "datetime": 1762902545,
+            },
+        ],
+    ),
+    (
         "https://rumble.com/vwu8gp-residente-bzrp-music-sessions-49.html?e9s=src_v1_s",
         [
             {
-                "url": "https://1a-1791.com/video/s8/2/z/z/A/s/zzAsd.daa.webm",
-                "filename": "RESIDENTE -- BZRP Music Sessions #49 [vu82er][360p].webm",
-                "original_filename": "zzAsd.daa.webm",
+                "url": "https://1a-1791.com/video/s8/2/z/z/A/s/zzAsd.caa.mp4",
+                "filename": "RESIDENTE -- BZRP Music Sessions #49 [vu82er][360p].mp4",
+                "original_filename": "RESIDENTE -- BZRP Music Sessions #49.mp4",
                 "referer": "https://rumble.com/vwu8gp-residente-bzrp-music-sessions-49.html",
                 "album_id": None,
                 "datetime": 1646760933,

--- a/tests/crawlers/test_cases/rumble.py
+++ b/tests/crawlers/test_cases/rumble.py
@@ -1,0 +1,16 @@
+DOMAIN = "rumble"
+TEST_CASES = [
+    (
+        "https://rumble.com/vwu8gp-residente-bzrp-music-sessions-49.html?e9s=src_v1_s",
+        [
+            {
+                "url": "https://1a-1791.com/video/s8/2/z/z/A/s/zzAsd.daa.webm",
+                "filename": "RESIDENTE -- BZRP Music Sessions #49 [vu82er][360p].webm",
+                "original_filename": "zzAsd.daa.webm",
+                "referer": "https://rumble.com/vwu8gp-residente-bzrp-music-sessions-49.html",
+                "album_id": None,
+                "datetime": 1646760933,
+            }
+        ],
+    ),
+]

--- a/tests/crawlers/test_cases/rumble.py
+++ b/tests/crawlers/test_cases/rumble.py
@@ -34,4 +34,25 @@ TEST_CASES = [
             }
         ],
     ),
+    (
+        "https://rumble.com/c/RumbleEvents",
+        [
+            {
+                "url": "https://1a-1791.com/video/s8/2/5/s/Q/8/5sQ8e.aaa.rec.mp4",
+                "filename": "CLOSING OUT Dave Rubin & Benny Johnson LIVE - Rumble Exclusive Live at TPU [v1at1kt][1080p].mp4",
+                "referer": "https://rumble.com/v1df7i1-rumble-exclusive-live-at-tpusa.html",
+                "album_id": None,
+            },
+            {
+                "url": "https://1a-1791.com/video/s8/2/p/W/J/7/pWJ7e.aaa.rec.mp4",
+                "filename": "Turning Point USA 2022 Student Action Summit DAY 1  - Rumble Exclusive Liv [v1amumr][1080p].mp4",
+                "referer": "https://rumble.com/v1d90jz-rumble-exclusive-live-at-tpusa.html",
+            },
+            {
+                "url": "https://1a-1791.com/video/s8/2/b/f/f/8/bff8e.aaa.rec.mp4",
+                "filename": "President Donald J. Trump LIVE at Turning Point - Rumble Exclusive Live at [v1apryd][1080p].mp4",
+                "referer": "https://rumble.com/v1dbxvl-rumble-exclusive-live-at-tpusa.html",
+            },
+        ],
+    ),
 ]


### PR DESCRIPTION
 - Add rumble support
 - Add method to parse subtitles to the base crawler (used by megacloud, vox and now rumble)
 - Fix best format selection for m3u8 streams with the same resolution but different bitrate.
 - Fix download of pure text subtitles