### PR TITLE
feat: parse API embed URL (Kemono / Coomer)

### DIFF
--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -5,11 +5,22 @@ import functools
 import itertools
 import re
 from collections import defaultdict
+from collections.abc import Generator
 from datetime import datetime  # noqa: TC003
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Concatenate, Literal, NamedTuple, NotRequired, ParamSpec
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ClassVar,
+    Concatenate,
+    Literal,
+    NamedTuple,
+    NotRequired,
+    ParamSpec,
+)
 
-from pydantic import AliasChoices, BeforeValidator, Field
+from pydantic import BeforeValidator, Field
 from typing_extensions import TypedDict  # Import from typing is not compatible with pydantic
 
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths, auto_task_id
@@ -48,7 +59,6 @@ class PostSelectors:
 
     DATE_PUBLISHED = "div[class*=__published] time[class=timestamp]"
     DATE_ADDED = "div[class*=__added]"
-    DATE = f"{DATE_PUBLISHED}, {DATE_ADDED}"
 
     TITLE = "h1[class*=__title]"
     USERNAME = "a[class*=__user-name]"
@@ -92,8 +102,10 @@ class Post(AliasModel):
     content: str = ""
     file: FileOrNone = None
     attachments: list[File] = []  # noqa: RUF012
-    published_or_added: datetime | None = Field(None, validation_alias=AliasChoices("published", "added"))
-    date: int | None = None
+    published: datetime | None = None
+    added: datetime | None = None
+    edited: datetime | None = None
+    timestamp: int | None = None
     tags: Tags = []  # noqa: RUF012
     embed: EmbedOrNone = None
 
@@ -101,8 +113,8 @@ class Post(AliasModel):
     soup_attachments: list[Any] = []  # noqa: RUF012
 
     def model_post_init(self, *_) -> None:
-        if self.published_or_added:
-            self.date = to_timestamp(self.published_or_added)
+        if date := self.published or self.added:
+            self.timestamp = to_timestamp(date)
 
     @property
     def all_files(self) -> Generator[File]:
@@ -142,12 +154,19 @@ class PartialUserPost(NamedTuple):
     title: str = ""
     content: str = ""
     user_name: str = ""
-    date: str | None = None
+    published: str | None = None
+    added: str | None = None
 
     @staticmethod
     def from_soup(soup: BeautifulSoup) -> PartialUserPost:
         params = {}
-        selectors = (PostSelectors.TITLE, PostSelectors.ALL_CONTENT, PostSelectors.USERNAME, PostSelectors.DATE)
+        selectors = (
+            PostSelectors.TITLE,
+            PostSelectors.ALL_CONTENT,
+            PostSelectors.USERNAME,
+            PostSelectors.DATE_PUBLISHED,
+            PostSelectors.DATE_ADDED,
+        )
         for name, selector in zip(PartialUserPost._fields, selectors, strict=True):
             if tag := soup.select_one(selector):
                 params[name] = tag.get_text().strip()
@@ -383,8 +402,8 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         user_name = self._user_names[post.user]
         title = self.create_title(user_name, post.user_id)
         scrape_item.setup_as_album(title, album_id=post.user_id)
-        scrape_item.possible_datetime = post.date
-        post_title = self.create_separate_post_title(post.title, post.id, post.date)
+        scrape_item.possible_datetime = post.timestamp
+        post_title = self.create_separate_post_title(post.title, post.id, post.timestamp)
         scrape_item.add_to_parent_title(post_title)
         self.__handle_post(scrape_item, post)
 
@@ -393,9 +412,9 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         title = self.create_title(f"{server.name} [discord]", server.id)
         channel_name = next(c.name for c in server.channels if c.id == post.channel_id)
         scrape_item.setup_as_album(title, album_id=server.id)
-        scrape_item.possible_datetime = post.date
+        scrape_item.possible_datetime = post.timestamp
         scrape_item.add_to_parent_title(f"#{channel_name}")
-        post_title = self.create_separate_post_title(None, post.id, post.date)
+        post_title = self.create_separate_post_title(None, post.id, post.timestamp)
         scrape_item.add_to_parent_title(post_title)
         self.__handle_post(scrape_item, post)
 
