### PR TITLE
fix: skip free space check on unsupported filesystems

### DIFF
--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -161,8 +161,19 @@ class StorageManager:
         async with self._mount_addition_locks[mount]:
             if mount not in self._free_space:
                 # Manually query this mount now. Next time it will be part of the loop
-                result = await asyncio.to_thread(psutil.disk_usage, str(mount))
-                self._free_space[mount] = result.free
+                try:
+                    result = await asyncio.to_thread(psutil.disk_usage, str(mount))
+                    free_space = result.free
+                except OSError as e:
+                    if "operation not supported" in str(e).casefold():
+                        msg = f"Unable to get free space from mount point ('{mount!s}')'. Skipping free space check"
+                        log(msg, 40, exc_info=e)
+
+                        free_space = 0
+                    else:
+                        raise
+
+                self._free_space[mount] = free_space
                 self._used_mounts.add(mount)
                 log(f"A new mountpoint ('{mount!s}') will be used for '{folder}'")
                 log(self._simplified_stats)

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -188,11 +188,8 @@ class StorageManager:
 
     def _get_partition(self, mount: Path) -> DiskPartition | None:
         for partition in self._partitions:
-            try:
-                mount.relative_to(partition.mountpoint)
+            if mount.is_relative_to(partition.mountpoint):
                 return partition
-            except ValueError:
-                continue
 
     def _is_fuse_fs(self, mount: Path) -> bool:
         if partition := self._get_partition(mount):
@@ -226,13 +223,14 @@ def get_mount_point(folder: Path, all_mounts: tuple[Path, ...]) -> Path | None:
     # It's not an expensive operation nor IO blocking, but it's very common for multiple files to share the same download folder
     # ex: HLS downloads could have over a thousand segments. All of them will go to the same folder
     assert folder.is_absolute()
-    possible_mountpoints = [mount for mount in all_mounts if mount in folder.parents or mount == folder]
-    if possible_mountpoints:
-        # Get the closest mountpoint to `folder`
-        # mount_a = /home/user/  -> points to an internal SSD
-        # mount_b = /home/user/USB -> points to an external USB drive
-        # If `folder`` is `/home/user/USB/videos`, the correct mountpoint is mount_b
-        return max(possible_mountpoints, key=lambda path: len(path.parts))
+    possible_mountpoints = (mount for mount in all_mounts if folder.is_relative_to(mount))
+
+    # Get the closest mountpoint to `folder`
+    # mount_a = /home/user/  -> points to an internal SSD
+    # mount_b = /home/user/USB -> points to an external USB drive
+    # If `folder`` is `/home/user/USB/videos`, the correct mountpoint is mount_b
+    if mount_point := max(possible_mountpoints, key=lambda path: len(path.parts), default=None):
+        return mount_point
 
     # Mount point for this path does not exists
     # This will only happen on Windows, ex: an USB drive (`D:`) that is not currently available (AKA disconnected)

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -4,10 +4,9 @@ import asyncio
 import itertools
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
-from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple
 
 import psutil
 from pydantic import ByteSize
@@ -27,39 +26,45 @@ if TYPE_CHECKING:
 @dataclass(frozen=True, slots=True, order=True)
 class DiskPartition:
     mountpoint: Path
-    device: Path = field(compare=False, hash=False)
-    fstype: str = field(compare=False, hash=False)
-    opts: str = field(compare=False, hash=False)
+    device: Path = field(compare=False)
+    fstype: str = field(compare=False)
+    opts: str = field(compare=False)
 
-    @classmethod
-    def from_psutil(cls, diskpart: sdiskpart) -> DiskPartition:
-        def resolve(path: str):
-            # Resolve converts any mapped drive to UNC paths (windows)
-            return Path(path).resolve()
-
-        device, mount = tuple(map(resolve, diskpart[:2]))
-        return DiskPartition(mount, device, *diskpart[2:4])
+    @staticmethod
+    def from_psutil(diskpart: sdiskpart) -> DiskPartition:
+        # Resolve converts any mapped drive to UNC paths (windows)
+        return DiskPartition(
+            Path(diskpart.mountpoint).resolve(),
+            Path(diskpart.device).resolve(),
+            diskpart.fstype,
+            diskpart.opts,
+        )
 
 
 class MountStats(NamedTuple):
     partition: DiskPartition
     free_space: ByteSize
 
