### PR TITLE
refactor: move no_crawler to its own module

### DIFF
--- a/cyberdrop_dl/crawlers/discourse/__init__.py
+++ b/cyberdrop_dl/crawlers/discourse/__init__.py
@@ -10,3 +10,5 @@ _DISCOURSES_SITES = ["https://forums.plex.tv"]
 
 
 DISCOURSE_CRAWLERS: set[type[DiscourseCrawler]] = create_crawlers(_DISCOURSES_SITES, DiscourseCrawler)
+
+__all__ = ["DISCOURSE_CRAWLERS", "DiscourseCrawler"]

--- a/cyberdrop_dl/crawlers/generic.py
+++ b/cyberdrop_dl/crawlers/generic.py
@@ -71,6 +71,7 @@ class GenericCrawler(Crawler):
         if not ext:
             msg = f"Received '{content_type}', was expecting other"
             raise InvalidContentTypeError(message=msg)
+
         fullname = Path(filename).with_suffix(ext)
         filename, _ = self.get_filename_and_ext(fullname.name)
         await self.handle_file(scrape_item.url, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/generic.py
+++ b/cyberdrop_dl/crawlers/generic.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, ClassVar, ParamSpec, TypeVar
 
 from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.exceptions import InvalidContentTypeError, NoExtensionError, ScrapeError
-from cyberdrop_dl.scraper.filters import has_valid_extension
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.logger import log
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_filename_and_ext
@@ -109,13 +108,10 @@ def get_ext_from_content_type(content_type: str) -> str | None:
 
 
 def get_name_and_ext_from_url(url: AbsoluteHttpURL) -> tuple[str, str | None]:
-    if not has_valid_extension(url):
-        return url.name, None
     try:
-        filename, ext = get_filename_and_ext(url.name)
+        return get_filename_and_ext(url.name)
     except NoExtensionError:
-        filename, ext = get_filename_and_ext(url.name, forum=True)
-    return filename, ext
+        return url.name, None
 
 
 CONTENT_TYPE_TO_EXTENSION = {

--- a/cyberdrop_dl/crawlers/http_direct.py
+++ b/cyberdrop_dl/crawlers/http_direct.py
@@ -18,22 +18,21 @@ class DirectHttpFile(Crawler, is_generic=True):
     DOMAIN: ClassVar[str] = "no_crawler"
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
-        url = scrape_item.url
         try:
             filename, ext = get_filename_and_ext(scrape_item.url.name)
         except NoExtensionError:
             filename, ext = get_filename_and_ext(scrape_item.url.name, forum=True)
 
-        if ext in MEDIA_EXTENSIONS:
+        if ext not in MEDIA_EXTENSIONS:
             raise ValueError
 
         scrape_item.add_to_parent_title("Loose Files")
         scrape_item.part_of_album = True
         self.create_task(
             self.handle_file(
-                url,
+                scrape_item.url,
                 scrape_item,
-                url.name,
+                scrape_item.url.name,
                 ext,
                 custom_filename=filename,
             )

--- a/cyberdrop_dl/crawlers/http_direct.py
+++ b/cyberdrop_dl/crawlers/http_direct.py
@@ -1,37 +1,24 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from cyberdrop_dl.constants import FILE_FORMATS
-from cyberdrop_dl.data_structures.url_objects import MediaItem
-from cyberdrop_dl.downloader.downloader import Downloader
+from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.exceptions import NoExtensionError
-from cyberdrop_dl.utils.logger import log
-from cyberdrop_dl.utils.utilities import get_download_path, get_filename_and_ext
+from cyberdrop_dl.utils.utilities import get_filename_and_ext
 
 if TYPE_CHECKING:
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
-    from cyberdrop_dl.managers.manager import Manager
 
-
-from typing import Final
 
 MEDIA_EXTENSIONS = FILE_FORMATS["Images"] | FILE_FORMATS["Videos"] | FILE_FORMATS["Audio"]
 
 
-class DirectHttpFile:
-    DOMAIN: Final = "no_crawler"
-
-    def __init__(self, manager: Manager) -> None:
-        self.manager = manager
-        self.downloader = Downloader(manager, self.DOMAIN)
-
-    def startup(self) -> None:
-        self.downloader.startup()
+class DirectHttpFile(Crawler, is_generic=True):
+    DOMAIN: ClassVar[str] = "no_crawler"
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
-        """Checks if the URL has a valid extension."""
-
+        url = scrape_item.url
         try:
             filename, ext = get_filename_and_ext(scrape_item.url.name)
         except NoExtensionError:
@@ -40,42 +27,14 @@ class DirectHttpFile:
         if ext in MEDIA_EXTENSIONS:
             raise ValueError
 
-        if await self.skip_no_crawler_by_config(scrape_item):
-            return
-
         scrape_item.add_to_parent_title("Loose Files")
         scrape_item.part_of_album = True
-        download_folder = get_download_path(self.manager, scrape_item, self.DOMAIN)
-
-        media_item = MediaItem.from_item(
-            scrape_item,
-            scrape_item.url,
-            self.DOMAIN,
-            download_folder,
-            filename,
-            original_filename=scrape_item.url.name,
+        self.create_task(
+            self.handle_file(
+                url,
+                scrape_item,
+                url.name,
+                ext,
+                custom_filename=filename,
+            )
         )
-        self.manager.task_group.create_task(self.downloader.run(media_item))
-
-    async def skip_no_crawler_by_config(self, scrape_item: ScrapeItem) -> bool:
-        check_complete = await self.manager.db_manager.history_table.check_complete(
-            "no_crawler",
-            scrape_item.url,
-            scrape_item.url,
-        )
-        if check_complete:
-            log(f"Skipping {scrape_item.url} as it has already been downloaded", 10)
-            self.manager.progress_manager.download_progress.add_previously_completed()
-            return True
-
-        posible_referer = scrape_item.parents[-1] if scrape_item.parents else scrape_item.url
-        check_referer = False
-        if self.manager.config_manager.settings_data.download_options.skip_referer_seen_before:
-            check_referer = await self.manager.db_manager.temp_referer_table.check_referer(posible_referer)
-
-        if check_referer:
-            log(f"Skipping {scrape_item.url} as referer has been seen before", 10)
-            self.manager.progress_manager.download_progress.add_skipped()
-            return True
-
-        return False

--- a/cyberdrop_dl/crawlers/http_direct.py
+++ b/cyberdrop_dl/crawlers/http_direct.py
@@ -28,12 +28,10 @@ class DirectHttpFile(Crawler, is_generic=True):
 
         scrape_item.add_to_parent_title("Loose Files")
         scrape_item.part_of_album = True
-        self.create_task(
-            self.handle_file(
-                scrape_item.url,
-                scrape_item,
-                scrape_item.url.name,
-                ext,
-                custom_filename=filename,
-            )
+        await self.handle_file(
+            scrape_item.url,
+            scrape_item,
+            scrape_item.url.name,
+            ext,
+            custom_filename=filename,
         )

--- a/cyberdrop_dl/crawlers/http_direct.py
+++ b/cyberdrop_dl/crawlers/http_direct.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cyberdrop_dl.constants import FILE_FORMATS
+from cyberdrop_dl.data_structures.url_objects import MediaItem
+from cyberdrop_dl.downloader.downloader import Downloader
+from cyberdrop_dl.exceptions import NoExtensionError
+from cyberdrop_dl.utils.logger import log
+from cyberdrop_dl.utils.utilities import get_download_path, get_filename_and_ext
+
+if TYPE_CHECKING:
+    from cyberdrop_dl.data_structures.url_objects import ScrapeItem
+    from cyberdrop_dl.managers.manager import Manager
+
+
+from typing import Final
+
+MEDIA_EXTENSIONS = FILE_FORMATS["Images"] | FILE_FORMATS["Videos"] | FILE_FORMATS["Audio"]
+
+
+class DirectHttpFile:
+    DOMAIN: Final = "no_crawler"
+
+    def __init__(self, manager: Manager) -> None:
+        self.manager = manager
+        self.downloader = Downloader(manager, self.DOMAIN)
+
+    def startup(self) -> None:
+        self.downloader.startup()
+
+    async def fetch(self, scrape_item: ScrapeItem) -> None:
+        """Checks if the URL has a valid extension."""
+
+        try:
+            filename, ext = get_filename_and_ext(scrape_item.url.name)
+        except NoExtensionError:
+            filename, ext = get_filename_and_ext(scrape_item.url.name, forum=True)
+
+        if ext in MEDIA_EXTENSIONS:
+            raise ValueError
+
+        if await self.skip_no_crawler_by_config(scrape_item):
+            return
+
+        scrape_item.add_to_parent_title("Loose Files")
+        scrape_item.part_of_album = True
+        download_folder = get_download_path(self.manager, scrape_item, self.DOMAIN)
+
+        media_item = MediaItem.from_item(
+            scrape_item,
+            scrape_item.url,
+            self.DOMAIN,
+            download_folder,
+            filename,
+            original_filename=scrape_item.url.name,
+        )
+        self.manager.task_group.create_task(self.downloader.run(media_item))
+
+    async def skip_no_crawler_by_config(self, scrape_item: ScrapeItem) -> bool:
+        check_complete = await self.manager.db_manager.history_table.check_complete(
+            "no_crawler",
+            scrape_item.url,
+            scrape_item.url,
+        )
+        if check_complete:
+            log(f"Skipping {scrape_item.url} as it has already been downloaded", 10)
+            self.manager.progress_manager.download_progress.add_previously_completed()
+            return True
+
+        posible_referer = scrape_item.parents[-1] if scrape_item.parents else scrape_item.url
+        check_referer = False
+        if self.manager.config_manager.settings_data.download_options.skip_referer_seen_before:
+            check_referer = await self.manager.db_manager.temp_referer_table.check_referer(posible_referer)
+
+        if check_referer:
+            log(f"Skipping {scrape_item.url} as referer has been seen before", 10)
+            self.manager.progress_manager.download_progress.add_skipped()
+            return True
+
+        return False

--- a/cyberdrop_dl/scraper/filters.py
+++ b/cyberdrop_dl/scraper/filters.py
@@ -7,11 +7,8 @@ from typing import TYPE_CHECKING
 
 from yarl import URL
 
-import cyberdrop_dl.constants as constants
-from cyberdrop_dl.constants import FILE_FORMATS
+from cyberdrop_dl import constants
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
-from cyberdrop_dl.exceptions import NoExtensionError
-from cyberdrop_dl.utils.utilities import get_filename_and_ext
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -22,8 +19,6 @@ if TYPE_CHECKING:
 
 
 return_values: dict[AbsoluteHttpURL | str, tuple] = {}
-
-MEDIA_EXTENSIONS = FILE_FORMATS["Images"] | FILE_FORMATS["Videos"] | FILE_FORMATS["Audio"]
 
 
 def is_valid_url(scrape_item: ScrapeItem) -> bool:
@@ -57,18 +52,6 @@ def is_outside_date_range(scrape_item: ScrapeItem, before: datetime.date | None,
 
 def is_in_domain_list(scrape_item: ScrapeItem, domain_list: Sequence[str]) -> bool:
     return any(domain in scrape_item.url.host for domain in domain_list)
-
-
-def has_valid_extension(url: URL, forum: bool = False) -> bool:
-    """Checks if the URL has a valid extension."""
-    try:
-        _, ext = get_filename_and_ext(url.name, forum=forum)
-    except NoExtensionError:
-        if not forum:
-            return has_valid_extension(url, forum=True)
-        return False
-    else:
-        return ext in MEDIA_EXTENSIONS
 
 
 cache_filter_functions = {}

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -15,15 +15,15 @@ from cyberdrop_dl.crawlers._chevereto import CheveretoCrawler
 from cyberdrop_dl.crawlers.crawler import Crawler, create_crawlers
 from cyberdrop_dl.crawlers.discourse import DiscourseCrawler
 from cyberdrop_dl.crawlers.generic import GenericCrawler
+from cyberdrop_dl.crawlers.http_direct import DirectHttpFile
 from cyberdrop_dl.crawlers.realdebrid import RealDebridCrawler
 from cyberdrop_dl.crawlers.wordpress import WordPressHTMLCrawler, WordPressMediaCrawler
-from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL, MediaItem, ScrapeItem
-from cyberdrop_dl.downloader.downloader import Downloader
+from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL, ScrapeItem
 from cyberdrop_dl.exceptions import JDownloaderError, NoExtensionError
-from cyberdrop_dl.scraper.filters import has_valid_extension, is_in_domain_list, is_outside_date_range, is_valid_url
+from cyberdrop_dl.scraper.filters import is_in_domain_list, is_outside_date_range, is_valid_url
 from cyberdrop_dl.scraper.jdownloader import JDownloader
 from cyberdrop_dl.utils.logger import log, log_spacer
-from cyberdrop_dl.utils.utilities import get_download_path, get_filename_and_ext, remove_trailing_slash
+from cyberdrop_dl.utils.utilities import get_download_path, remove_trailing_slash
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -46,7 +46,7 @@ class ScrapeMapper:
     def __init__(self, manager: Manager) -> None:
         self.manager = manager
         self.existing_crawlers: dict[str, Crawler] = {}
-        self.no_crawler_downloader = Downloader(self.manager, "no_crawler")
+        self.no_crawler = DirectHttpFile(self.manager)
         self.jdownloader = JDownloader(self.manager)
         self.jdownloader_whitelist = self.manager.config_manager.settings_data.runtime_options.jdownloader_whitelist
         self.using_input_file = False
@@ -107,7 +107,7 @@ class ScrapeMapper:
         await self.manager.db_manager.history_table.update_previously_unsupported(self.existing_crawlers)
         self.jdownloader.connect()
         await self.start_real_debrid()
-        self.no_crawler_downloader.startup()
+        self.no_crawler.startup()
         async for item in self.get_input_items():
             self.manager.task_group.create_task(self.send_to_crawler(item))
 
@@ -182,7 +182,7 @@ class ScrapeMapper:
             return
 
         for url in self.manager.parsed_args.cli_only_args.links:
-            yield ScrapeItem(url=url)  # type: ignore
+            yield ScrapeItem(url=url)
 
     async def load_failed_links(self) -> AsyncGenerator[ScrapeItem]:
         """Loads failed links from database."""
@@ -232,21 +232,12 @@ class ScrapeMapper:
             self.manager.task_group.create_task(self.real_debrid.run(scrape_item))
             return
 
-        if has_valid_extension(scrape_item.url):
-            if await self.skip_no_crawler_by_config(scrape_item):
-                return
-
-            scrape_item.add_to_parent_title("Loose Files")
-            scrape_item.part_of_album = True
-            domain = "no_crawler"
-            download_folder = get_download_path(self.manager, scrape_item, domain)
-            try:
-                filename, _ = get_filename_and_ext(scrape_item.url.name)
-            except NoExtensionError:
-                filename, _ = get_filename_and_ext(scrape_item.url.name, forum=True)
-            media_item = MediaItem.from_item(scrape_item, scrape_item.url, domain, download_folder, filename)
-            self.manager.task_group.create_task(self.no_crawler_downloader.run(media_item))
+        try:
+            await self.no_crawler.fetch(scrape_item)
             return
+
+        except (NoExtensionError, ValueError):
+            pass
 
         if self.jdownloader.enabled and jdownloader_whitelisted:
             log(f"Sending unsupported URL to JDownloader: {scrape_item.url}", 20)
@@ -315,29 +306,6 @@ class ScrapeMapper:
             return False
 
         return True
-
-    async def skip_no_crawler_by_config(self, scrape_item: ScrapeItem) -> bool:
-        check_complete = await self.manager.db_manager.history_table.check_complete(
-            "no_crawler",
-            scrape_item.url,
-            scrape_item.url,
-        )
-        if check_complete:
-            log(f"Skipping {scrape_item.url} as it has already been downloaded", 10)
-            self.manager.progress_manager.download_progress.add_previously_completed()
-            return True
-
-        posible_referer = scrape_item.parents[-1] if scrape_item.parents else scrape_item.url
-        check_referer = False
-        if self.manager.config_manager.settings_data.download_options.skip_referer_seen_before:
-            check_referer = await self.manager.db_manager.temp_referer_table.check_referer(posible_referer)
-
-        if check_referer:
-            log(f"Skipping {scrape_item.url} as referer has been seen before", 10)
-            self.manager.progress_manager.download_progress.add_skipped()
-            return True
-
-        return False
 
     def disable_crawler(self, domain: str) -> Crawler | None:
         """Disables a crawler at runtime, after the scrape mapper is already running.

--- a/cyberdrop_dl/scraper/scrape_mapper.py
+++ b/cyberdrop_dl/scraper/scrape_mapper.py
@@ -46,7 +46,7 @@ class ScrapeMapper:
     def __init__(self, manager: Manager) -> None:
         self.manager = manager
         self.existing_crawlers: dict[str, Crawler] = {}
-        self.no_crawler = DirectHttpFile(self.manager)
+        self.direct_crawler = DirectHttpFile(self.manager)
         self.jdownloader = JDownloader(self.manager)
         self.jdownloader_whitelist = self.manager.config_manager.settings_data.runtime_options.jdownloader_whitelist
         self.using_input_file = False
@@ -73,7 +73,6 @@ class ScrapeMapper:
         """Starts all scrapers."""
         self.existing_crawlers = get_crawlers_mapping(self.manager)
         self.fallback_generic = GenericCrawler(self.manager)
-
         generic_crawlers = create_generic_crawlers_by_config(self.global_settings.generic_crawlers_instances)
         for crawler in generic_crawlers:
             register_crawler(self.existing_crawlers, crawler(self.manager), from_user=True)
@@ -107,7 +106,7 @@ class ScrapeMapper:
         await self.manager.db_manager.history_table.update_previously_unsupported(self.existing_crawlers)
         self.jdownloader.connect()
         await self.start_real_debrid()
-        self.no_crawler.startup()
+        self.direct_crawler._init_downloader()
         async for item in self.get_input_items():
             self.manager.task_group.create_task(self.send_to_crawler(item))
 
@@ -233,7 +232,7 @@ class ScrapeMapper:
             return
 
         try:
-            await self.no_crawler.fetch(scrape_item)
+            await self.direct_crawler.fetch(scrape_item)
             return
 
         except (NoExtensionError, ValueError):


### PR DESCRIPTION
It has to actually inherit from crawler to make sure the URL follows all logic workflow (skip by filename regex, be logged to json output, etc)