### PR TITLE
refactor: delete partial HLS segments alongside .part files

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import aiofiles
 
+from cyberdrop_dl import constants
 from cyberdrop_dl.constants import FILE_FORMATS
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, InvalidContentTypeError, SlowDownloadError
@@ -334,7 +335,8 @@ class DownloadClient:
     async def get_final_file_info(self, media_item: MediaItem, domain: str) -> tuple[bool, bool]:
         """Complicated checker for if a file already exists, and was already downloaded."""
         media_item.complete_file = self.get_file_location(media_item)
-        media_item.partial_file = media_item.complete_file.with_suffix(media_item.complete_file.suffix + ".part")
+        part_suffix = media_item.complete_file.suffix + constants.TempExt.PART
+        media_item.partial_file = media_item.complete_file.with_suffix(part_suffix)
 
         expected_size = media_item.filesize
         proceed = True
@@ -423,7 +425,8 @@ class DownloadClient:
 
     async def iterate_filename(self, complete_file: Path, media_item: MediaItem) -> tuple[Path, Path]:
         """Iterates the filename until it is unique."""
-        partial_file = complete_file.with_suffix(complete_file.suffix + ".part")
+        part_suffix = complete_file.suffix + constants.TempExt.PART
+        partial_file = complete_file.with_suffix(part_suffix)
         for iteration in itertools.count(1):
             filename = f"{complete_file.stem} ({iteration}){complete_file.suffix}"
             temp_complete_file = media_item.download_folder / filename
@@ -433,7 +436,7 @@ class DownloadClient:
             ):
                 media_item.filename = filename
                 complete_file = media_item.download_folder / media_item.filename
-                partial_file = complete_file.with_suffix(complete_file.suffix + ".part")
+                partial_file = complete_file.with_suffix(part_suffix)
                 break
         return complete_file, partial_file
 

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -98,7 +98,7 @@ class DownloadClient:
         if media_item.is_segment:
             media_item.partial_file = media_item.complete_file = download_dir / media_item.filename
         else:
-            media_item.partial_file = download_dir / f"{downloaded_filename}.part"
+            media_item.partial_file = download_dir / f"{downloaded_filename}.{constants.TempExt.PART}"
 
         resume_point = 0
         if media_item.partial_file and (size := await asyncio.to_thread(get_size_or_none, media_item.partial_file)):

--- a/cyberdrop_dl/clients/hash_client.py
+++ b/cyberdrop_dl/clients/hash_client.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Literal
 
 from send2trash import send2trash
 
+from cyberdrop_dl import constants
 from cyberdrop_dl.data_structures.hash import Hashing
 from cyberdrop_dl.ui.prompts.basic_prompts import enter_to_continue
 from cyberdrop_dl.utils.logger import log
@@ -97,10 +98,13 @@ class HashClient:
         self, file: Path | str, original_filename: str | None = None, referer: URL | None = None
     ) -> str | None:
         file = Path(file)
-        if file.suffix in (".cdl_hls", ".cdl_hsl", ".part"):
+
+        if file.suffix in constants.TempExt:
             return
+
         if not await asyncio.to_thread(get_size_or_none, file):
             return
+
         hash = await self._update_db_and_retrive_hash_helper(file, original_filename, referer, hash_type=self.xxhash)
         if self.manager.config_manager.settings_data.dupe_cleanup_options.add_md5_hash:
             await self._update_db_and_retrive_hash_helper(file, original_filename, referer, hash_type=self.md5)

--- a/cyberdrop_dl/constants.py
+++ b/cyberdrop_dl/constants.py
@@ -60,6 +60,12 @@ class CustomHTTPStatus(IntEnum):
     DDOS_GUARD = 429
 
 