@@ -453,10 +472,10 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         if self.ignore_ads and self.__has_ads(post):
             return
 
+        embeds = (self.parse_url(post.embed.url),) if post.embed else ()
         files = (self.__make_file_url(file) for file in post.all_files)
-
         seen: set[AbsoluteHttpURL] = set()
-        for url in itertools.chain(files, post.soup_attachments):
+        for url in itertools.chain(files, post.soup_attachments, embeds):
             if url not in seen:
                 seen.add(url)
                 self.create_task(self.handle_direct_link(scrape_item, url))
@@ -487,7 +506,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             server_profile: dict[str, Any] = await self.__api_request(server_api_url)
             name = server_profile.get("name") or f"Discord Server {server_id}"
             channels_api_url = self.API_ENTRYPOINT / "discord/channel/lookup" / server_id
-            channels_resp: list[dict] = await self.__api_request(channels_api_url)
+            channels_resp: list[dict[str, Any]] = await self.__api_request(channels_api_url)
             channels = tuple(DiscordChannel(channel["name"], channel["id"]) for channel in channels_resp)
             self.__known_discord_servers[server_id] = server = DiscordServer(name, server_id, channels)
             return server
@@ -580,7 +599,8 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             id=post_id,
             title=partial_post.title,
             content=partial_post.content,
-            published_or_added=partial_post.date,  # type: ignore[reportArgumentType]
+            published=partial_post.published,  # type: ignore[reportArgumentType]
+            added=partial_post.added,  # type: ignore[reportArgumentType]
             soup_attachments=list(files()),
         )
 

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -76,6 +76,13 @@ class File(TypedDict):
     server: NotRequired[str]  # Sometimes present in attachments
 
 
+class Embed(NamedTuple):
+    url: str
+    subject: str
+    description: str
+
+
+EmbedOrNone = Annotated[Embed | None, BeforeValidator(falsy_as_none)]
 FileOrNone = Annotated[File | None, BeforeValidator(falsy_as_none)]
 Tags = Annotated[list[str], BeforeValidator(lambda x: falsy_as(x, []))]
 
@@ -88,6 +95,7 @@ class Post(AliasModel):
     published_or_added: datetime | None = Field(None, validation_alias=AliasChoices("published", "added"))
     date: int | None = None
     tags: Tags = []  # noqa: RUF012
+    embed: EmbedOrNone = None
 
     # `Any` to skip validation, but these are `yarl.URL`. We generate them internally so no validation is needed
     soup_attachments: list[Any] = []  # noqa: RUF012

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -8,16 +8,7 @@ from collections import defaultdict
 from collections.abc import Generator
 from datetime import datetime  # noqa: TC003
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Annotated,
-    Any,
-    ClassVar,
-    Concatenate,
-    Literal,
-    NamedTuple,
-    ParamSpec,
-)
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Concatenate, Literal, NamedTuple, ParamSpec
 
 from pydantic import BeforeValidator, Field
 
@@ -470,14 +461,19 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         if self.ignore_ads and self.__has_ads(post):
             return
 
-        embeds = (self.parse_url(post.embed.url),) if post.embed else ()
         files = (self.__make_file_url(file) for file in post.all_files)
         seen: set[AbsoluteHttpURL] = set()
-        for url in itertools.chain(files, post.soup_attachments, embeds):
+        for url in itertools.chain(files, post.soup_attachments):
             if url not in seen:
                 seen.add(url)
                 self.create_task(self.handle_direct_link(scrape_item, url))
                 scrape_item.add_children()
+
+        if post.embed:
+            embed_url = self.parse_url(post.embed.url)
+            new_scrape_item = scrape_item.create_child(embed_url)
+            self.handle_external_links(new_scrape_item)
+            scrape_item.add_children()
 
         self._handle_post_content(scrape_item, post)
 

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -16,12 +16,10 @@ from typing import (
     Concatenate,
     Literal,
     NamedTuple,
-    NotRequired,
     ParamSpec,
 )
 
 from pydantic import BeforeValidator, Field