+    def __str__(self) -> str:
+        free_space = self.free_space.human_readable(decimal=True)
+        stats_as_dict = asdict(self.partition) | {"free_space": free_space}
+        return ", ".join(f"'{k}': '{v}'" for k, v in stats_as_dict.items())
+
+
+_CHECK_PERIOD: Final = 2  # how often the check_free_space_loop will run (in seconds)
+_LOG_PERIOD: Final = 10  # log storage details every <x> loops, AKA log every 20 (2x10) seconds,
+
 
 class StorageManager:
     """Runs an infinite loop to keep an updated value of the available space on all storage devices."""
 
     def __init__(self, manager: Manager):
-        self.manager = manager
+        self.manager: Manager = manager
         self.total_data_written: int = 0
-        self._paused_datetime = None
         self._used_mounts: set[Path] = set()
         self._free_space: dict[Path, int] = {}
         self._mount_addition_locks: dict[Path, asyncio.Lock] = defaultdict(asyncio.Lock)
-        self._updated = asyncio.Event()
-        self._period: int = 2  # how often the check_free_space_loop will run (in seconds)
-        self._log_period: int = 10  # log storage details every <x> loops, AKA log every 20 (2x10) seconds,
-        self._timedelta_period = timedelta(seconds=self._period)
+        self._updated: asyncio.Event = asyncio.Event()
         self._partitions = list(_get_disk_partitions())
         self._loop = asyncio.create_task(self._check_free_space_loop())
         self._unavailable_mounts: set[Path] = set()
@@ -70,24 +75,15 @@ class StorageManager:
 
     @property
     def _simplified_stats(self) -> str:
-        def stringify(mount_stats: MountStats) -> str:
-            free_space = mount_stats.free_space.human_readable(decimal=True)
-            stats_as_dict = asdict(mount_stats.partition) | {"free_space": free_space}
-            return ", ".join(f"'{k}': '{v}'" for k, v in stats_as_dict.items())
-
-        stats_as_str = "\n".join(f"    {stringify(mount_stats)}" for mount_stats in self.get_used_mounts_stats())
+        stats_as_str = "\n".join(f"    {mount_stats!s}" for mount_stats in self._mount_stats())
         return f"Storage status:\n {stats_as_str}"
 
-    def get_used_mounts_stats(self) -> list[MountStats]:
+    def _mount_stats(self) -> Generator[MountStats]:
         """Returns information of every used mount + its free space."""
 
-        def get_mounts():
-            for mount in self._used_mounts:
-                free_space = ByteSize(self._free_space[mount])
-                partition = next(p for p in self._partitions if p.mountpoint == mount)
-                yield MountStats(partition, free_space)
-
-        return list(get_mounts())
+        for partition in self._partitions:
+            free_space = ByteSize(self._free_space[partition.mountpoint])
+            yield MountStats(partition, free_space)
 
     async def check_free_space(self, media_item: MediaItem) -> None:
         """Checks if there is enough free space to download this item."""
@@ -129,6 +125,7 @@ class StorageManager:
         async with self._mount_addition_locks[folder_drive]:
             if folder_drive in itertools.chain(self._unavailable_mounts, self.mounts):
                 return
+
             msg = f"Checking new possible network_drive: '{folder_drive}' for folder '{folder}'"
             log_debug(msg)
 
@@ -136,9 +133,11 @@ class StorageManager:
                 is_dir = await asyncio.to_thread(folder_drive.is_dir)
             except OSError:
                 is_dir = False
+
             if is_dir:
                 net_drive = DiskPartition(folder_drive, folder_drive, "network_drive", "")
                 self._partitions.append(net_drive)
+
             else:
                 self._unavailable_mounts.add(folder_drive)
 
