### PR TITLE
feat: add metadata attribute to `media_item`

### DIFF
--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -363,6 +363,12 @@ class Crawler(ABC):
             return False
         return primary_domain in other_domain and other_domain.count(".") > primary_domain.count(".")
 
+    @final
+    async def handle_metadata(self, scrape_item: ScrapeItem, stem: str, metadata: object) -> None:
+        ext = ".metadata"
+        filename = f"{stem}{ext}"
+        await self.handle_file(None, scrape_item, filename, ext, metadata=metadata)
+
     # TODO: make this sync
     async def handle_file(
         self,

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -400,7 +400,8 @@ class Crawler(ABC):
         media_item = MediaItem.from_item(
             scrape_item, url, self.DOMAIN, download_folder, filename, original_filename, debrid_link, ext=ext
         )
-        media_item.metadata = metadata
+        if metadata is not None:
+            media_item.metadata = metadata
         await self.handle_media_item(media_item, m3u8)
 
     @final

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -374,6 +374,7 @@ class Crawler(ABC):
         custom_filename: str | None = None,
         debrid_link: URL | None = None,
         m3u8: m3u8.RenditionGroup | None = None,
+        metadata: object = None,
     ) -> None:
         """Finishes handling the file and hands it off to the downloader."""
         if not ext:
@@ -392,6 +393,7 @@ class Crawler(ABC):
         media_item = MediaItem.from_item(
             scrape_item, url, self.DOMAIN, download_folder, filename, original_filename, debrid_link, ext=ext
         )
+        media_item.metadata = metadata
 
         self.create_task(self.handle_media_item(media_item, m3u8))
 

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -364,9 +364,10 @@ class Crawler(ABC):
         return primary_domain in other_domain and other_domain.count(".") > primary_domain.count(".")
 
     @final
-    async def handle_metadata(self, scrape_item: ScrapeItem, stem: str, metadata: object) -> None:
+    async def handle_metadata(self, scrape_item: ScrapeItem, name: str, metadata: object) -> None:
+        """Write general metadata (not specific to a single scraped file) to json output"""
         ext = ".metadata"
-        filename = f"{stem}{ext}"
+        filename = f"{name}{ext}"
         await self.handle_file(None, scrape_item, filename, ext, metadata=metadata)
 
     # TODO: make this sync

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -367,11 +367,10 @@ class Crawler(ABC):
     async def write_metadata(self, scrape_item: ScrapeItem, name: str, metadata: object) -> None:
         """Write general metadata (not specific to a single file) to json output"""
 
-        ext = ".metadata"
-        filename = f"{name}{ext}"  # we won't write to fs, so we skip name sanitization
+        filename = f"{name}.metadata"  # we won't write to fs, so we skip name sanitization
         download_folder = get_download_path(self.manager, scrape_item, self.FOLDER_DOMAIN)
-        url = AbsoluteHttpURL((download_folder / filename).as_uri())
-        media_item = MediaItem.from_item(scrape_item, url, self.DOMAIN, download_folder, filename, ext=ext)
+        url = scrape_item.url.with_scheme("metadata")
+        media_item = MediaItem.from_item(scrape_item, url, self.DOMAIN, download_folder, filename)
         media_item.metadata = metadata
         await self.__write_to_jsonl(media_item)
 

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -364,16 +364,20 @@ class Crawler(ABC):
         return primary_domain in other_domain and other_domain.count(".") > primary_domain.count(".")
 
     @final
-    async def handle_metadata(self, scrape_item: ScrapeItem, name: str, metadata: object) -> None:
-        """Write general metadata (not specific to a single scraped file) to json output"""
-        ext = ".metadata"
-        filename = f"{name}{ext}"
-        await self.handle_file(None, scrape_item, filename, ext, metadata=metadata)
+    async def write_metadata(self, scrape_item: ScrapeItem, name: str, metadata: object) -> None:
+        """Write general metadata (not specific to a single file) to json output"""
 