+class TempExt(StrEnum):
+    HLS = ".cdl_hls"
+    WRONG_CDL_HLS = ".cdl_hsl"  # used for a while in old versions, has a typo
+    PART = ".part"
+
+
 class BlockedDomains:
     partial_match = (
         "facebook",

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, NamedTuple, ParamSpec, TypeVar
 
 from aiohttp import ClientConnectorError, ClientError, ClientResponseError
 
+from cyberdrop_dl import constants
 from cyberdrop_dl.constants import CustomHTTPStatus
 from cyberdrop_dl.data_structures.url_objects import HlsSegment, MediaItem
 from cyberdrop_dl.exceptions import (
@@ -211,7 +212,7 @@ class Downloader:
     ) -> tuple[Path, Path | None, Path | None]:
         async def download(m3u8: M3U8):
             assert m3u8.media_type
-            download_folder = media_item.complete_file.with_suffix(".cdl_hls") / m3u8.media_type
+            download_folder = media_item.complete_file.with_suffix(constants.TempExt.HLS) / m3u8.media_type
             coros = self._prepare_hls_downloads(media_item, m3u8, download_folder)
             n_segmets = len(m3u8.segments)
             if n_segmets > 1:
@@ -266,7 +267,7 @@ class Downloader:
         def create_segments() -> Generator[HlsSegment]:
             for index, segment in enumerate(m3u8.segments, 1):
                 assert segment.uri
-                name = f"{index:0{padding}d}.cdl_hls"
+                name = f"{index:0{padding}d}{constants.TempExt.HLS}"
                 yield HlsSegment(segment.title, name, parse_url(segment.absolute_uri))
 
         async def download_segment(segment: HlsSegment):

--- a/cyberdrop_dl/utils/sorting.py
+++ b/cyberdrop_dl/utils/sorting.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import imagesize
 from videoprops import get_audio_properties, get_video_properties
 
+from cyberdrop_dl import constants
 from cyberdrop_dl.constants import FILE_FORMATS
 from cyberdrop_dl.utils import strings
 from cyberdrop_dl.utils.logger import log, log_with_color
@@ -111,8 +112,9 @@ class Sorter:
             for file in files:
                 ext = file.suffix.lower()
 
-                if ext in (".cdl_hls", ".cdl_hsl", ".part"):
+                if ext in constants.TempExt:
                     continue
+
                 if ext in FILE_FORMATS["Audio"]:
                     await self.sort_audio(file, folder_name)
                 elif ext in FILE_FORMATS["Images"]:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -309,7 +309,7 @@ def purge_dir_tree(dirname: Path | str) -> bool:
         return False
 
 
-def check_partials_and_empty_folders(manager: Manager):
+def check_partials_and_empty_folders(manager: Manager) -> None:
     """Checks for partial downloads, deletes partial files and empty folders."""
     settings = manager.config_manager.settings_data.runtime_options
     if settings.delete_partial_files:
@@ -320,18 +320,21 @@ def check_partials_and_empty_folders(manager: Manager):
         delete_empty_folders(manager)
 
 
-def delete_partial_files(manager: Manager):
+def delete_partial_files(manager: Manager) -> None:
     """Deletes partial download files recursively."""
     log_red("Deleting partial downloads...")
-    for file in manager.path_manager.download_folder.rglob("*.part"):
-        file.unlink(missing_ok=True)
+    for file in manager.path_manager.download_folder.rglob("*"):
+        if file.suffix in constants.TempExt:
+            file.unlink(missing_ok=True)
 
 
-def check_for_partial_files(manager: Manager):
+def check_for_partial_files(manager: Manager) -> None:
     """Checks if there are partial downloads in any subdirectory and logs if found."""
     log_yellow("Checking for partial downloads...")
-    if next(manager.path_manager.download_folder.rglob("*.part"), None) is not None:
-        log_yellow("There are partial downloads in the downloads folder")
+    for file in manager.path_manager.download_folder.rglob("*"):
+        if file.suffix in constants.TempExt:
+            log_yellow("There are partial downloads in the downloads folder")
+            return
 
 
 def delete_empty_folders(manager: Manager):


### PR DESCRIPTION
Delete partial HLS segments (`.cdl_hls`) alongside `.part` files when using the `--delete-partial-files` option

- Related to #1427 