### PR TITLE
refactor: rename date filter config options

### DIFF
--- a/cyberdrop_dl/config/config_model.py
+++ b/cyberdrop_dl/config/config_model.py
@@ -164,8 +164,8 @@ class IgnoreOptions(BaseModel):
     only_hosts: ListNonEmptyStr = []
     skip_hosts: ListNonEmptyStr = []
     exclude_files_with_no_extension: bool = True
-    exclude_posts_before: datetime | None = None
-    exclude_posts_after: datetime | None = None
+    exclude_before: datetime | None = None
+    exclude_after: datetime | None = None
 
     @field_validator("filename_regex_filter")
     @classmethod

--- a/cyberdrop_dl/config/config_model.py
+++ b/cyberdrop_dl/config/config_model.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from logging import DEBUG
 from pathlib import Path
 
@@ -164,8 +164,8 @@ class IgnoreOptions(BaseModel):
     only_hosts: ListNonEmptyStr = []
     skip_hosts: ListNonEmptyStr = []
     exclude_files_with_no_extension: bool = True
-    exclude_before: datetime | None = None
-    exclude_after: datetime | None = None
+    exclude_before: date | None = None
+    exclude_after: date | None = None
 
     @field_validator("filename_regex_filter")
     @classmethod

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -200,6 +200,10 @@ class MediaItem:
 
         return url.path
 