-from typing_extensions import TypedDict  # Import from typing is not compatible with pydantic
 
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths, auto_task_id
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
@@ -80,10 +78,10 @@ class User(NamedTuple):
     id: str
 
 
-class File(TypedDict):
-    name: NotRequired[str]  # Sometimes present
+class File(NamedTuple):
     path: str
-    server: NotRequired[str]  # Sometimes present in attachments
+    name: str | None = None  # Sometimes present
+    server: str | None = None  # Sometimes present in attachments
 
 
 class Embed(NamedTuple):
@@ -383,11 +381,11 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
 
     def _register_attachments_servers(self, attachments: list[File]) -> None:
         for attach in attachments:
-            server = attach.get("server")
+            server = attach.server
             if not server:
                 continue
 
-            path = attach["path"]
+            path = attach.path
             if previous_server := self.__known_attachment_servers.get(path):
                 if previous_server != server:
                     msg = (
@@ -484,10 +482,10 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         self._handle_post_content(scrape_item, post)
 
     def __make_file_url(self, file: File) -> AbsoluteHttpURL:
-        path = file["path"]
+        path = file.path
         server = self.__known_attachment_servers.get(path) or ""
         url = self.parse_url(server + f"/data{path}")
-        return url.with_query(f=file.get("name") or url.name)
+        return url.with_query(f=file.name or url.name)
 
     def __make_api_url_w_offset(self, web_url: AbsoluteHttpURL, path: str | None = None) -> AbsoluteHttpURL:
         api_url = self.API_ENTRYPOINT / (path or web_url.path).removeprefix("/")
@@ -599,8 +597,8 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
             id=post_id,
             title=partial_post.title,
             content=partial_post.content,
-            published=partial_post.published,  # type: ignore[reportArgumentType]
-            added=partial_post.added,  # type: ignore[reportArgumentType]
+            published=partial_post.published,  # type: ignore[reportArgumentType]  # pyright: ignore[reportArgumentType]
+            added=partial_post.added,  # type: ignore[reportArgumentType]  # pyright: ignore[reportArgumentType]
             soup_attachments=list(files()),
         )
 
@@ -630,7 +628,7 @@ class KemonoCrawler(KemonoBaseCrawler):
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = "kemono.party", "kemono.su"
 
     @property
-    def session_cookie(self):
+    def session_cookie(self) -> str:
         return self.manager.config_manager.authentication_data.kemono.session
 
 

--- a/tests/crawlers/test_cases/kemono.py
+++ b/tests/crawlers/test_cases/kemono.py
@@ -62,4 +62,21 @@ TEST_CASES = [
         ],
         41,
     ),
+    (
+        "https://kemono.cr/patreon/user/47101380/post/128071303",
+        [
+            {
+                "url": "https://kemono.cr/data/83/66/8366796e0d9fadd5e22ae8f8ea32d1b539d54e25e9da19f906fa36d1cf973cc2.jpg?f=461372899.jpg",
+                "filename": "461372899.jpg",
+                "referer": "https://kemono.cr/patreon/user/47101380/post/128071303",
+                "download_folder": r"re:Emma_Ruby \(Kemono\)",
+            },
+            {
+                "url": "re:pcloud",
+                "filename": "ASMR ~ Girl Next Door ~ Patreon EXCLUSIVE.mp4",
+                "download_folder": r"re:Emma_Ruby \(Kemono\)/Loose Files \(pCloud\)",
+                "referer": "https://u.pcloud.link/publink/show?code=XZDlYb5ZlyjdRy0vl0bJWMbT2L2cp5RbUCFX",
+            },
+        ],
+    ),
 ]


### PR DESCRIPTION
- Parse the new? `embed` files from the API response
- Split parsing of `published` and `added` dates

The API also returns a `videos` attribute but it's just a subset of `attachments`. `embed` is unique AFAIK, they are not part of the content of the post nor `attachments`.

They also return `captions`. I'm not sure if those are subtitles. All the posts that i tried return `None` for it