@@ -148,7 +147,7 @@ class StorageManager:
         `folder` must be an absolute path"""
 
         await self._check_nt_network_drive(folder)
-        mount = get_mount_point(folder, self.mounts)
+        mount = _get_mount_point(folder, self.mounts)
         if not mount:
             return False
 
@@ -210,15 +209,15 @@ class StorageManager:
                 results = await asyncio.gather(*tasks)
                 for mount, free_space in zip(used_mounts, results, strict=True):
                     self._free_space[mount] = free_space
-                if last_check % self._log_period == 0:
+                if last_check % _LOG_PERIOD == 0:
                     log_debug(self._simplified_stats)
 
             self._updated.set()
-            await asyncio.sleep(self._period)
+            await asyncio.sleep(_CHECK_PERIOD)
 
 
 @lru_cache
-def get_mount_point(folder: Path, all_mounts: tuple[Path, ...]) -> Path | None:
+def _get_mount_point(folder: Path, all_mounts: tuple[Path, ...]) -> Path | None:
     # Cached for performance.
     # It's not an expensive operation nor IO blocking, but it's very common for multiple files to share the same download folder
     # ex: HLS downloads could have over a thousand segments. All of them will go to the same folder

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -193,8 +193,7 @@ class StorageManager:
             except ValueError:
                 continue
             else:
-                if "fuse" in p.fstype:
-                    return True
+                return "fuse" in p.fstype
         return False
 
     async def _check_free_space_loop(self) -> None:

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -186,14 +186,17 @@ class StorageManager:
 
         return free_space
 
-    def _is_fuse_fs(self, mount: Path) -> bool:
-        for p in self._partitions:
+    def _get_partition(self, mount: Path) -> DiskPartition | None:
+        for partition in self._partitions:
             try:
-                mount.relative_to(p.mountpoint)
+                mount.relative_to(partition.mountpoint)
+                return partition
             except ValueError:
                 continue
-            else:
-                return "fuse" in p.fstype
+
+    def _is_fuse_fs(self, mount: Path) -> bool:
+        if partition := self._get_partition(mount):
+            return "fuse" in partition.fstype
         return False
 
     async def _check_free_space_loop(self) -> None:

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -82,8 +82,9 @@ class StorageManager:
         """Returns information of every used mount + its free space."""
 
         for partition in self._partitions:
-            free_space = ByteSize(self._free_space[partition.mountpoint])
-            yield MountStats(partition, free_space)
+            free_space =  self._free_space.get(partition.mountpoint)
+            if free_space is not None:
+                yield MountStats(partition, ByteSize(free_space))
 
     async def check_free_space(self, media_item: MediaItem) -> None:
         """Checks if there is enough free space to download this item."""

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -60,9 +60,7 @@ class StorageManager:
         self._period: int = 2  # how often the check_free_space_loop will run (in seconds)
         self._log_period: int = 10  # log storage details every <x> loops, AKA log every 20 (2x10) seconds,
         self._timedelta_period = timedelta(seconds=self._period)
-
         self._partitions = list(_get_disk_partitions())
-
         self._loop = asyncio.create_task(self._check_free_space_loop())
         self._unavailable_mounts: set[Path] = set()
 
@@ -82,13 +80,14 @@ class StorageManager:
 
     def get_used_mounts_stats(self) -> list[MountStats]:
         """Returns information of every used mount + its free space."""
-        mounts_stats: list[MountStats] = []
-        for mount in self._used_mounts:
-            free_space = ByteSize(self._free_space[mount])
-            partition = next(p for p in self._partitions if p.mountpoint == mount)
-            mounts_stats.append(MountStats(partition, free_space))
 
-        return mounts_stats
+        def get_mounts():
+            for mount in self._used_mounts:
+                free_space = ByteSize(self._free_space[mount])
+                partition = next(p for p in self._partitions if p.mountpoint == mount)
+                yield MountStats(partition, free_space)
+
+        return list(get_mounts())
 
     async def check_free_space(self, media_item: MediaItem) -> None:
         """Checks if there is enough free space to download this item."""
@@ -106,8 +105,8 @@ class StorageManager:
 
     async def close(self) -> None:
         await self.reset()
-        self._loop.cancel()
         try:
+            self._loop.cancel()
             await self._loop
         except asyncio.CancelledError:
             pass
@@ -126,7 +125,7 @@ class StorageManager:
         if is_mapped_drive or not is_unc_path:
             return
 
-        folder_drive = drive_as_path(folder.drive)
+        folder_drive = _drive_as_path(folder.drive)
         async with self._mount_addition_locks[folder_drive]:
             if folder_drive in itertools.chain(self._unavailable_mounts, self.mounts):
                 return
@@ -165,7 +164,7 @@ class StorageManager:
         free_space = self._free_space[mount]
         if free_space == -1:
             return True
-        return self._free_space[mount] > self.manager.config_manager.global_settings_data.general.required_free_space
+        return free_space > self.manager.global_config.general.required_free_space
 
     async def _get_free_space(self, mount: Path) -> int:
         exc_info = None
@@ -237,11 +236,11 @@ def get_mount_point(folder: Path, all_mounts: tuple[Path, ...]) -> Path | None:
     # This will only happen on Windows, ex: an USB drive (`D:`) that is not currently available (AKA disconnected)
     # On Unix there's always at least 1 mountpoint, root (`/`)
     msg = f"No available mountpoint found for '{folder}'"
-    msg += f"\n -> drive = '{drive_as_path(folder.drive)}' , last_parent = '{folder.parents[-1]}'"
+    msg += f"\n -> drive = '{_drive_as_path(folder.drive)}' , last_parent = '{folder.parents[-1]}'"
     log(msg, 40)
 
 
-def drive_as_path(drive: str) -> Path:
+def _drive_as_path(drive: str) -> Path:
     is_mapped_drive = ":" in drive and len(drive) == 2
     return Path(f"{drive}/" if is_mapped_drive else drive)
 

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -16,6 +16,8 @@ from cyberdrop_dl.exceptions import InsufficientFreeSpaceError
 from cyberdrop_dl.utils.logger import log, log_debug
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from psutil._common import sdiskpart
 
     from cyberdrop_dl.data_structures.url_objects import MediaItem
@@ -58,15 +60,8 @@ class StorageManager:
         self._period: int = 2  # how often the check_free_space_loop will run (in seconds)
         self._log_period: int = 10  # log storage details every <x> loops, AKA log every 20 (2x10) seconds,
         self._timedelta_period = timedelta(seconds=self._period)
-        self._partitions = []
-        for p in psutil.disk_partitions(all=True):
-            try:
-                part = DiskPartition.from_psutil(p)
-            except OSError as e:
-                msg = f"Unable to get information about {p.mountpoint}. All files with that mountpoint as target will be skipped: {e!r}"
-                log(msg, 40)
-            else:
-                self._partitions.append(part)
+
+        self._partitions = list(_get_disk_partitions())
 
         self._loop = asyncio.create_task(self._check_free_space_loop())
         self._unavailable_mounts: set[Path] = set()
@@ -117,43 +112,43 @@ class StorageManager:
         except asyncio.CancelledError:
             pass
 
+    async def _check_nt_network_drive(self, folder: Path) -> None:
+        """Checks is the drive of this folder is a Windows network drive (UNC or unknown mapped drive) and exists."""
+        # See: https://github.com/jbsparrow/CyberDropDownloader/issues/860
+        if not psutil.WINDOWS:
+            return
+
+        # We can discard mapped drives because they would have been converted to UNC path at startup
+        # calling resolve on a mapped network drive returns its UNC path
+        # it would only still be a mapped drive is the network address is not available
+        is_mapped_drive = ":" in folder.drive and len(folder.drive) == 2
+        is_unc_path = folder.drive.startswith("\\\\")
+        if is_mapped_drive or not is_unc_path:
+            return
+
+        folder_drive = drive_as_path(folder.drive)
+        async with self._mount_addition_locks[folder_drive]:
+            if folder_drive in itertools.chain(self._unavailable_mounts, self.mounts):
+                return
+            msg = f"Checking new possible network_drive: '{folder_drive}' for folder '{folder}'"
+            log_debug(msg)
+
+            try:
+                is_dir = await asyncio.to_thread(folder_drive.is_dir)
+            except OSError:
+                is_dir = False
+            if is_dir:
+                net_drive = DiskPartition(folder_drive, folder_drive, "network_drive", "")
+                self._partitions.append(net_drive)
+            else:
+                self._unavailable_mounts.add(folder_drive)
+
     async def _has_sufficient_space(self, folder: Path) -> bool:
         """Checks if there is enough free space to download to this folder.
 
         `folder` must be an absolute path"""
 
-        async def check_nt_network_drive():
-            """Checks is the drive of this folder is a Windows network drive (UNC or unknown mapped drive) and exists."""
-            # See: https://github.com/jbsparrow/CyberDropDownloader/issues/860
-            if not psutil.WINDOWS:
-                return
-
-            # We can discard mapped drives because they would have been converted to UNC path at startup
-            # calling resolve on a mapped network drive returns its UNC path
-            # it would only still be a mapped drive is the network address is not available
-            is_mapped_drive = ":" in folder.drive and len(folder.drive) == 2
-            is_unc_path = folder.drive.startswith("\\\\")
-            if is_mapped_drive or not is_unc_path:
-                return
-
-            folder_drive = drive_as_path(folder.drive)
-            async with self._mount_addition_locks[folder_drive]:
-                if folder_drive in itertools.chain(self._unavailable_mounts, self.mounts):
-                    return
-                msg = f"Checking new possible network_drive: '{folder_drive}' for folder '{folder}'"
-                log_debug(msg)
-
-                try:
-                    is_dir = await asyncio.to_thread(folder_drive.is_dir)
-                except OSError:
-                    is_dir = False
-                if is_dir:
-                    net_drive = DiskPartition(folder_drive, folder_drive, "network_drive", "")
-                    self._partitions.append(net_drive)
-                else:
-                    self._unavailable_mounts.add(folder_drive)
-
-        await check_nt_network_drive()
+        await self._check_nt_network_drive(folder)
         mount = get_mount_point(folder, self.mounts)
         if not mount:
             return False
@@ -161,24 +156,47 @@ class StorageManager:
         async with self._mount_addition_locks[mount]:
             if mount not in self._free_space:
                 # Manually query this mount now. Next time it will be part of the loop
-                try:
-                    result = await asyncio.to_thread(psutil.disk_usage, str(mount))
-                    free_space = result.free
-                except OSError as e:
-                    if "operation not supported" in str(e).casefold():
-                        msg = f"Unable to get free space from mount point ('{mount!s}')'. Skipping free space check"
-                        log(msg, 40, exc_info=e)
 
-                        free_space = 0
-                    else:
-                        raise
-
-                self._free_space[mount] = free_space
+                self._free_space[mount] = await self._get_free_space(mount)
                 self._used_mounts.add(mount)
                 log(f"A new mountpoint ('{mount!s}') will be used for '{folder}'")
                 log(self._simplified_stats)
 
+        free_space = self._free_space[mount]
+        if free_space == -1:
+            return True
         return self._free_space[mount] > self.manager.config_manager.global_settings_data.general.required_free_space
+
+    async def _get_free_space(self, mount: Path) -> int:
+        exc_info = None
+        free_space = 0
+
+        try:
+            result = await asyncio.to_thread(psutil.disk_usage, str(mount))
+            free_space = result.free
+        except OSError as e:
+            if "operation not supported" in str(e).casefold():
+                exc_info = e
+            else:
+                raise
+
+        if exc_info or (free_space == 0 and self._is_fuse_fs(mount)):
+            msg = f"Unable to get free space from mount point ('{mount!s}')'. Skipping free space check"
+            log(msg, 40, exc_info=exc_info)
+            free_space = -1
+
+        return free_space
+
+    def _is_fuse_fs(self, mount: Path) -> bool:
+        for p in self._partitions:
+            try:
+                mount.relative_to(p.mountpoint)
+            except ValueError:
+                continue
+            else:
+                if "fuse" in p.fstype:
+                    return True
+        return False
 
     async def _check_free_space_loop(self) -> None:
         """Infinite loop to get free space of all used mounts and update internal dict"""
@@ -189,13 +207,14 @@ class StorageManager:
             self._updated.clear()
             last_check += 1
             if self._used_mounts:
-                used_mounts = sorted(self._used_mounts)
-                tasks = [asyncio.to_thread(psutil.disk_usage, str(mount)) for mount in used_mounts]
+                used_mounts = sorted(mount for mount in self._used_mounts if self._free_space[mount] != -1)
+                tasks = [self._get_free_space(mount) for mount in used_mounts]
                 results = await asyncio.gather(*tasks)
-                for mount, result in zip(used_mounts, results, strict=True):
-                    self._free_space[mount] = result.free
+                for mount, free_space in zip(used_mounts, results, strict=True):
+                    self._free_space[mount] = free_space
                 if last_check % self._log_period == 0:
                     log_debug(self._simplified_stats)
+
             self._updated.set()
             await asyncio.sleep(self._period)
 
@@ -225,3 +244,12 @@ def get_mount_point(folder: Path, all_mounts: tuple[Path, ...]) -> Path | None:
 def drive_as_path(drive: str) -> Path:
     is_mapped_drive = ":" in drive and len(drive) == 2
     return Path(f"{drive}/" if is_mapped_drive else drive)
+
+
+def _get_disk_partitions() -> Generator[DiskPartition]:
+    for p in psutil.disk_partitions(all=True):
+        try:
+            yield DiskPartition.from_psutil(p)
+        except OSError as e:
+            msg = f"Unable to get information about {p.mountpoint}. All files with that mountpoint as target will be skipped: {e!r}"
+            log(msg, 40)

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -82,7 +82,7 @@ class StorageManager:
         """Returns information of every used mount + its free space."""
 
         for partition in self._partitions:
-            free_space =  self._free_space.get(partition.mountpoint)
+            free_space = self._free_space.get(partition.mountpoint)
             if free_space is not None:
                 yield MountStats(partition, ByteSize(free_space))
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,42 @@
+import dataclasses
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from unittest import mock
+
+import psutil
+import pytest
+
+from cyberdrop_dl.managers.manager import Manager
+from cyberdrop_dl.managers.storage_manager import StorageManager
+
+
+@pytest.fixture
+async def storage(running_manager: Manager) -> AsyncGenerator[StorageManager]:
+    yield StorageManager(running_manager)
+
+
+async def test_unsupported_fs_should_not_return_zero(storage: StorageManager) -> None:
+    cwd = Path().resolve()
+    free_space = await storage._get_free_space(cwd)
+    assert free_space > 0
+    with mock.patch("psutil.disk_usage", side_effect=OSError(None, "operation not supported")):
+        free_space = await storage._get_free_space(cwd)
+        assert free_space == -1
+
+    with mock.patch("psutil.disk_usage", side_effect=OSError(None, "another error")):
+        with pytest.raises(OSError):
+            await storage._get_free_space(cwd)
+
+
+async def test_fuse_filesystem_should_not_return_zero(storage: StorageManager) -> None:
+    cwd = Path().resolve()
+    partition = storage._get_partition(cwd)
+    assert partition
+    storage._partitions = [dataclasses.replace(partition, fstype="fuse")]
+
+    free_space = await storage._get_free_space(cwd)
+    assert free_space > 0
+
+    with mock.patch("psutil.disk_usage", return_value=psutil._common.sdiskusage(0, 0, 0, 0)):
+        free_space = await storage._get_free_space(cwd)
+        assert free_space == -1


### PR DESCRIPTION
- Fixes #1450 
- Fixes #979
 
Skip free space check when:
- The file system does not support it
- The file system report 0B and its using FUSE