+    def datetime_obj(self) -> datetime.datetime | None:
+        if self.datetime:
+            return datetime.datetime.fromtimestamp(self.datetime).astimezone(datetime.UTC)
+
     @staticmethod
     def from_item(
         origin: ScrapeItem | MediaItem,

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -203,7 +203,7 @@ class MediaItem:
     def datetime_obj(self) -> datetime.datetime | None:
         if self.datetime:
             assert isinstance(self.datetime, int), f"Invalid {self.datetime =!r} from {self.referer}"
-            return datetime.datetime.fromtimestamp(self.datetime).astimezone(datetime.UTC)
+            return datetime.datetime.fromtimestamp(self.datetime)
 
     @staticmethod
     def from_item(

--- a/cyberdrop_dl/data_structures/url_objects.py
+++ b/cyberdrop_dl/data_structures/url_objects.py
@@ -202,6 +202,7 @@ class MediaItem:
 
     def datetime_obj(self) -> datetime.datetime | None:
         if self.datetime:
+            assert isinstance(self.datetime, int), f"Invalid {self.datetime =!r} from {self.referer}"
             return datetime.datetime.fromtimestamp(self.datetime).astimezone(datetime.UTC)
 
     @staticmethod
@@ -257,9 +258,8 @@ class MediaItem:
 
     def as_jsonable_dict(self) -> dict[str, Any]:
         item = asdict(self)
-        if self.datetime:
-            assert isinstance(self.datetime, int), f"Invalid {self.datetime =!r} from {self.referer}"
-            item["datetime"] = datetime.datetime.fromtimestamp(self.datetime)
+        if datetime := self.datetime_obj():
+            item["datetime"] = datetime
         item["attempts"] = item.pop("current_attempt")
         if self.hash:
             item["hash"] = f"xxh128:{self.hash}"

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -446,7 +446,7 @@ class Downloader:
             if not media_item.is_segment:
                 log(f"Download skip {media_item.url}: {e}", 10)
                 self.manager.progress_manager.download_progress.add_skipped()
-                self.attempt_task_removal(media_item)
+            self.attempt_task_removal(media_item)
 
         except (DownloadError, ClientResponseError, InvalidContentTypeError):
             raise

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -24,6 +24,7 @@ from cyberdrop_dl.exceptions import (
     InvalidContentTypeError,
     RestrictedDateRangeError,
     RestrictedFiletypeError,
+    SkipDownloadError,
     TooManyCrawlerErrors,
 )
 from cyberdrop_dl.utils import aio, ffmpeg
@@ -441,21 +442,11 @@ class Downloader:
             self.attempt_task_removal(media_item)
             return downloaded
 
-        except RestrictedFiletypeError:
+        except SkipDownloadError as e:
             if not media_item.is_segment:
-                log(f"Download skip {media_item.url} due to ignore_extension config ({media_item.ext})", 10)
+                log(f"Download skip {media_item.url}: {e}", 10)
                 self.manager.progress_manager.download_progress.add_skipped()
                 self.attempt_task_removal(media_item)
-
-        except RestrictedDateRangeError:
-            timestamp_str = (
-                datetime.fromtimestamp(media_item.datetime).strftime("%Y-%m-%d %H:%M:%S")
-                if media_item.datetime
-                else "Unknown date"
-            )
-            log(f"Download skip {media_item.url} due to exclude_posts_date config ({timestamp_str})", 10)
-            self.manager.progress_manager.download_progress.add_skipped()
-            self.attempt_task_removal(media_item)
 
         except (DownloadError, ClientResponseError, InvalidContentTypeError):
             raise

--- a/cyberdrop_dl/exceptions.py
+++ b/cyberdrop_dl/exceptions.py
@@ -150,18 +150,30 @@ class InsufficientFreeSpaceError(CDLBaseError):
         super().__init__(ui_failure, origin=origin)
 
 
-class RestrictedFiletypeError(CDLBaseError):
-    def __init__(self, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
-        """This error will be thrown when has a filytpe not allowed by config."""
+class SkipDownloadError(CDLBaseError):
+    """Throw this when a download is not allowed by config options"""
+
+
+class RestrictedFiletypeError(SkipDownloadError):
+    def __init__(self, origin: MediaItem) -> None:
+        """This error will be thrown when has a filetype not allowed by config."""
         ui_failure = "Restricted Filetype"
         super().__init__(ui_failure, origin=origin)
 
 
-class DurationError(CDLBaseError):
+class DurationError(SkipDownloadError):
     def __init__(self, origin: MediaItem) -> None:
-        """THis error will be thrown when the file duration is not allowed by the config."""
+        """This error will be thrown when the file duration is not allowed by the config."""
         ui_failure = "Duration Not Allowed"
         message = f"Duration ({origin.duration}s) out of config range"
+        super().__init__(ui_failure, message=message, origin=origin)
+
+
+class RestrictedDateRangeError(SkipDownloadError):
+    def __init__(self, origin: MediaItem) -> None:
+        """This error will be thrown when the publication date of the media item is not allowed by config."""
+        ui_failure = "Restricted DateRange"
+        message = f"File upload date ({origin.datetime}s) out of config range"
         super().__init__(ui_failure, message=message, origin=origin)
 
 
@@ -211,13 +223,6 @@ class InvalidYamlError(CDLBaseError):
         msg += f"\n\n{problem.capitalize()}"
         msg += f"\n\n{VALIDATION_ERROR_FOOTER}"
         super().__init__(ui_failure, message=msg, origin=file)
-
-
-class RestrictedDateRangeError(CDLBaseError):
-    def __init__(self, origin: ScrapeItem | MediaItem | URL | None = None) -> None:
-        """This error will be thrown when the publication date of the media item is not allowed by config."""
-        ui_failure = "Restricted DateRange"
-        super().__init__(ui_failure, origin=origin)
 
 
 def create_error_msg(error: int | str) -> str:

--- a/cyberdrop_dl/exceptions.py
+++ b/cyberdrop_dl/exceptions.py
@@ -157,15 +157,16 @@ class SkipDownloadError(CDLBaseError):
 class RestrictedFiletypeError(SkipDownloadError):
     def __init__(self, origin: MediaItem) -> None:
         """This error will be thrown when has a filetype not allowed by config."""
-        ui_failure = "Restricted Filetype"
-        super().__init__(ui_failure, origin=origin)
+        ui_failure = "Restricted File Ext"
+        message = f"File extension ({origin.ext}) ignored config options"
+        super().__init__(ui_failure, message=message, origin=origin)
 
 
 class DurationError(SkipDownloadError):
     def __init__(self, origin: MediaItem) -> None:
         """This error will be thrown when the file duration is not allowed by the config."""
         ui_failure = "Duration Not Allowed"
-        message = f"Duration ({origin.duration}s) out of config range"
+        message = f"File duration ({origin.duration}s) out of config range"
         super().__init__(ui_failure, message=message, origin=origin)
 
 

--- a/cyberdrop_dl/exceptions.py
+++ b/cyberdrop_dl/exceptions.py
@@ -173,7 +173,7 @@ class RestrictedDateRangeError(SkipDownloadError):
     def __init__(self, origin: MediaItem) -> None:
         """This error will be thrown when the publication date of the media item is not allowed by config."""
         ui_failure = "Restricted DateRange"
-        message = f"File upload date ({origin.datetime}s) out of config range"
+        message = f"File upload date ({origin.datetime_obj()}s) out of config range"
         super().__init__(ui_failure, message=message, origin=origin)
 
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -5,7 +5,6 @@ import contextlib
 import ssl
 from base64 import b64encode
 from collections import defaultdict
-from datetime import datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Literal, Self, overload
 
@@ -226,14 +225,15 @@ class ClientManager:
 
     def check_allowed_date_range(self, media_item: MediaItem) -> bool:
         """Checks if the file was uploaded within the config date range"""
-        if not media_item.datetime:
+        datetime = media_item.datetime_obj()
+        if not datetime:
             return True
 
         ignore_options = self.manager.config_manager.settings_data.ignore_options
-        post_datetime = datetime.fromtimestamp(media_item.datetime)
-        if ignore_options.exclude_before and post_datetime < ignore_options.exclude_before:
+
+        if ignore_options.exclude_before and datetime < ignore_options.exclude_before:
             return False
-        if ignore_options.exclude_after and post_datetime > ignore_options.exclude_after:
+        if ignore_options.exclude_after and datetime > ignore_options.exclude_after:
             return False
         return True
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -225,15 +225,15 @@ class ClientManager:
         return not (ignore_options.exclude_other and media_item.ext.lower() not in _VALID_EXTENSIONS)
 
     def check_allowed_date_range(self, media_item: MediaItem) -> bool:
-        """Checks if the file is published within the date range configured."""
+        """Checks if the file was uploaded within the config date range"""
         if not media_item.datetime:
             return True
 
         ignore_options = self.manager.config_manager.settings_data.ignore_options
         post_datetime = datetime.fromtimestamp(media_item.datetime)
-        if ignore_options.exclude_posts_before and post_datetime < ignore_options.exclude_posts_before:
+        if ignore_options.exclude_before and post_datetime < ignore_options.exclude_before:
             return False
-        if ignore_options.exclude_posts_after and post_datetime > ignore_options.exclude_posts_after:
+        if ignore_options.exclude_after and post_datetime > ignore_options.exclude_after:
             return False
         return True
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -229,11 +229,12 @@ class ClientManager:
         if not datetime:
             return True
 
+        item_date = datetime.date()
         ignore_options = self.manager.config_manager.settings_data.ignore_options
 
-        if ignore_options.exclude_before and datetime < ignore_options.exclude_before:
+        if ignore_options.exclude_before and item_date < ignore_options.exclude_before:
             return False
-        if ignore_options.exclude_after and datetime > ignore_options.exclude_after:
+        if ignore_options.exclude_after and item_date > ignore_options.exclude_after:
             return False
         return True
 

--- a/docs/reference/configuration-options/settings/ignore_options.md
+++ b/docs/reference/configuration-options/settings/ignore_options.md
@@ -101,7 +101,7 @@ You can supply hosts that you'd like the program to skip, to not scrape/download
 
 | Type                 | Default | Additional Info                                                    |
 | -------------------- | ------- | ------------------------------------------------------------------ |
-| `datetime` or `null` | `null`  | The `datetime` value should be in the `YYYY-MM-DD HH:MM:SS` format |
+| `date` or `null` | `null`  | The date should a valid ISO 8601 format, for example, `2021-12-23` |
 
 Do not download files uploaded before this date.
 
@@ -109,6 +109,6 @@ Do not download files uploaded before this date.
 
 | Type                 | Default | Additional Info                                                    |
 | -------------------- | ------- | ------------------------------------------------------------------ |
-| `datetime` or `null` | `null`  | The `datetime` value should be in the `YYYY-MM-DD HH:MM:SS` format |
+| `date` or `null` | `null`  | The date should a valid ISO 8601 format, for example, `2021-12-23` |
 
 Do not download files uploaded after this date.

--- a/docs/reference/configuration-options/settings/ignore_options.md
+++ b/docs/reference/configuration-options/settings/ignore_options.md
@@ -97,18 +97,18 @@ You can supply hosts that you'd like the program to exclusively scrape/download 
 
 You can supply hosts that you'd like the program to skip, to not scrape/download from them. This setting accepts any domain, even if they are no supported.
 
-## `exclude_posts_before`
+## `exclude_before`
 
 | Type                 | Default | Additional Info                                                    |
 | -------------------- | ------- | ------------------------------------------------------------------ |
 | `datetime` or `null` | `null`  | The `datetime` value should be in the `YYYY-MM-DD HH:MM:SS` format |
 
-When a valid datetime value is provided, this excludes all posts published before that particular datetime.
+Do not download files uploaded before this date.
 
-## `exclude_posts_after`
+## `exclude_after`
 
 | Type                 | Default | Additional Info                                                    |
 | -------------------- | ------- | ------------------------------------------------------------------ |
 | `datetime` or `null` | `null`  | The `datetime` value should be in the `YYYY-MM-DD HH:MM:SS` format |
 
-When a valid datetime value is provided, this excludes all posts published after that particular datetime.
+Do not download files uploaded after this date.


### PR DESCRIPTION
Rename `exclude_posts_before` -> `exclude_before`
Rename `exclude_posts_after` -> `exclude_after`

They apply to every file. It does not matter if they came from a post of not

Also:
- fix files skipped by duration before the actual download not being marked as skipped
- Add method to `MediaItem` to get the date as a `datetime` object
- Related to #1334 