-    # TODO: make this sync
+        ext = ".metadata"
+        filename = f"{name}{ext}"  # we won't write to fs, so we skip name sanitization
+        download_folder = get_download_path(self.manager, scrape_item, self.FOLDER_DOMAIN)
+        url = AbsoluteHttpURL((download_folder / filename).as_uri())
+        media_item = MediaItem.from_item(scrape_item, url, self.DOMAIN, download_folder, filename, ext=ext)
+        media_item.metadata = metadata
+        await self.__write_to_jsonl(media_item)
+
     async def handle_file(
         self,
-        url: AbsoluteHttpURL | None,
+        url: AbsoluteHttpURL,
         scrape_item: ScrapeItem,
         filename: str,
         ext: str | None = None,
@@ -394,27 +398,29 @@ class Crawler(ABC):
             original_filename = filename
 
         download_folder = get_download_path(self.manager, scrape_item, self.FOLDER_DOMAIN)
-        url = url or AbsoluteHttpURL((download_folder / filename).as_uri())
         media_item = MediaItem.from_item(
             scrape_item, url, self.DOMAIN, download_folder, filename, original_filename, debrid_link, ext=ext
         )
         media_item.metadata = metadata
-
         await self.handle_media_item(media_item, m3u8)
 
     @final
     async def _download(self, media_item: MediaItem, m3u8: m3u8.RenditionGroup | None) -> None:
         try:
-            if not media_item.is_local_file:
-                if m3u8:
-                    await self.downloader.download_hls(media_item, m3u8)
-                else:
-                    await self.downloader.run(media_item)
+            if m3u8:
+                await self.downloader.download_hls(media_item, m3u8)
+            else:
+                await self.downloader.run(media_item)
 
         finally:
-            if self.manager.config_manager.settings_data.files.dump_json:
-                data = [media_item.as_jsonable_dict()]
-                await self.manager.log_manager.write_jsonl(data)
+            await self.__write_to_jsonl(media_item)
+
+    async def __write_to_jsonl(self, media_item: MediaItem) -> None:
+        if not self.manager.config.files.dump_json:
+            return
+
+        data = [media_item.as_jsonable_dict()]
+        await self.manager.log_manager.write_jsonl(data)
 
     async def check_complete(self, url: AbsoluteHttpURL, referer: AbsoluteHttpURL) -> bool:
         """Checks if this URL has been download before.
@@ -432,9 +438,6 @@ class Crawler(ABC):
         if media_item.datetime and not isinstance(media_item.datetime, int):
             msg = f"Invalid datetime from '{self.FOLDER_DOMAIN}' crawler . Got {media_item.datetime!r}, expected int."
             log(msg, bug=True)
-
-        if media_item.is_local_file:
-            return await self._download(media_item, m3u8)
 
         check_complete = await self.check_complete(media_item.url, media_item.referer)
         if check_complete:

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -366,13 +366,13 @@ class Crawler(ABC):
     # TODO: make this sync
     async def handle_file(
         self,
-        url: URL,
+        url: AbsoluteHttpURL | None,
         scrape_item: ScrapeItem,
         filename: str,
         ext: str | None = None,
         *,
         custom_filename: str | None = None,
-        debrid_link: URL | None = None,
+        debrid_link: AbsoluteHttpURL | None = None,
         m3u8: m3u8.RenditionGroup | None = None,
         metadata: object = None,
     ) -> None:
@@ -386,24 +386,23 @@ class Crawler(ABC):
         else:
             original_filename = filename
 
-        assert is_absolute_http_url(url)
-        if isinstance(debrid_link, URL):
-            assert is_absolute_http_url(debrid_link)
         download_folder = get_download_path(self.manager, scrape_item, self.FOLDER_DOMAIN)
+        url = url or AbsoluteHttpURL((download_folder / filename).as_uri())
         media_item = MediaItem.from_item(
             scrape_item, url, self.DOMAIN, download_folder, filename, original_filename, debrid_link, ext=ext
         )
         media_item.metadata = metadata
 
-        self.create_task(self.handle_media_item(media_item, m3u8))
+        await self.handle_media_item(media_item, m3u8)
 
     @final
     async def _download(self, media_item: MediaItem, m3u8: m3u8.RenditionGroup | None) -> None:
         try:
-            if m3u8:
-                await self.downloader.download_hls(media_item, m3u8)
-            else:
-                await self.downloader.run(media_item)
+            if not media_item.is_local_file:
+                if m3u8:
+                    await self.downloader.download_hls(media_item, m3u8)
+                else:
+                    await self.downloader.run(media_item)
 
         finally:
             if self.manager.config_manager.settings_data.files.dump_json:
@@ -426,6 +425,9 @@ class Crawler(ABC):
         if media_item.datetime and not isinstance(media_item.datetime, int):
             msg = f"Invalid datetime from '{self.FOLDER_DOMAIN}' crawler . Got {media_item.datetime!r}, expected int."
             log(msg, bug=True)
+
+        if media_item.is_local_file:
+            return await self._download(media_item, m3u8)
 
         check_complete = await self.check_complete(media_item.url, media_item.referer)
         if check_complete:

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -445,6 +445,8 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         if self.ignore_ads and self.__has_ads(post):
             return
 
+        self.create_task(self.handle_metadata(scrape_item, f"post_{post.id}", post))
+
         files = (self.__make_file_url(file) for file in post.all_files)
 
         seen: set[AbsoluteHttpURL] = set()

--- a/cyberdrop_dl/crawlers/kemono.py
+++ b/cyberdrop_dl/crawlers/kemono.py
@@ -445,7 +445,7 @@ class KemonoBaseCrawler(Crawler, is_abc=True):
         if self.ignore_ads and self.__has_ads(post):
             return
 
-        self.create_task(self.handle_metadata(scrape_item, f"post_{post.id}", post))
+        self.create_task(self.write_metadata(scrape_item, f"post_{post.id}", post))
 
         files = (self.__make_file_url(file) for file in post.all_files)
 

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -171,8 +171,12 @@ class MediaItem:
     downloaded: bool = field(default=False, compare=False)
 
     parent_media_item: MediaItem | None = field(default=None, compare=False)
-    db_path: str = field(init=False, repr=False)
+    db_path: str = field(init=False)
     _task_id: TaskID | None = field(default=None, compare=False)
+    metadata: object = field(init=False, default=None, compare=False)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(domain={self.domain!r}, url={self.url!r}, referer={self.referer!r}, filename={self.filename!r}"
 
     def __post_init__(self) -> None:
         self.db_path = self.create_db_path(self.url, self.domain)

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -179,11 +179,14 @@ class MediaItem:
         return f"{type(self).__name__}(domain={self.domain!r}, url={self.url!r}, referer={self.referer!r}, filename={self.filename!r}"
 
     def __post_init__(self) -> None:
-        self.db_path = "" if self.is_local_file else self.create_db_path(self.url, self.domain)
+        self.db_path = self.create_db_path(self.url, self.domain)
 
     @staticmethod
     def create_db_path(url: yarl.URL, domain: str) -> str:
         """Gets the URL path to be put into the DB and checked from the DB."""
+
+        if url.scheme == "metadata":
+            return ""
 
         if domain:
             if "e-hentai" in domain:
@@ -259,10 +262,6 @@ class MediaItem:
         for name in ("fallbacks", "_task_id", "is_segment", "parent_media_item"):
             _ = item.pop(name)
         return item
-
-    @property
-    def is_local_file(self) -> bool:
-        return self.url.scheme == "file"
 
 
 @dataclass(kw_only=True, slots=True)

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -173,7 +173,7 @@ class MediaItem:
     parent_media_item: MediaItem | None = field(default=None, compare=False)
     db_path: str = field(init=False)
     _task_id: TaskID | None = field(default=None, compare=False)
-    metadata: object = field(init=False, default=None, compare=False)
+    metadata: object = field(init=False, default_factory=dict, compare=False)
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(domain={self.domain!r}, url={self.url!r}, referer={self.referer!r}, filename={self.filename!r}"

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -260,6 +260,10 @@ class MediaItem:
             _ = item.pop(name)
         return item
 
+    @property
+    def is_local_file(self) -> bool:
+        return self.url.scheme == "file"
+
 
 @dataclass(kw_only=True, slots=True)
 class ScrapeItem:

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -179,7 +179,7 @@ class MediaItem:
         return f"{type(self).__name__}(domain={self.domain!r}, url={self.url!r}, referer={self.referer!r}, filename={self.filename!r}"
 
     def __post_init__(self) -> None:
-        self.db_path = self.create_db_path(self.url, self.domain)
+        self.db_path = "" if self.is_local_file else self.create_db_path(self.url, self.domain)
 
     @staticmethod
     def create_db_path(url: yarl.URL, domain: str) -> str:


### PR DESCRIPTION
metadata will be site specific information that will be written to the `--dump-json` output file

The metadata object can be literally any type (dict, dataclass, pydantic model, etc).

I added an example to save the Kemono/Coomer's posts response as metadata