### PR TITLE
refactor: remove `ScrapeItem`s `retry` property

### DIFF
--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -264,7 +264,6 @@ class ScrapeItem:
     part_of_album: bool = False
     album_id: str | None = None
     possible_datetime: int | None = None
-    retry: bool = False
     retry_path: Path | None = None
 
     parents: list[AbsoluteHttpURL] = field(default_factory=list, init=False)
@@ -284,8 +283,9 @@ class ScrapeItem:
         """Adds a title to the parent title."""
         from cyberdrop_dl.utils.utilities import sanitize_folder
 
-        if not title or self.retry:
+        if not title or self.retry_path:
             return
+
         title = sanitize_folder(title)
         if title.endswith(")") and " (" in title:
             for part in reversed(self.parent_title.split("/")):

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -410,6 +410,15 @@ class ScrapeItem:
         if self.parents:
             return self.parents[-1]
 
+    def create_download_path(self, domain: str) -> Path:
+        if self.retry_path:
+            return self.retry_path
+        if self.parent_title and self.part_of_album:
+            return Path(self.parent_title)
+        if self.parent_title:
+            return Path(self.parent_title) / f"Loose Files ({domain})"
+        return Path(f"Loose Files ({domain})")
+
     def copy(self) -> Self:
         """Returns a deep copy of this scrape_item"""
         return copy.deepcopy(self)

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -384,7 +384,7 @@ def regex_links(line: str) -> Generator[AbsoluteHttpURL]:
 def _create_item_from_row(row: aiosqlite.Row) -> ScrapeItem:
     referer: str = row["referer"]
     url = AbsoluteHttpURL(referer, encoded="%" in referer)
-    item = ScrapeItem(url=url, retry_path=Path(row["download_path"]), part_of_album=True, retry=True)
+    item = ScrapeItem(url=url, retry_path=Path(row["download_path"]), part_of_album=True)
     if completed_at := row["completed_at"]:
         item.completed_at = int(datetime.fromisoformat(completed_at).timestamp())
     if created_at := row["created_at"]:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -231,8 +231,8 @@ def get_download_path(manager: Manager, scrape_item: ScrapeItem, domain: str) ->
     """Returns the path to the download folder."""
     download_dir = manager.path_manager.download_folder
 
-    if scrape_item.retry:
-        return scrape_item.retry_path  # type: ignore
+    if scrape_item.retry_path:
+        return scrape_item.retry_path
     if scrape_item.parent_title and scrape_item.part_of_album:
         return download_dir / scrape_item.parent_title
     if scrape_item.parent_title:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -231,13 +231,7 @@ def get_download_path(manager: Manager, scrape_item: ScrapeItem, domain: str) ->
     """Returns the path to the download folder."""
     download_dir = manager.path_manager.download_folder
 
-    if scrape_item.retry_path:
-        return scrape_item.retry_path
-    if scrape_item.parent_title and scrape_item.part_of_album:
-        return download_dir / scrape_item.parent_title
-    if scrape_item.parent_title:
-        return download_dir / scrape_item.parent_title / f"Loose Files ({domain})"
-    return download_dir / f"Loose Files ({domain})"
+    return download_dir / scrape_item.create_download_path(domain)
 
 
 def remove_file_id(manager: Manager, filename: str, ext: str) -> tuple[str, str]:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -13,12 +13,18 @@ from cyberdrop_dl.utils.utilities import parse_url
 if TYPE_CHECKING:
     import aiosqlite
 
+
 _MOCK_ROW = {
     "referer": "https://drive.google.com/file/d/1F0YBsnQRvrMbK0p9UlnyLu88kqQ0j_F6/edit",
     "download_path": "/cdl/downloads",
     "completed_at": None,
     "created_at": None,
 }
+
+
+@pytest.fixture
+def item() -> ScrapeItem:
+    return ScrapeItem(url=AbsoluteHttpURL("https://drive.google.com"))
 
 
 @pytest.fixture
@@ -110,3 +116,30 @@ def test_create_db_path(url: str, expected: str) -> None:
     url_ = parse_url(url)
     path = MediaItem.create_db_path(url_, url_.host)
     assert path == expected
+
+
+class TestGetDownloadPath:
+    def test_loose_file(self, item: ScrapeItem) -> None:
+        assert not item.parent_title
+        assert not item.part_of_album
+        assert not item.retry_path
+        download_path = item.create_download_path("cyberdrop")
+        assert download_path == Path("Loose Files (cyberdrop)")
+
+    def test_loose_file_with_parent(self, item: ScrapeItem) -> None:
+        item.add_to_parent_title("a/sub/folder")
+        download_path = item.create_download_path("cyberdrop")
+        assert download_path == Path("a-sub-folder/Loose Files (cyberdrop)")
+
+    def test_album_file(self, item: ScrapeItem) -> None:
+        item.add_to_parent_title("a/sub/folder")
+        item.part_of_album = True
+        download_path = item.create_download_path("cyberdrop")
+        assert download_path == Path("a-sub-folder")
+
+    def test_retry_path(self, item: ScrapeItem) -> None:
+        item.add_to_parent_title("a/sub/folder")
+        item.part_of_album = True
+        item.retry_path = retry_path = Path("a/retry/path")
+        download_path = item.create_download_path("cyberdrop")
+        assert download_path == retry_path

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -39,7 +39,6 @@ def test_scrape_item_creation(row: aiosqlite.Row) -> None:
     assert item.url == AbsoluteHttpURL("https://drive.google.com/file/d/1F0YBsnQRvrMbK0p9UlnyLu88kqQ0j_F6/edit")
     assert item.retry_path == Path("/cdl/downloads")
     assert item.part_of_album is True
-    assert item.retry is True
     assert item.completed_at is None
     assert item.created_at is None
 


### PR DESCRIPTION
If `retry_path` is not `None`, we already know this is a retried download