### PR TITLE
refactor: simplify `css` module API

### DIFF
--- a/cyberdrop_dl/crawlers/_forum.py
+++ b/cyberdrop_dl/crawlers/_forum.py
@@ -80,11 +80,11 @@ class ForumPost:
     def new(article: Tag, selectors: PostSelectors) -> ForumPost:
         for trash in selectors.article_trash:
             css.decompose(article, trash)
-        content = css.select_one(article, selectors.content)
+        content = css.select(article, selectors.content)
         for trash in selectors.content_trash:
             css.decompose(article, trash)
         try:
-            date = datetime.datetime.fromisoformat(css.select_one_get_attr(article, *selectors.date))
+            date = datetime.datetime.fromisoformat(css.select(article, *selectors.date))
         except Exception:
             date = None
 
@@ -658,8 +658,8 @@ async def check_is_not_last_page(response: ClientResponse, selectors: MessageBoa
 
 def is_last_page(soup: BeautifulSoup, selectors: MessageBoardSelectors) -> bool:
     try:
-        last_page = css.select_one_get_attr(soup, *selectors.last_page)
-        current_page = css.select_one_get_attr(soup, *selectors.current_page)
+        last_page = css.select(soup, *selectors.last_page)
+        current_page = css.select(soup, *selectors.current_page)
     except (AttributeError, IndexError, css.SelectorError):
         return True
     return current_page == last_page
@@ -667,7 +667,7 @@ def is_last_page(soup: BeautifulSoup, selectors: MessageBoardSelectors) -> bool:
 
 def get_post_title(soup: BeautifulSoup, selectors: MessageBoardSelectors) -> str:
     try:
-        title_block = css.select_one(soup, selectors.title.element)
+        title_block = css.select(soup, selectors.title.element)
         for trash in selectors.title_trash:
             css.decompose(title_block, trash)
     except (AttributeError, AssertionError, css.SelectorError) as e:

--- a/cyberdrop_dl/crawlers/_kvs.py
+++ b/cyberdrop_dl/crawlers/_kvs.py
@@ -85,7 +85,7 @@ class KernelVideoSharingCrawler(Crawler, is_abc=True):
             search_query = search_query or scrape_item.url.parts[2]
             title = f"{search_query} [search]"
         else:
-            common_title = css.select_one_get_text(soup, _SELECTORS.COMMON_VIDEOS_TITLE)
+            common_title = css.select_text(soup, _SELECTORS.COMMON_VIDEOS_TITLE)
             if common_title.startswith("New Videos Tagged"):
                 common_title = common_title.split("Showing")[0].split("Tagged with")[1].strip()
                 title = f"{common_title} [tag]"
@@ -101,7 +101,7 @@ class KernelVideoSharingCrawler(Crawler, is_abc=True):
     async def profile(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        user_name: str = css.select_one_get_text(soup, _SELECTORS.USER_NAME).split("'s Profile")[0].strip()
+        user_name: str = css.select_text(soup, _SELECTORS.USER_NAME).split("'s Profile")[0].strip()
         title = f"{user_name} [user]"
         title = self.create_title(title)
         scrape_item.setup_as_profile(title)
@@ -132,7 +132,7 @@ class KernelVideoSharingCrawler(Crawler, is_abc=True):
             date_str = css.get_json_ld_date(soup)
             scrape_item.possible_datetime = self.parse_iso_date(date_str)
         except (LookupError, ValueError, css.SelectorError):
-            date_str = css.select_one_get_text(soup, _SELECTORS.DATE).split(":", 1)[-1].strip()
+            date_str = css.select_text(soup, _SELECTORS.DATE).split(":", 1)[-1].strip()
             scrape_item.possible_datetime = self.parse_date(date_str)
 
         await self.handle_file(
@@ -143,11 +143,11 @@ class KernelVideoSharingCrawler(Crawler, is_abc=True):
     async def album(self, scrape_item: ScrapeItem, album_id: str | None = None) -> None:
         soup = await self.request_soup(scrape_item.url)
         if not album_id:
-            js_text = css.select_one_get_text(soup, _SELECTORS.ALBUM_ID)
+            js_text = css.select_text(soup, _SELECTORS.ALBUM_ID)
             album_id = get_text_between(js_text, "params['album_id'] =", ";")
 
         results = await self.get_album_results(album_id)
-        title = css.select_one_get_text(soup, _SELECTORS.ALBUM_NAME)
+        title = css.select_text(soup, _SELECTORS.ALBUM_NAME)
         title = self.create_title(f"{title} [album]", album_id)
         scrape_item.setup_as_album(title, album_id=album_id)
         for _, new_scrape_item in self.iter_children(scrape_item, soup, _SELECTORS.ALBUM_PICTURES, results=results):
@@ -159,7 +159,7 @@ class KernelVideoSharingCrawler(Crawler, is_abc=True):
             return
 
         soup = await self.request_soup(scrape_item.url)
-        url = self.parse_url(css.select_one_get_attr(soup, _SELECTORS.PICTURE, "src"))
+        url = self.parse_url(css.select(soup, _SELECTORS.PICTURE, "src"))
         filename, ext = self.get_filename_and_ext(url.name)
         await self.handle_file(url, scrape_item, filename, ext)
 
@@ -168,7 +168,7 @@ def extract_kvs_video(cls: Crawler, soup: BeautifulSoup) -> KVSVideo:
     if soup.select_one(_SELECTORS.UNAUTHORIZED):
         raise ScrapeError(401, "Private video")
 
-    script = css.select_one_get_text(soup, _SELECTORS.FLASHVARS)
+    script = css.select_text(soup, _SELECTORS.FLASHVARS)
     video = _parse_video_vars(script)
     if not video.title:
         title = open_graph.get_title(soup) or css.page_title(soup)

--- a/cyberdrop_dl/crawlers/_one_manager.py
+++ b/cyberdrop_dl/crawlers/_one_manager.py
@@ -62,21 +62,21 @@ class OneManagerCrawler(Crawler, is_abc=True):
             pass
 
         # href are not actual links, they only have the name of the new part
-        table = css.select_one(soup, _SELECTORS.TABLE)
+        table = css.select(soup, _SELECTORS.TABLE)
         for file in css.iselect(table, _SELECTORS.FILE):
             await self.process_file(scrape_item, file)
             scrape_item.add_children()
 
         for folder in css.iselect(table, _SELECTORS.FOLDER):
-            link = scrape_item.url / css.select_one_get_attr(folder, _SELECTORS.FOLDER_LINK, "href")
+            link = scrape_item.url / css.select(folder, _SELECTORS.FOLDER_LINK, "href")
             new_scrape_item = scrape_item.create_child(link, new_title_part=link.name)
             self.create_task(self.run(new_scrape_item))
             scrape_item.add_children()
 
     @error_handling_wrapper
     async def process_file(self, scrape_item: ScrapeItem, file: Tag) -> None:
-        datetime = self.parse_date(css.select_one_get_text(file, _SELECTORS.DATE))
-        link = scrape_item.url / css.select_one_get_attr(file, _SELECTORS.FILE_LINK, "href")
+        datetime = self.parse_date(css.select_text(file, _SELECTORS.DATE))
+        link = scrape_item.url / css.select(file, _SELECTORS.FILE_LINK, "href")
         await self._process_file(scrape_item, link, datetime)
 
     async def _process_file(self, scrape_item: ScrapeItem, link: AbsoluteHttpURL, datetime: int | None = None) -> None:

--- a/cyberdrop_dl/crawlers/_yetishare.py
+++ b/cyberdrop_dl/crawlers/_yetishare.py
@@ -106,7 +106,7 @@ class YetiShareCrawler(Crawler, is_abc=True):
             )
 
             if total_pages is None:
-                total_pages = int(css.select_one_get_attr(ajax_soup, Selector.FOLDER_TOTAL_PAGES, "value"))
+                total_pages = int(css.select(ajax_soup, Selector.FOLDER_TOTAL_PAGES, "value"))
 
             for file in ajax_soup.select(Selector.FILES):
                 file_url = self.parse_url(css.get_attr(file, "dtfullurl"))
@@ -137,7 +137,7 @@ class YetiShareCrawler(Crawler, is_abc=True):
 
         content_id = int(
             get_text_between(
-                css.select_one_get_text(soup, Selector.FILE_INFO),
+                css.select_text(soup, Selector.FILE_INFO),
                 "showFileInformation(",
                 ");",
             )
@@ -153,7 +153,7 @@ class YetiShareCrawler(Crawler, is_abc=True):
             is_file=True,
         )
 
-        download_tag = soup.select_one(Selector.DROPDOWN_MENU) or css.select_one(soup, Selector.DOWNLOAD_BUTTON)
+        download_tag = soup.select_one(Selector.DROPDOWN_MENU) or css.select(soup, Selector.DOWNLOAD_BUTTON)
 
         # Manually parse link. Some URLs are invalid. ex: https://cyberfile.me/7cfu
         # For the download URL, the slug does not actually matter. It can be anything
@@ -162,11 +162,11 @@ class YetiShareCrawler(Crawler, is_abc=True):
         link = self.parse_url(raw_link).with_query(download_token=token)
 
         scrape_item.possible_datetime = self.parse_date(
-            css.select_one_get_text(soup, Selector.FILE_UPLOAD_DATE),
+            css.select_text(soup, Selector.FILE_UPLOAD_DATE),
             "%d/%m/%Y %H:%M:%S",
         )
 
-        filename = css.select_one_get_text(soup, Selector.FILE_NAME)
+        filename = css.select_text(soup, Selector.FILE_NAME)
         custom_filename, ext = self.get_filename_and_ext(filename)
         await self.handle_file(link, scrape_item, filename, ext, custom_filename=custom_filename)
 
@@ -188,7 +188,7 @@ class YetiShareCrawler(Crawler, is_abc=True):
 
         soup = await ajax_api_request()
         if soup.select_one(Selector.PASSWORD_PROTECTED):
-            node_id: str = data.get("nodeId") or css.select_one_get_attr(soup, Selector.FOLDER_ID, "value")
+            node_id: str = data.get("nodeId") or css.select(soup, Selector.FOLDER_ID, "value")
             await self._unlock_password_protected_folder(scrape_item, node_id)
             soup = await ajax_api_request()
 

--- a/cyberdrop_dl/crawlers/archivebate.py
+++ b/cyberdrop_dl/crawlers/archivebate.py
@@ -69,9 +69,9 @@ class ArchiveBateCrawler(MixDropCrawler):
 
         description = open_graph.description(soup)
         date_str = get_text_between(description, "show on", " - ").strip()
-        user_name = css.select_one_get_text(soup, _SELECTORS.USER_NAME)
-        site_name = css.select_one_get_text(soup, _SELECTORS.SITE_NAME)
-        video_src = css.select_one_get_attr(soup, _SELECTORS.VIDEO, "src")
+        user_name = css.select_text(soup, _SELECTORS.USER_NAME)
+        site_name = css.select_text(soup, _SELECTORS.SITE_NAME)
+        video_src = css.select(soup, _SELECTORS.VIDEO, "src")
         title = self.create_title(f"{user_name} [{site_name}]")
         scrape_item.setup_as_profile(title)
         scrape_item.possible_datetime = self.parse_date(date_str)

--- a/cyberdrop_dl/crawlers/ashemaletube.py
+++ b/cyberdrop_dl/crawlers/ashemaletube.py
@@ -156,7 +156,7 @@ class AShemaleTubeCrawler(Crawler):
         if image := img_tag.select_one("img"):
             link_str: str = css.get_attr(image, "src")
         else:
-            style: str = css.select_one_get_attr(img_tag, "a", "style")
+            style: str = css.select(img_tag, "a", "style")
             link_str = get_text_between(style, "url('", "');")
         url = self.parse_url(link_str).with_query(None)
         filename, ext = self.get_filename_and_ext(url.name)
@@ -174,7 +174,7 @@ class AShemaleTubeCrawler(Crawler):
 
         if soup.select_one(_SELECTORS.LOGIN_REQUIRED):
             raise ScrapeError(401)
-        js_text = css.select_one_get_text(soup, _SELECTORS.JS_PLAYER)
+        js_text = css.select_text(soup, _SELECTORS.JS_PLAYER)
         best_format = parse_player_info(js_text)
         m3u8 = debrid_link = None
         if best_format.hls:
@@ -186,7 +186,7 @@ class AShemaleTubeCrawler(Crawler):
             json_data = json.loads(css.get_text(video_object))
             scrape_item.possible_datetime = self.parse_iso_date(json_data.get("uploadDate", ""))
 
-        title = css.select_one_get_text(soup, "title").split("- aShemaletube.com")[0].strip()
+        title = css.select_text(soup, "title").split("- aShemaletube.com")[0].strip()
         scrape_item.url = canonical_url
         filename, ext = self.get_filename_and_ext(best_format.url.name, assume_ext=".mp4")
         custom_filename = self.create_custom_filename(title, ext, file_id=video_id, resolution=best_format.resolution)

--- a/cyberdrop_dl/crawlers/box_dot_com.py
+++ b/cyberdrop_dl/crawlers/box_dot_com.py
@@ -78,7 +78,7 @@ class BoxDotComCrawler(Crawler):
         if "file or folder link has been removed" in soup.text:
             raise ScrapeError(410)
 
-        js_text: str = css.select_one_get_text(soup, JS_SELECTOR)
+        js_text: str = css.select_text(soup, JS_SELECTOR)
         data = js_text.removesuffix(";").partition("=")[-1]
         if not data:
             raise ScrapeError(422)

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -97,10 +97,10 @@ class AlbumItem:
 
     @staticmethod
     def from_tag(tag: Tag) -> AlbumItem:
-        name = css.select_one_get_text(tag, _SELECTORS.ITEM_NAME)
-        thumbnail: str = css.select_one_get_attr(tag, _SELECTORS.THUMBNAIL, "src")
-        date_str = css.select_one_get_text(tag, _SELECTORS.ITEM_DATE)
-        path_qs: str = css.select_one_get_attr(tag, "a", "href")
+        name = css.select_text(tag, _SELECTORS.ITEM_NAME)
+        thumbnail: str = css.select(tag, _SELECTORS.THUMBNAIL, "src")
+        date_str = css.select_text(tag, _SELECTORS.ITEM_DATE)
+        path_qs: str = css.select(tag, "a", "href")
         return AlbumItem(name, thumbnail, date_str, path_qs)
 
     @property
@@ -248,7 +248,7 @@ class BunkrrCrawler(Crawler):
     @error_handling_wrapper
     async def reinforced_file(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
-        title = css.select_one_get_text(soup, "h1")
+        title = css.select_text(soup, "h1")
         link = await self.get_download_url_from_api(scrape_item.url)
         if not link:
             raise ScrapeError(422)

--- a/cyberdrop_dl/crawlers/cyberdrop.py
+++ b/cyberdrop_dl/crawlers/cyberdrop.py
@@ -54,11 +54,11 @@ class CyberdropCrawler(Crawler):
     async def album(self, scrape_item: ScrapeItem, album_id: str) -> None:
         scrape_item.url = scrape_item.url.with_query("nojs")
         soup = await self.request_soup(scrape_item.url)
-        title = css.select_one_get_text(soup, Selector.ALBUM_TITLE)
+        title = css.select_text(soup, Selector.ALBUM_TITLE)
         title = self.create_title(title, album_id)
         scrape_item.setup_as_album(title, album_id=album_id)
 
-        date_str = css.select_one_get_text(soup, Selector.ALBUM_DATE)
+        date_str = css.select_text(soup, Selector.ALBUM_DATE)
         scrape_item.possible_datetime = self.parse_date(date_str, "%d.%m.%Y")
 
         for _, new_scrape_item in self.iter_children(scrape_item, soup, Selector.ALBUM_ITEM):

--- a/cyberdrop_dl/crawlers/desivideo.py
+++ b/cyberdrop_dl/crawlers/desivideo.py
@@ -44,7 +44,7 @@ class DesiVideoCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
         video_url = self.parse_url(Selector.VIDEO_SRC(soup))
-        title = css.select_one_get_text(soup, Selector.TITLE)
+        title = css.select_text(soup, Selector.TITLE)
         _, ext = self.get_filename_and_ext(video_url.name)
         scrape_item.possible_datetime = self.parse_iso_date(css.get_json_ld_date(soup))
         custom_filename = self.create_custom_filename(title, ext, file_id=video_id)

--- a/cyberdrop_dl/crawlers/dirtyship.py
+++ b/cyberdrop_dl/crawlers/dirtyship.py
@@ -111,7 +111,7 @@ class DirtyShipCrawler(Crawler):
         title: str = ""
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                title: str = css.select_one_get_text(soup, "title")
+                title: str = css.select_text(soup, "title")
                 title = title.split("Archives - DirtyShip")[0]
                 title = self.create_title(title)
                 scrape_item.setup_as_album(title)
@@ -123,7 +123,7 @@ class DirtyShipCrawler(Crawler):
     async def video(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        title: str = css.select_one_get_text(soup, "title")
+        title: str = css.select_text(soup, "title")
         title = title.split(" - DirtyShip")[0]
         videos = soup.select(_SELECTORS.VIDEO)
 

--- a/cyberdrop_dl/crawlers/doodstream.py
+++ b/cyberdrop_dl/crawlers/doodstream.py
@@ -84,11 +84,11 @@ class DoodStreamCrawler(Crawler):
 
 
 def _get_md5_path(soup: BeautifulSoup) -> str:
-    js_text = css.select_one_get_text(soup, _SELECTORS.MD5_JS)
+    js_text = css.select_text(soup, _SELECTORS.MD5_JS)
     return get_text_between(js_text, "/pass_md5/", "'")
 
 
 def _get_file_id(soup: BeautifulSoup) -> str:
-    js_text = css.select_one_get_text(soup, _SELECTORS.FILE_ID_JS)
+    js_text = css.select_text(soup, _SELECTORS.FILE_ID_JS)
     _, file_id, _ = js_text.split("'file_id'")[-1].split("'", 2)
     return file_id

--- a/cyberdrop_dl/crawlers/efukt.py
+++ b/cyberdrop_dl/crawlers/efukt.py
@@ -54,7 +54,7 @@ class EfuktCrawler(Crawler):
         homepage = is_homepage(scrape_item.url)
         async for soup in self.web_pager(scrape_item.url):
             if not homepage and not title:
-                title = css.select_one_get_text(soup, _SELECTORS.TITLE)
+                title = css.select_text(soup, _SELECTORS.TITLE)
                 scrape_item.setup_as_album(self.create_title(f"{title} [series]"))
 
             for _, new_scrape_item in self.iter_children(scrape_item, soup, _SELECTORS.VIDEO_THUMBS):
@@ -67,19 +67,19 @@ class EfuktCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        date_str = css.select_one_get_text(soup, _SELECTORS.DATE).split(" ", 1)[-1]
+        date_str = css.select_text(soup, _SELECTORS.DATE).split(" ", 1)[-1]
         datetime = self._parse_date(date_str, "%m/%d/%y")
         if not datetime:
             raise ScrapeError(422)
         scrape_item.possible_datetime = to_timestamp(datetime)
 
         if is_image_or_gif(scrape_item.url):
-            link = self.parse_url(css.select_one_get_attr(soup, _SELECTORS.IMAGE, "src"))
+            link = self.parse_url(css.select(soup, _SELECTORS.IMAGE, "src"))
         else:
-            link = self.parse_url(css.select_one_get_attr(soup, _SELECTORS.VIDEO, "src"))
+            link = self.parse_url(css.select(soup, _SELECTORS.VIDEO, "src"))
 
         item_id = scrape_item.url.query.get("id") or scrape_item.url.name.partition("_")[0]
-        title = Path(css.select_one_get_text(soup, _SELECTORS.TITLE)).as_posix().replace("/", "-")
+        title = Path(css.select_text(soup, _SELECTORS.TITLE)).as_posix().replace("/", "-")
         filename, ext = self.get_filename_and_ext(link.name)
         custom_filename = self.create_custom_filename(f"{datetime.date().isoformat()} {title}", ext, file_id=item_id)
         # Video links expire, but the path is always the same, only query params change

--- a/cyberdrop_dl/crawlers/ehentai.py
+++ b/cyberdrop_dl/crawlers/ehentai.py
@@ -55,8 +55,8 @@ class EHentaiCrawler(Crawler):
         scrape_item.url = scrape_item.url.with_query(None)
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                title = self.create_title(css.select_one_get_text(soup, _SELECTORS.TITLE))
-                date_str: str = css.select_one_get_text(soup, _SELECTORS.DATE)
+                title = self.create_title(css.select_text(soup, _SELECTORS.TITLE))
+                date_str: str = css.select_text(soup, _SELECTORS.DATE)
                 title = self.create_title(title, gallery_id)
                 scrape_item.setup_as_album(title, album_id=gallery_id)
                 scrape_item.possible_datetime = self.parse_iso_date(date_str)
@@ -70,7 +70,7 @@ class EHentaiCrawler(Crawler):
             return
 
         soup = await self.request_soup(scrape_item.url)
-        link_str: str = css.select_one_get_attr(soup, _SELECTORS.IMAGE, "src")
+        link_str: str = css.select(soup, _SELECTORS.IMAGE, "src")
         link = self.parse_url(link_str)
         filename, ext = self.get_filename_and_ext(link.name)
         custom_filename = self.create_custom_filename(scrape_item.url.name, ext)

--- a/cyberdrop_dl/crawlers/eightmuses.py
+++ b/cyberdrop_dl/crawlers/eightmuses.py
@@ -48,7 +48,7 @@ class EightMusesCrawler(Crawler):
         for tile in soup.select(TILE_SELECTOR):
             tile_link = self.parse_url(css.get_attr(tile, "href"))
             tile_title: str = css.get_attr_or_none(tile, "title") or ""
-            image = css.select_one(tile, IMAGE_SELECTOR)
+            image = css.select(tile, IMAGE_SELECTOR)
             is_new_album = image["itemtype"] == "https://schema.org/ImageGallery"
             new_album_id = f"{scrape_item.album_id}/{tile_title.replace(' ', '-')}"
             new_scrape_item = scrape_item.create_child(tile_link, new_title_part=tile_title, album_id=new_album_id)
@@ -56,7 +56,7 @@ class EightMusesCrawler(Crawler):
                 await self.album(new_scrape_item)
                 continue
 
-            image_link_str: str = css.select_one_get_attr(image, "img", "data-src").replace("/th/", "/fm/")
+            image_link_str: str = css.select(image, "img", "data-src").replace("/th/", "/fm/")
             image_link = self.parse_url(image_link_str)
             if not self.check_album_results(image_link, results):
                 filename, ext = self.get_filename_and_ext(f"{tile_title}.jpg")

--- a/cyberdrop_dl/crawlers/eporner.py
+++ b/cyberdrop_dl/crawlers/eporner.py
@@ -124,7 +124,7 @@ class EpornerCrawler(Crawler):
         title: str = ""
         async for soup in self.web_pager(scrape_item.url):
             if not title and not from_profile:
-                title = css.select_one_get_text(soup, "title")
+                title = css.select_text(soup, "title")
                 title_trash = "Porn Star Videos", "Porn Videos", "Videos -", "EPORNER"
                 for trash in title_trash:
                     title = title.rsplit(trash)[0].strip()
@@ -139,7 +139,7 @@ class EpornerCrawler(Crawler):
         title: str = ""
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                title = css.select_one_get_text(soup, _SELECTORS.GALLERY_TITLE)
+                title = css.select_text(soup, _SELECTORS.GALLERY_TITLE)
                 title = self.create_title(title)
                 scrape_item.setup_as_album(title)
 
@@ -160,7 +160,7 @@ class EpornerCrawler(Crawler):
         soup = await self.request_soup(scrape_item.url)
 
         scrape_item.url = canonical_url
-        link_str = css.select_one_get_attr(soup, _SELECTORS.PHOTO, "href")
+        link_str = css.select(soup, _SELECTORS.PHOTO, "href")
         link = self.parse_url(link_str)
         filename, ext = self.get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)
@@ -193,7 +193,7 @@ class EpornerCrawler(Crawler):
 
 
 def _get_available_sources(soup: BeautifulSoup) -> list[VideoSource]:
-    downloads = css.select_one(soup, _SELECTORS.DOWNLOADS)
+    downloads = css.select(soup, _SELECTORS.DOWNLOADS)
     formats = downloads.select(_SELECTORS.H264)
     if ALLOW_AV1:
         formats.extend(downloads.select(_SELECTORS.AV1))
@@ -206,7 +206,7 @@ def _get_best_src(soup: BeautifulSoup) -> VideoSource:
 
 
 def _parse_video(soup: BeautifulSoup) -> Video:
-    ld_json = css.select_one_get_text(soup, _SELECTORS.DATE_JS)
+    ld_json = css.select_text(soup, _SELECTORS.DATE_JS)
     # This may have invalid json. They do not sanitize the description field
     # See: https://github.com/jbsparrow/CyberDropDownloader/issues/1211
     return Video(

--- a/cyberdrop_dl/crawlers/erome.py
+++ b/cyberdrop_dl/crawlers/erome.py
@@ -59,7 +59,7 @@ class EromeCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        title_portion = css.select_one_get_text(soup, "title").rsplit(" - Porn")[0].strip()
+        title_portion = css.select_text(soup, "title").rsplit(" - Porn")[0].strip()
         if not title_portion:
             title_portion = scrape_item.url.name
 

--- a/cyberdrop_dl/crawlers/fapello.py
+++ b/cyberdrop_dl/crawlers/fapello.py
@@ -41,13 +41,13 @@ class FapelloCrawler(Crawler):
         title: str = ""
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                title = self.create_title(css.select_one_get_text(soup, TITLE_SELECTOR))
+                title = self.create_title(css.select_text(soup, TITLE_SELECTOR))
                 scrape_item.setup_as_album(title)
 
             for post in soup.select(CONTENT_SELECTOR):
                 link_str: str = css.get_attr(post, "href")
                 if "javascript" in link_str:
-                    link_str = css.select_one_get_attr(post, "iframe", "src")
+                    link_str = css.select(post, "iframe", "src")
 
                 link = self.parse_url(link_str)
                 new_scrape_item = scrape_item.create_child(link)
@@ -58,7 +58,7 @@ class FapelloCrawler(Crawler):
     async def post(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        content = css.select_one(soup, POST_CONTENT_SELECTOR)
+        content = css.select(soup, POST_CONTENT_SELECTOR)
         for _, link in self.iter_tags(content, "img, source"):
             filename, ext = self.get_filename_and_ext(link.name)
             await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/fileditch.py
+++ b/cyberdrop_dl/crawlers/fileditch.py
@@ -31,7 +31,7 @@ class FileditchCrawler(Crawler):
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
-        link_str: str = css.select_one_get_attr(soup, DOWNLOAD_SELECTOR, "href")
+        link_str: str = css.select(soup, DOWNLOAD_SELECTOR, "href")
         link = self.parse_url(link_str)
         if link.path == HOMEPAGE_CATCHALL_FILE:
             raise ScrapeError(422)

--- a/cyberdrop_dl/crawlers/generic.py
+++ b/cyberdrop_dl/crawlers/generic.py
@@ -78,8 +78,8 @@ class GenericCrawler(Crawler):
 
     async def try_video_from_soup(self, scrape_item: ScrapeItem, soup: BeautifulSoup) -> None:
         try:
-            title = css.select_one_get_text(soup, "title").rsplit(" - ", 1)[0].rsplit("|", 1)[0]
-            link_str: str = css.select_one_get_attr(soup, VIDEO_SELECTOR, "src")
+            title = css.select_text(soup, "title").rsplit(" - ", 1)[0].rsplit("|", 1)[0]
+            link_str: str = css.select(soup, VIDEO_SELECTOR, "src")
         except (AssertionError, AttributeError, KeyError):
             raise ScrapeError(422) from None
 

--- a/cyberdrop_dl/crawlers/google_drive.py
+++ b/cyberdrop_dl/crawlers/google_drive.py
@@ -123,7 +123,7 @@ class GoogleDriveCrawler(Crawler):
         embeded_folder_url = (self.PRIMARY_URL / "embeddedfolderview").with_query(id=folder_id)
         soup = await self.request_soup(embeded_folder_url)
 
-        folder_name = css.select_one_get_text(soup, "title")
+        folder_name = css.select_text(soup, "title")
         title = self.create_title(folder_name, folder_id)
         scrape_item.setup_as_album(title, album_id=folder_id)
 

--- a/cyberdrop_dl/crawlers/hianime.py
+++ b/cyberdrop_dl/crawlers/hianime.py
@@ -120,7 +120,7 @@ class HiAnimeCrawler(Crawler):
 
         return Anime(
             id=anime_id,
-            name=css.select_one_get_text(anime_soup, Selector.ANIME_NAME),
+            name=css.select_text(anime_soup, Selector.ANIME_NAME),
             episodes=dict(_parse_episodes_resp(episodes_resp["html"])),
         )
 

--- a/cyberdrop_dl/crawlers/hotleak_vip.py
+++ b/cyberdrop_dl/crawlers/hotleak_vip.py
@@ -24,6 +24,6 @@ class HotLeakVipCrawler(LeakedZoneCrawler):
 
     @classmethod
     def get_encoded_video_url(cls, soup: BeautifulSoup) -> str:
-        video_info_text = css.select_one_get_attr(soup, LIGHT_GALLERY_ITEM_SELECTOR, "data-video")
+        video_info_text = css.select(soup, LIGHT_GALLERY_ITEM_SELECTOR, "data-video")
         video_data: dict[str, Any] = json.loads(video_info_text)
         return video_data["source"][0]["src"]

--- a/cyberdrop_dl/crawlers/hotpic.py
+++ b/cyberdrop_dl/crawlers/hotpic.py
@@ -47,7 +47,7 @@ class HotPicCrawler(Crawler):
         soup = await self.request_soup(scrape_item.url)
 
         album_id = scrape_item.url.parts[2]
-        title = self.create_title(css.select_one_get_text(soup, "title").rsplit(" - ")[0], scrape_item.album_id)
+        title = self.create_title(css.select_text(soup, "title").rsplit(" - ")[0], scrape_item.album_id)
         scrape_item.setup_as_profile(title, album_id=album_id)
 
         for _, link in self.iter_tags(soup, _SELECTORS.ALBUM_ITEM):
@@ -60,7 +60,7 @@ class HotPicCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        link_str = css.select_one_get_attr(soup, _SELECTORS.IMAGE_OR_VIDEO, "src")
+        link_str = css.select(soup, _SELECTORS.IMAGE_OR_VIDEO, "src")
         link = self.parse_url(link_str)
         await self.handle_direct_link(scrape_item, link)
 

--- a/cyberdrop_dl/crawlers/imagebam.py
+++ b/cyberdrop_dl/crawlers/imagebam.py
@@ -75,7 +75,7 @@ class ImageBamCrawler(Crawler):
         if not soup:
             soup = await self.request_soup(scrape_item.url)
 
-        gallery_name = css.select_one_get_text(soup, Selectors.GALLERY_TITLE)
+        gallery_name = css.select_text(soup, Selectors.GALLERY_TITLE)
         gallery_id = scrape_item.url.name
         title = self.create_title(gallery_name, gallery_id)
         scrape_item.setup_as_album(title, album_id=gallery_id)
@@ -98,7 +98,7 @@ class ImageBamCrawler(Crawler):
 
             soup = await self.request_soup(scrape_item.url)
 
-        image_tag = css.select_one(soup, Selectors.IMAGE)
+        image_tag = css.select(soup, Selectors.IMAGE)
         if not scrape_item.album_id and (gallery_info := soup.select_one(Selectors.GALLERY_INFO)):
             gallery_id = self.parse_url(css.get_attr(gallery_info, "href")).name
             scrape_item.album_id = gallery_id

--- a/cyberdrop_dl/crawlers/imgbox.py
+++ b/cyberdrop_dl/crawlers/imgbox.py
@@ -42,7 +42,7 @@ class ImgBoxCrawler(Crawler):
         album_id = scrape_item.url.parts[2]
 
         scrape_item.set_type(FILE_HOST_ALBUM, self.manager)
-        title = css.select_one(soup, ALBUM_TITLE_SELECTOR).get_text(strip=True).rsplit(" - ", 1)[0]
+        title = css.select(soup, ALBUM_TITLE_SELECTOR).get_text(strip=True).rsplit(" - ", 1)[0]
         title = self.create_title(title, album_id)
         scrape_item.setup_as_album(title, album_id=album_id)
 
@@ -60,7 +60,7 @@ class ImgBoxCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        link_str: str = css.select_one_get_attr(soup, IMAGE_SELECTOR, "src")
+        link_str: str = css.select(soup, IMAGE_SELECTOR, "src")
         link = self.parse_url(link_str)
         filename, ext = self.get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/imgur.py
+++ b/cyberdrop_dl/crawlers/imgur.py
@@ -42,7 +42,7 @@ class ImgurCrawler(Crawler):
         """Get public client id."""
         with self.disable_on_error("Unable to get client id"):
             soup = await self.request_soup(self.PRIMARY_URL)
-            js_src = css.select_one_get_attr(soup, "script[src*='/desktop-assets/js/main']", "src")
+            js_src = css.select(soup, "script[src*='/desktop-assets/js/main']", "src")
             js_text = await self.request_text(self.parse_url(js_src))
             self.client_id = get_text_between(js_text, 'apiClientId:"', '"')
 

--- a/cyberdrop_dl/crawlers/imx_to.py
+++ b/cyberdrop_dl/crawlers/imx_to.py
@@ -63,7 +63,7 @@ class ImxToCrawler(Crawler):
             method="POST",
             data={"imgContinue": "Continue+to+image+...+"},
         )
-        image = css.select_one(soup, Selector.IMAGES)
+        image = css.select(soup, Selector.IMAGES)
         name = css.get_attr(image, "alt")
         link = self.parse_url(css.get_attr(image, "src"))
         filename, ext = self.get_filename_and_ext(name)
@@ -72,7 +72,7 @@ class ImxToCrawler(Crawler):
     @error_handling_wrapper
     async def gallery(self, scrape_item: ScrapeItem, album_id: str) -> None:
         soup = await self.request_soup(scrape_item.url)
-        name = css.select_one_get_text(soup, Selector.GALLERY_TITLE)
+        name = css.select_text(soup, Selector.GALLERY_TITLE)
         title = self.create_title(name, album_id)
         scrape_item.setup_as_album(title, album_id=album_id)
 

--- a/cyberdrop_dl/crawlers/incestflix.py
+++ b/cyberdrop_dl/crawlers/incestflix.py
@@ -43,8 +43,8 @@ class IncestflixCrawler(Crawler):
         if await self.check_complete_from_referer(scrape_item):
             return
         soup = await self.request_soup(scrape_item.url)
-        title: str = css.select_one_get_text(soup, _SELECTORS.TITLE)
-        link_str = css.select_one_get_attr(soup, _SELECTORS.VIDEO, "src")
+        title: str = css.select_text(soup, _SELECTORS.TITLE)
+        link_str = css.select(soup, _SELECTORS.VIDEO, "src")
         url = self.parse_url(link_str)
         filename, ext = self.get_filename_and_ext(f"{title}.mp4")
         await self.handle_file(scrape_item.url, scrape_item, filename, ext, debrid_link=url)
@@ -54,7 +54,7 @@ class IncestflixCrawler(Crawler):
         title_created: bool = False
         async for soup in self.web_pager(scrape_item.url):
             if not title_created:
-                title = self.create_title(css.select_one(soup, _SELECTORS.TAG_TITLE).get_text(strip=True))
+                title = self.create_title(css.select(soup, _SELECTORS.TAG_TITLE).get_text(strip=True))
                 scrape_item.setup_as_album(title)
                 title_created = True
             for _, new_scrape_item in self.iter_children(scrape_item, soup, _SELECTORS.VIDEO_THUMBS):

--- a/cyberdrop_dl/crawlers/influencer_bitches.py
+++ b/cyberdrop_dl/crawlers/influencer_bitches.py
@@ -54,7 +54,7 @@ class InfluencerBitchesCrawler(Crawler):
         scrape_item.setup_as_album("Photos", album_id=album_id)
         results = await self.get_album_results(album_id)
         for a_tag in soup.select(_SELECTORS.PICTURES):
-            link_str: str = css.select_one_get_attr(a_tag, "img", "data-full")
+            link_str: str = css.select(a_tag, "img", "data-full")
             link = self.parse_url(link_str)
             if self.check_album_results(link, results):
                 continue

--- a/cyberdrop_dl/crawlers/leakedzone.py
+++ b/cyberdrop_dl/crawlers/leakedzone.py
@@ -75,14 +75,14 @@ class LeakedZoneCrawler(Crawler):
 
     @classmethod
     def get_encoded_video_url(cls, soup: BeautifulSoup) -> str:
-        js_text = css.select_one_get_text(soup, _SELECTORS.JW_PLAYER)
+        js_text = css.select_text(soup, _SELECTORS.JW_PLAYER)
         return get_text_between(js_text, 'file: f("', '"),')
 
     @error_handling_wrapper
     async def model(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        model_name: str = css.select_one_get_text(soup, _SELECTORS.MODEL_NAME_FROM_PROFILE)
+        model_name: str = css.select_text(soup, _SELECTORS.MODEL_NAME_FROM_PROFILE)
         scrape_item.setup_as_profile(self.create_title(model_name))
         headers = {"X-Requested-With": "XMLHttpRequest"}
         for page in itertools.count(1):
@@ -109,7 +109,7 @@ class LeakedZoneCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        model_name = css.select_one_get_text(soup, _SELECTORS.MODEL_NAME)
+        model_name = css.select_text(soup, _SELECTORS.MODEL_NAME)
         scrape_item.setup_as_album(self.create_title(model_name))
         encoded_url = self.get_encoded_video_url(soup)
         post = Post(video_id, PostType.VIDEO, stream_url_play=encoded_url)

--- a/cyberdrop_dl/crawlers/luxuretv.py
+++ b/cyberdrop_dl/crawlers/luxuretv.py
@@ -63,8 +63,8 @@ class LuxureTVCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url, impersonate=True)
         scrape_item.possible_datetime = self.parse_iso_date(css.get_json_ld_date(soup))
-        video_player = css.select_one(soup, Selector.VIDEO_PLAYER)
-        title = css.select_one_get_text(soup, Selector.TITLE)
+        video_player = css.select(soup, Selector.VIDEO_PLAYER)
+        title = css.select_text(soup, Selector.TITLE)
         link = self.parse_url(css.get_attr(video_player, "src"))
         filename, ext = self.get_filename_and_ext(link.name)
         custom_filename = self.create_custom_filename(title, ext, file_id=video_id)

--- a/cyberdrop_dl/crawlers/masahub.py
+++ b/cyberdrop_dl/crawlers/masahub.py
@@ -43,7 +43,7 @@ class MasahubCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
         link = self.parse_url(Selector.VIDEO_SRC(soup))
-        title = css.select_one_get_text(soup, Selector.TITLE)
+        title = css.select_text(soup, Selector.TITLE)
         _, ext = self.get_filename_and_ext(link.name)
         scrape_item.possible_datetime = self.parse_iso_date(css.get_json_ld_date(soup))
         custom_filename = self.create_custom_filename(title, ext)

--- a/cyberdrop_dl/crawlers/missav.py
+++ b/cyberdrop_dl/crawlers/missav.py
@@ -82,7 +82,7 @@ class MissAVCrawler(Crawler):
 
 
 def _get_uuid(soup: BeautifulSoup) -> str:
-    js_text = css.select_one_get_text(soup, Selector.UUID)
+    js_text = css.select_text(soup, Selector.UUID)
     uuid_joined_parts = js_text.split("m3u8|", 1)[-1].split("|com|surrit", 1)[0]
     uuid_parts = reversed(uuid_joined_parts.split("|"))
     return "-".join(uuid_parts)

--- a/cyberdrop_dl/crawlers/mixdrop.py
+++ b/cyberdrop_dl/crawlers/mixdrop.py
@@ -53,7 +53,7 @@ class MixDropCrawler(Crawler):
         scrape_item.url = embed_url
         soup = await self.request_soup(video_url)
 
-        title = css.select_one_get_text(soup, _SELECTOR.FILE_NAME)
+        title = css.select_text(soup, _SELECTOR.FILE_NAME)
 
         soup = await self.request_soup(embed_url)
 
@@ -65,7 +65,7 @@ class MixDropCrawler(Crawler):
     @staticmethod
     def create_download_link(soup: BeautifulSoup) -> AbsoluteHttpURL:
         # Defined as a method to simplify subclasses calls
-        js_text = css.select_one_get_text(soup, _SELECTOR.JS)
+        js_text = css.select_text(soup, _SELECTOR.JS)
         file_id = get_text_between(js_text, "|v2||", "|")
         parts = get_text_between(js_text, "MDCore||", "|thumbs").split("|")
         secure_key = get_text_between(js_text, f"{file_id}|", "|")

--- a/cyberdrop_dl/crawlers/motherless.py
+++ b/cyberdrop_dl/crawlers/motherless.py
@@ -146,7 +146,7 @@ class MotherlessCrawler(Crawler):
         media_info = self.process_media_soup(scrape_item, soup)
         link = self.parse_url(media_info.url)
         scrape_item.url = canonical_url
-        title = css.select_one_get_text(soup, ITEM_TITLE_SELECTOR)
+        title = css.select_text(soup, ITEM_TITLE_SELECTOR)
         filename, ext = self.get_filename_and_ext(link.name)
         custom_filename = self.create_custom_filename(title, ext, file_id=media_id)
         await self.handle_file(link, scrape_item, filename, ext, custom_filename=custom_filename)

--- a/cyberdrop_dl/crawlers/nhentai.py
+++ b/cyberdrop_dl/crawlers/nhentai.py
@@ -56,14 +56,14 @@ class NHentaiCrawler(Crawler):
         async for soup in self.web_pager(scrape_item.url, cffi=True):
             if not title:
                 if collection_type == "favorites":
-                    title_tag = css.select_one(soup, Selector.FAVORITES_TITLE)
+                    title_tag = css.select(soup, Selector.FAVORITES_TITLE)
                     if soup.select_one(Selector.LOGIN_PAGE):
                         raise LoginError("No cookies provided to download favorites")
 
                     css.decompose(title_tag, "span")
 
                 else:
-                    title_tag = css.select_one(soup, Selector.COLLECTION_TITLE)
+                    title_tag = css.select(soup, Selector.COLLECTION_TITLE)
                     title = f" [{collection_type}]"
 
                 title = self.create_title(title_tag.get_text(strip=True) + title)

--- a/cyberdrop_dl/crawlers/noodle_magazine.py
+++ b/cyberdrop_dl/crawlers/noodle_magazine.py
@@ -60,7 +60,7 @@ class NoodleMagazineCrawler(Crawler):
             soup = await self.request_soup(page_url, impersonate=True)
 
             if not title:
-                search_string: str = css.select_one_get_text(soup, SEARCH_STRING_SELECTOR)
+                search_string: str = css.select_text(soup, SEARCH_STRING_SELECTOR)
                 title = search_string.rsplit(" videos", 1)[0]
                 title = self.create_title(f"{title} [search]")
                 scrape_item.setup_as_album(title)
@@ -80,7 +80,7 @@ class NoodleMagazineCrawler(Crawler):
             return
         soup = await self.request_soup(scrape_item.url, impersonate=True)
 
-        metadata_text = css.select_one(soup, METADATA_SELECTOR).get_text()
+        metadata_text = css.select(soup, METADATA_SELECTOR).get_text()
         metadata = json.loads(metadata_text.strip())
         playlist = soup.select_one(PLAYLIST_SELECTOR)
         if not playlist:
@@ -88,7 +88,7 @@ class NoodleMagazineCrawler(Crawler):
 
         playlist_data = json.loads(get_text_between(playlist.text, "window.playlist = ", ";\nwindow.ads"))
         best_source = max(Source.new(source) for source in playlist_data["sources"])
-        title: str = css.select_one(soup, "title").get_text().split(" watch online")[0]
+        title: str = css.select(soup, "title").get_text().split(" watch online")[0]
 
         scrape_item.possible_datetime = self.parse_iso_date(metadata["uploadDate"])
         content_url = self.parse_url(metadata["contentUrl"])

--- a/cyberdrop_dl/crawlers/nudostartv.py
+++ b/cyberdrop_dl/crawlers/nudostartv.py
@@ -38,7 +38,7 @@ class NudoStarTVCrawler(Crawler):
         title = ""
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                title = self.create_title(css.select_one(soup, "title").get_text().split("/")[0])
+                title = self.create_title(css.select(soup, "title").get_text().split("/")[0])
                 scrape_item.setup_as_album(title)
 
             if "Last OnlyFans Updates" in title or not soup.select_one(CONTENT_SELECTOR):
@@ -53,7 +53,7 @@ class NudoStarTVCrawler(Crawler):
             return
 
         soup = await self.request_soup(scrape_item.url)
-        link_str = css.select_one_get_attr(soup, IMAGE_SELECTOR, "src")
+        link_str = css.select(soup, IMAGE_SELECTOR, "src")
         link = self.parse_url(link_str)
         filename, ext = self.get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/odnoklassniki.py
+++ b/cyberdrop_dl/crawlers/odnoklassniki.py
@@ -75,9 +75,9 @@ class OdnoklassnikiCrawler(Crawler):
         soup = await self.request_soup(scrape_item.url, headers=_HEADERS)
 
         channel_id = channel_str.removeprefix("c")
-        gwt_hash = get_text_between(css.select_one_get_text(soup, Selector.CHANNEL_HASH), 'gwtHash:"', '",')
+        gwt_hash = get_text_between(css.select_text(soup, Selector.CHANNEL_HASH), 'gwtHash:"', '",')
         last_element_id = css.select_one_get_attr_or_none(soup, *Selector.CHANNEL_LAST_ELEMENT)
-        name = css.select_one_get_text(soup, Selector.CHANNEL_NAME)
+        name = css.select_text(soup, Selector.CHANNEL_NAME)
         scrape_item.setup_as_album(self.create_title(name, channel_id), album_id=channel_id)
 
         page_url = (self.PRIMARY_URL / "video" / channel_str).with_query(

--- a/cyberdrop_dl/crawlers/omegascans.py
+++ b/cyberdrop_dl/crawlers/omegascans.py
@@ -73,7 +73,7 @@ class OmegaScansCrawler(Crawler):
             raise ScrapeError(401, "This chapter is premium")
 
         scrape_item.part_of_album = True
-        title_parts = css.select_one_get_text(soup, "title").split(" - ")
+        title_parts = css.select_text(soup, "title").split(" - ")
         series_name, chapter_title = title_parts[:2]
         series_title = self.create_title(series_name)
         scrape_item.add_to_parent_title(series_title)
@@ -82,7 +82,7 @@ class OmegaScansCrawler(Crawler):
         date_str = soup.select(DATE_SELECTOR)[-1].get_text()
         date = self.parse_date(date_str)
         if not date:
-            date_str = css.select_one_get_text(soup, DATE_JS_SELECTOR).split('created_at\\":\\"')[1].split(".")[0]
+            date_str = css.select_text(soup, DATE_JS_SELECTOR).split('created_at\\":\\"')[1].split(".")[0]
             date = self.parse_date(date_str)
 
         scrape_item.possible_datetime = date

--- a/cyberdrop_dl/crawlers/pimp_bunny.py
+++ b/cyberdrop_dl/crawlers/pimp_bunny.py
@@ -93,7 +93,7 @@ class PimpBunnyCrawler(Crawler):
         query = _pagination_query(scrape_item.url)
         async for soup in self.web_pager(model_url.with_query(query)):
             if not name:
-                name = css.select_one_get_text(soup, Selector.MODEL_NAME)
+                name = css.select_text(soup, Selector.MODEL_NAME)
                 scrape_item.setup_as_profile(self.create_title(f"{name} [model]"))
 
             for _, new_scrape_item in self.iter_children(scrape_item, soup, Selector.ITEM):
@@ -111,7 +111,7 @@ class PimpBunnyCrawler(Crawler):
         query = _pagination_query(scrape_item.url)
         async for soup in self.web_pager(albums_url.with_query(query)):
             if not name:
-                name = css.select_one_get_text(soup, Selector.MODEL_NAME)
+                name = css.select_text(soup, Selector.MODEL_NAME)
                 if name not in scrape_item.parent_title:
                     scrape_item.setup_as_profile(self.create_title(f"{name} [model]"))
 
@@ -144,7 +144,7 @@ class PimpBunnyCrawler(Crawler):
         title: str = ""
         async for soup in self.web_pager(album_url):
             if not title:
-                title = css.select_one_get_text(soup, Selector.ALBUM_TITLE)
+                title = css.select_text(soup, Selector.ALBUM_TITLE)
                 scrape_item.setup_as_album(self.create_title(f"{title} [album]"))
 
             for _, image in self.iter_tags(soup, Selector.ITEM):

--- a/cyberdrop_dl/crawlers/pimpandhost.py
+++ b/cyberdrop_dl/crawlers/pimpandhost.py
@@ -37,7 +37,7 @@ class PimpAndHostCrawler(Crawler):
         async for soup in self.web_pager(scrape_item.url):
             if not title:
                 album_id = scrape_item.url.parts[2]
-                title_portion = css.select_one(soup, ALBUM_TITLE_SELECTOR).text
+                title_portion = css.select(soup, ALBUM_TITLE_SELECTOR).text
                 title = self.create_title(title_portion, album_id)
                 scrape_item.setup_as_album(title, album_id=album_id)
 
@@ -51,9 +51,9 @@ class PimpAndHostCrawler(Crawler):
     async def image(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        link_str: str = css.select_one_get_attr(soup, IMAGE_SELECTOR, "data-src")
+        link_str: str = css.select(soup, IMAGE_SELECTOR, "data-src")
         link = self.parse_url(link_str)
-        date_str: str = css.select_one_get_attr(soup, DATE_SELECTOR, "title")
+        date_str: str = css.select(soup, DATE_SELECTOR, "title")
         scrape_item.possible_datetime = self.parse_date(date_str, DATE_FORMAT)
         filename, ext = self.get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/pixhost.py
+++ b/cyberdrop_dl/crawlers/pixhost.py
@@ -53,7 +53,7 @@ class PixHostCrawler(Crawler):
     async def gallery(self, scrape_item: ScrapeItem, album_id: str) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        title = css.select_one_get_text(soup, _SELECTORS.GALLERY_TITLE)
+        title = css.select_text(soup, _SELECTORS.GALLERY_TITLE)
         title = self.create_title(title, album_id)
         scrape_item.setup_as_album(title, album_id=album_id)
         results = await self.get_album_results(album_id)
@@ -73,7 +73,7 @@ class PixHostCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        link_str = css.select_one_get_attr(soup, _SELECTORS.IMAGE, "src")
+        link_str = css.select(soup, _SELECTORS.IMAGE, "src")
         link = self.parse_url(link_str)
         await self.direct_file(scrape_item, link)
 

--- a/cyberdrop_dl/crawlers/pkmncards.py
+++ b/cyberdrop_dl/crawlers/pkmncards.py
@@ -137,7 +137,7 @@ class PkmncardsCrawler(Crawler):
         page_url = url.with_query(sort="date", ord="auto", display="images")
         async for soup in self.web_pager(page_url):
             for thumb in soup.select(_SELECTORS.CARD):
-                link_str = css.select_one_get_attr(thumb, "img", "src")
+                link_str = css.select(thumb, "img", "src")
                 card_page_url_str = css.get_attr(thumb, "href")
                 title = css.get_attr(thumb, "title")
                 card_page_url = self.parse_url(card_page_url_str)
@@ -151,9 +151,9 @@ class PkmncardsCrawler(Crawler):
     async def card(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        name = css.select_one_get_text(soup, _SELECTORS.CARD_NAME)
-        number = css.select_one_get_text(soup, _SELECTORS.CARD_NUMBER)
-        link_str: str = css.select_one_get_attr(soup, _SELECTORS.CARD_DOWNLOAD, "href")
+        name = css.select_text(soup, _SELECTORS.CARD_NAME)
+        number = css.select_text(soup, _SELECTORS.CARD_NUMBER)
+        link_str: str = css.select(soup, _SELECTORS.CARD_DOWNLOAD, "href")
         link = self.parse_url(link_str)
         card_set = create_set(soup)
         card = Card(name, number, card_set, link)
@@ -220,15 +220,15 @@ def create_set(soup: Tag) -> CardSet:
     tag = soup.select_one(_SELECTORS.SET_SERIES_CODE)
     # Some sets do not have series code
     set_series_code: str | None = tag.get_text(strip=True) if tag else None
-    set_info: dict[str, list[dict]] = json.loads(css.select_one(soup, _SELECTORS.SET_INFO).text)
+    set_info: dict[str, list[dict]] = json.loads(css.select(soup, _SELECTORS.SET_INFO).text)
     release_date: int | None = None
     for item in set_info["@graph"]:
         if iso_date := item.get("datePublished"):
             release_date = to_timestamp(datetime.fromisoformat(iso_date))
             break
 
-    set_abbr = css.select_one(soup, _SELECTORS.SET_ABBR).text
-    set_name = css.select_one(soup, _SELECTORS.SET_NAME).text
+    set_abbr = css.select(soup, _SELECTORS.SET_ABBR).text
+    set_name = css.select(soup, _SELECTORS.SET_NAME).text
 
     if not release_date:
         raise ScrapeError(422)

--- a/cyberdrop_dl/crawlers/pornpics.py
+++ b/cyberdrop_dl/crawlers/pornpics.py
@@ -58,7 +58,7 @@ class PornPicsCrawler(Crawler):
 
         def update_scrape_item(soup: BeautifulSoup) -> None:
             selector = "h2" if collection_type == "channel" else "h1"
-            title = css.select_one_get_text(soup, selector).removesuffix(" Nude Pics").removesuffix(" Porn Pics")
+            title = css.select_text(soup, selector).removesuffix(" Nude Pics").removesuffix(" Porn Pics")
             title = self.create_title(f"{title} [{collection_type}]")
             scrape_item.setup_as_profile(title)
 
@@ -80,7 +80,7 @@ class PornPicsCrawler(Crawler):
         soup = await self.request_soup(scrape_item.url)
 
         scrape_item.url = PRIMARY_URL / "galleries" / gallery_id  # canonical URL
-        title = css.select_one_get_text(soup, "h1")
+        title = css.select_text(soup, "h1")
         title = self.create_title(title, gallery_id)
         scrape_item.setup_as_album(title, album_id=gallery_id)
 

--- a/cyberdrop_dl/crawlers/porntrex.py
+++ b/cyberdrop_dl/crawlers/porntrex.py
@@ -75,7 +75,7 @@ class PorntrexCrawler(Crawler):
         if "This album is a private album" in soup.text:
             raise ScrapeError(401, "Private album")
 
-        title = css.select_one_get_text(soup, _SELECTORS.ALBUM_TITLE)
+        title = css.select_text(soup, _SELECTORS.ALBUM_TITLE)
         title = self.create_title(title, album_id)
         scrape_item.setup_as_album(title)
 
@@ -110,13 +110,13 @@ class PorntrexCrawler(Crawler):
         soup = await self.request_soup(scrape_item.url)
 
         if "models" in scrape_item.url.parts:
-            title: str = css.select_one_get_text(soup, _SELECTORS.MODEL_NAME).title()
+            title: str = css.select_text(soup, _SELECTORS.MODEL_NAME).title()
         elif "members" in scrape_item.url.parts:
-            title: str = css.select_one_get_text(soup, _SELECTORS.USER_NAME)
+            title: str = css.select_text(soup, _SELECTORS.USER_NAME)
         elif "latest-updates" in scrape_item.url.parts:
             title: str = "Latest Updates"
         else:
-            title = css.select_one_get_text(soup, _SELECTORS.TITLE)
+            title = css.select_text(soup, _SELECTORS.TITLE)
 
         for trash in TITLE_TRASH:
             title = title.replace(trash, "").strip()

--- a/cyberdrop_dl/crawlers/postimg.py
+++ b/cyberdrop_dl/crawlers/postimg.py
@@ -67,7 +67,7 @@ class PostImgCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        link_str: str = css.select_one_get_attr(soup, DOWNLOAD_BUTTON_SELECTOR, "href")
+        link_str: str = css.select(soup, DOWNLOAD_BUTTON_SELECTOR, "href")
         link = self.parse_url(link_str).with_query(None)
         filename, ext = self.get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/realbooru.py
+++ b/cyberdrop_dl/crawlers/realbooru.py
@@ -54,7 +54,7 @@ class RealBooruCrawler(Crawler):
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
-        link_str = css.select_one_get_attr(soup, _SELECTORS.IMAGE_OR_VIDEO, "src")
+        link_str = css.select(soup, _SELECTORS.IMAGE_OR_VIDEO, "src")
         link = self.parse_url(link_str)
         filename, ext = self.get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/rule34vault.py
+++ b/cyberdrop_dl/crawlers/rule34vault.py
@@ -55,7 +55,7 @@ class Rule34VaultCrawler(Crawler):
             if not title:
                 if is_playlist:
                     album_id = scrape_item.url.parts[-1]
-                    title_str: str = css.select_one_get_text(soup, _SELECTORS.TITLE)
+                    title_str: str = css.select_text(soup, _SELECTORS.TITLE)
                     title = self.create_title(title_str, album_id)
                     scrape_item.setup_as_album(title, album_id=album_id)
                 else:

--- a/cyberdrop_dl/crawlers/rule34video.py
+++ b/cyberdrop_dl/crawlers/rule34video.py
@@ -55,7 +55,7 @@ class Rule34VideoCrawler(KernelVideoSharingCrawler):
         title: str = ""
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                title_tag = css.select_one(soup, Selector.TITLE)
+                title_tag = css.select(soup, Selector.TITLE)
                 css.decompose(title_tag, "span")
                 title = css.get_text(title_tag)
                 for trash in ("Videos for: ", "Tagged with "):

--- a/cyberdrop_dl/crawlers/rule34xxx.py
+++ b/cyberdrop_dl/crawlers/rule34xxx.py
@@ -57,9 +57,9 @@ class Rule34XXXCrawler(Crawler):
     async def file(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        date_str = css.select_one_get_text(soup, _SELECTORS.DATE).removeprefix("Posted: ")
+        date_str = css.select_text(soup, _SELECTORS.DATE).removeprefix("Posted: ")
         scrape_item.possible_datetime = self.parse_date(date_str)
-        link_str = css.select_one_get_attr(soup, _SELECTORS.IMAGE_OR_VIDEO, "src")
+        link_str = css.select(soup, _SELECTORS.IMAGE_OR_VIDEO, "src")
         link = self.parse_url(link_str)
         filename, ext = self.get_filename_and_ext(link.name)
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/safe_soul.py
+++ b/cyberdrop_dl/crawlers/safe_soul.py
@@ -39,17 +39,17 @@ class SafeSoulCrawler(ChibiSafeCrawler):
         soup = await self.request_soup(scrape_item.url)
         album = Album(
             id=album_id,
-            name=css.select_one_get_text(soup, Selector.ALBUM_TITLE),
+            name=css.select_text(soup, Selector.ALBUM_TITLE),
             files=[_parse_file(tag) for tag in soup.select(Selector.FILE)],
         )
         return await self._handle_album(scrape_item, album)
 
 
 def _parse_file(file_tag: bs4.Tag) -> File:
-    timestamp = int(css.select_one_get_attr(file_tag, Selector.FILE_DATE, "data-value"))
+    timestamp = int(css.select(file_tag, Selector.FILE_DATE, "data-value"))
 
     return File(
-        name=css.select_one_get_text(file_tag, Selector.FILE_NAME),
-        url=css.select_one_get_attr(file_tag, Selector.FILE_URL, "href"),
+        name=css.select_text(file_tag, Selector.FILE_NAME),
+        url=css.select(file_tag, Selector.FILE_URL, "href"),
         createdAt=datetime.datetime.fromtimestamp(timestamp),
     )

--- a/cyberdrop_dl/crawlers/sendvid.py
+++ b/cyberdrop_dl/crawlers/sendvid.py
@@ -38,9 +38,9 @@ class SendVidCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        title = css.select_one_get_text(soup, TITLE_SELECTOR)
+        title = css.select_text(soup, TITLE_SELECTOR)
         try:
-            link_str: str = css.select_one_get_attr(soup, VIDEO_SRC_SELECTOR, "src")
+            link_str: str = css.select(soup, VIDEO_SRC_SELECTOR, "src")
         except AssertionError:
             raise ScrapeError(422, "Couldn't find video source") from None
         link = self.parse_url(link_str)

--- a/cyberdrop_dl/crawlers/spankbang.py
+++ b/cyberdrop_dl/crawlers/spankbang.py
@@ -35,7 +35,7 @@ class PlaylistInfo:
         playlist_id = url.parts[1].split("-")[0]
         name = url.parts[3]
         canonical_url = PRIMARY_URL / playlist_id / "playlist" / name
-        title = css.select_one_get_text(soup, "title").rsplit("Playlist -")[0].strip() if soup else ""
+        title = css.select_text(soup, "title").rsplit("Playlist -")[0].strip() if soup else ""
         return cls(playlist_id, canonical_url, title)
 
 
@@ -130,8 +130,8 @@ class SpankBangCrawler(Crawler):
 
 
 def _parse_video(soup: BeautifulSoup) -> Video:
-    title_tag = css.select_one(soup, "div#video h1")
-    stream_js_text = css.select_one_get_text(soup, JS_STREAM_DATA_SELECTOR)
+    title_tag = css.select(soup, "div#video h1")
+    stream_js_text = css.select_text(soup, JS_STREAM_DATA_SELECTOR)
     video_id = get_text_between(stream_js_text, "ana_video_id = ", ";").strip("'")
     del soup
     stream_data = json.load_js_obj(get_text_between(stream_js_text, "stream_data = ", ";"))

--- a/cyberdrop_dl/crawlers/streamtape.py
+++ b/cyberdrop_dl/crawlers/streamtape.py
@@ -50,7 +50,7 @@ class StreamtapeCrawler(Crawler):
 
 
 def _extract_download_link(soup: BeautifulSoup) -> AbsoluteHttpURL:
-    script = css.select_one_get_text(soup, Selector.JS_TOKEN)
+    script = css.select_text(soup, Selector.JS_TOKEN)
     token = get_text_between(script, "&token=", "'")
-    bait_url = css.select_one_get_text(soup, Selector.BAIT_LINK)
+    bait_url = css.select_text(soup, Selector.BAIT_LINK)
     return parse_url(f"https:/{bait_url}").update_query(token=token)

--- a/cyberdrop_dl/crawlers/tnaflix.py
+++ b/cyberdrop_dl/crawlers/tnaflix.py
@@ -72,7 +72,7 @@ class TNAFlixCrawler(Crawler):
         title: str = ""
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                name = name or css.select_one_get_text(soup, Selector.COLLECTION_TITLE)
+                name = name or css.select_text(soup, Selector.COLLECTION_TITLE)
                 title = self.create_title(f"{name} - [{collection_type}]")
                 scrape_item.setup_as_album(title)
 

--- a/cyberdrop_dl/crawlers/tokyomotion.py
+++ b/cyberdrop_dl/crawlers/tokyomotion.py
@@ -88,10 +88,10 @@ class TokioMotionCrawler(Crawler):
                 raise ScrapeError(401, "Private video")
             raise ScrapeError(422, "Couldn't find video source")
 
-        scrape_item.possible_datetime = self.parse_date(css.select_one_get_text(soup, _SELECTORS.VIDEO_DATE))
+        scrape_item.possible_datetime = self.parse_date(css.select_text(soup, _SELECTORS.VIDEO_DATE))
         link_str = css.get_attr(src, "src")
         link = self.parse_url(link_str)
-        title = css.select_one_get_text(soup, "title").rsplit(" - TOKYO Motion")[0].strip()
+        title = css.select_text(soup, "title").rsplit(" - TOKYO Motion")[0].strip()
         filename, ext = f"{video_id}.mp4", ".mp4"
         custom_filename = self.create_custom_filename(title, ext, file_id=video_id)
         await self.handle_file(link, scrape_item, filename, ext, custom_filename=custom_filename)
@@ -202,7 +202,7 @@ class TokioMotionCrawler(Crawler):
         if "album" in scrape_item.url.parts and len(scrape_item.url.parts) > 3:
             return scrape_item.url.parts[3]
         soup = await self.request_soup(scrape_item.url)
-        return css.select_one_get_text(soup, _SELECTORS.ALBUM_TITLE)
+        return css.select_text(soup, _SELECTORS.ALBUM_TITLE)
 
     def add_user_title(self, scrape_item: ScrapeItem) -> None:
         try:

--- a/cyberdrop_dl/crawlers/toonily.py
+++ b/cyberdrop_dl/crawlers/toonily.py
@@ -39,7 +39,7 @@ class ToonilyCrawler(Crawler):
     async def series(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        title_tag = css.select_one(soup, Selector.SERIES_TITLE)
+        title_tag = css.select(soup, Selector.SERIES_TITLE)
         css.decompose(title_tag, "*")
         series_title = self.create_title(css.get_text(title_tag))
         scrape_item.setup_as_profile(series_title)
@@ -50,7 +50,7 @@ class ToonilyCrawler(Crawler):
     async def chapter(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
 
-        series_name, chapter_title = css.select_one_get_text(soup, Selector.CHAPTER_TITLE).split(" - ", 1)
+        series_name, chapter_title = css.select_text(soup, Selector.CHAPTER_TITLE).split(" - ", 1)
         if scrape_item.type != FILE_HOST_PROFILE:
             series_title = self.create_title(series_name)
             scrape_item.add_to_parent_title(series_title)

--- a/cyberdrop_dl/crawlers/tranny_one.py
+++ b/cyberdrop_dl/crawlers/tranny_one.py
@@ -59,7 +59,7 @@ class TrannyOneCrawler(Crawler):
             return
 
         soup = await self.request_soup(scrape_item.url)
-        title = css.select_one_get_text(soup, Selector.VIDEO_TITLE)
+        title = css.select_text(soup, Selector.VIDEO_TITLE)
         link = self.parse_url(Selector.VIDEO_SRC(soup))
         filename, ext = self.get_filename_and_ext(link.name)
         custom_filename = self.create_custom_filename(title, ext, file_id=video_id)
@@ -86,7 +86,7 @@ class TrannyOneCrawler(Crawler):
     @error_handling_wrapper
     async def album(self, scrape_item: ScrapeItem, album_id: str) -> None:
         soup = await self.request_soup(scrape_item.url)
-        name = css.select_one_get_text(soup, Selector.ALBUM_TITLE)
+        name = css.select_text(soup, Selector.ALBUM_TITLE)
         scrape_item.setup_as_album(self.create_title(f"{name} [album]"), album_id=album_id)
         results = await self.get_album_results(album_id)
         for _, pic in self.iter_tags(soup, Selector.IMAGES, results=results):
@@ -95,7 +95,7 @@ class TrannyOneCrawler(Crawler):
     @error_handling_wrapper
     async def model(self, scrape_item: ScrapeItem, model_id: str) -> None:
         soup = await self.request_soup(scrape_item.url)
-        name = css.select_one_get_text(soup, Selector.MODEL_NAME)
+        name = css.select_text(soup, Selector.MODEL_NAME)
         scrape_item.setup_as_profile(self.create_title(f"{name} [model]"))
 
         ajax_url = self.PRIMARY_URL.with_query(area="pornstarsViewer", ajax=1, id=model_id, tab="albums")

--- a/cyberdrop_dl/crawlers/transflix.py
+++ b/cyberdrop_dl/crawlers/transflix.py
@@ -48,7 +48,7 @@ class TransflixCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
         title = open_graph.title(soup)
-        video = css.select_one(soup, _SELECTORS.VIDEO)
+        video = css.select(soup, _SELECTORS.VIDEO)
         link = self.parse_url(css.get_attr(video, "src"))
         filename, ext = self.get_filename_and_ext(link.name)
         scrape_item.possible_datetime = _timestamp_from_filename(link.name)

--- a/cyberdrop_dl/crawlers/vipr_dot_im.py
+++ b/cyberdrop_dl/crawlers/vipr_dot_im.py
@@ -36,7 +36,7 @@ class ViprImCrawler(Crawler):
 
         soup = await self.request_soup(scrape_item.url)
 
-        link_str: str = css.select_one_get_attr(soup, IMG_SELECTOR, "src")
+        link_str: str = css.select(soup, IMG_SELECTOR, "src")
         link = self.parse_url(link_str)
         filename, ext = self.get_filename_and_ext(link.name, assume_ext=".jpg")
         await self.handle_file(link, scrape_item, filename, ext)

--- a/cyberdrop_dl/crawlers/wordpress/_wordpress.py
+++ b/cyberdrop_dl/crawlers/wordpress/_wordpress.py
@@ -286,7 +286,7 @@ class WordPressHTMLCrawler(WordPressBaseCrawler, is_generic=True):
         return await self.handle_post(scrape_item, post, is_single_post=True)
 
     def parse_post(self, scrape_item: ScrapeItem, soup: BeautifulSoup) -> Post:
-        title = open_graph.get_title(soup) or css.select_one_get_text(soup, _SELECTORS.POST_TITLE)
+        title = open_graph.get_title(soup) or css.select_text(soup, _SELECTORS.POST_TITLE)
         date = open_graph.get("published_time", soup) or _match_date_from_path(scrape_item.url.parts[1:4])
         data = {
             "id": get_post_id(soup),
@@ -294,7 +294,7 @@ class WordPressHTMLCrawler(WordPressBaseCrawler, is_generic=True):
             "title": title,
             "date_gmt": date,
             "link": str(scrape_item.url),
-            "content": str(css.select_one(soup, _SELECTORS.POST_CONTENT)),
+            "content": str(css.select(soup, _SELECTORS.POST_CONTENT)),
         }
         return Post.model_validate(data, by_name=True)
 

--- a/cyberdrop_dl/crawlers/xbunkr.py
+++ b/cyberdrop_dl/crawlers/xbunkr.py
@@ -32,7 +32,7 @@ class XBunkrCrawler(Crawler):
         soup = await self.request_soup(scrape_item.url)
 
         album_id = scrape_item.url.parts[2]
-        title = self.create_title(css.select_one_get_text(soup, TITLE_SELECTOR), album_id)
+        title = self.create_title(css.select_text(soup, TITLE_SELECTOR), album_id)
         scrape_item.setup_as_album(title, album_id=album_id)
 
         for _, link in self.iter_tags(soup, IMAGE_SELECTOR):

--- a/cyberdrop_dl/crawlers/xenforo/titsintops.py
+++ b/cyberdrop_dl/crawlers/xenforo/titsintops.py
@@ -23,7 +23,7 @@ class TitsInTopsCrawler(XenforoCrawler):
         text = css.get_text(link_obj)
         if "view attachment" in text.lower():
             return True
-        title = css.get_attr_no_error(link_obj, "title")
+        title = css.get_attr_or_none(link_obj, "title")
         if title and "permanent link" in title.lower():
             return True
         return super().is_username_or_attachment(link_obj)

--- a/cyberdrop_dl/crawlers/xgroovy.py
+++ b/cyberdrop_dl/crawlers/xgroovy.py
@@ -91,7 +91,7 @@ class XGroovyCrawler(Crawler):
         title: str = ""
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                name = name or css.select_one_get_text(soup, Selector.COLLECTION_TITLE)
+                name = name or css.select_text(soup, Selector.COLLECTION_TITLE)
                 title = self.create_title(f"{name} [{collection_type}]")
                 scrape_item.setup_as_album(title)
 

--- a/cyberdrop_dl/crawlers/xvideos.py
+++ b/cyberdrop_dl/crawlers/xvideos.py
@@ -118,7 +118,7 @@ class XVideosCrawler(Crawler):
 
         title = css.page_title(soup, self.DOMAIN)
         scrape_item.possible_datetime = self.parse_iso_date(css.get_json_ld_date(soup))
-        script = css.select_one_get_text(soup, Selectors.HLS_VIDEO_JS)
+        script = css.select_text(soup, Selectors.HLS_VIDEO_JS)
         m3u8_url = self.parse_url(get_text_between(script, "setVideoHLS('", "')"))
         m3u8, info = await self.get_m3u8_from_playlist_url(m3u8_url)
         custom_filename = self.create_custom_filename(title, ".mp4", file_id=encoded_id, resolution=info.resolution)
@@ -133,7 +133,7 @@ class XVideosCrawler(Crawler):
             scrape_item.url = await self._get_redirect_url(scrape_item.url)
 
         soup = await self._get_soup(scrape_item.url)
-        script = css.select_one_get_text(soup, Selectors.ACCOUNT_INFO_JS)
+        script = css.select_text(soup, Selectors.ACCOUNT_INFO_JS)
         display_name = get_text_between(script, '"display":"', '",')
         scrape_item.setup_as_profile(self.create_title(f"{display_name} [{name}]"))
 
@@ -171,7 +171,7 @@ class XVideosCrawler(Crawler):
         results = await self.get_album_results(album_id)
         async for soup in self.web_pager(scrape_item.url, relative_to=scrape_item.url.origin()):
             if not title:
-                title_tag = css.select_one(soup, Selectors.GALLERY_TITLE)
+                title_tag = css.select(soup, Selectors.GALLERY_TITLE)
                 for tag in title_tag.select("*"):
                     tag.decompose()
                 title = self.create_title(css.get_text(title_tag).split(">", 1)[-1].strip(), album_id)

--- a/cyberdrop_dl/crawlers/xxxbunker.py
+++ b/cyberdrop_dl/crawlers/xxxbunker.py
@@ -56,9 +56,9 @@ class XXXBunkerCrawler(Crawler):
         soup = await self.request_soup(scrape_item.url)
         _check_video_is_available(soup)
         title = open_graph.title(soup)
-        iframe_url = self.parse_url(css.select_one_get_attr(soup, Selector.VIDEO_IFRAME, "data-src"))
+        iframe_url = self.parse_url(css.select(soup, Selector.VIDEO_IFRAME, "data-src"))
         iframe_soup = await self.request_soup(iframe_url)
-        src = self.parse_url(css.select_one_get_attr(iframe_soup, "source", "src"))
+        src = self.parse_url(css.select(iframe_soup, "source", "src"))
         video_id = iframe_url.name
         custom_filename = self.create_custom_filename(title, ".mp4", file_id=video_id)
         await self.handle_file(

--- a/cyberdrop_dl/crawlers/yandex_disk.py
+++ b/cyberdrop_dl/crawlers/yandex_disk.py
@@ -168,7 +168,7 @@ class YandexDiskCrawler(Crawler):
 
 
 def get_item_info(soup: BeautifulSoup) -> dict:
-    js_text: str = css.select_one_get_text(soup, JS_SELECTOR)
+    js_text: str = css.select_text(soup, JS_SELECTOR)
     info_json: dict[str, AnyDict] = json.loads(js_text)
     info_json = {k: v for k, v in info_json.items() if k in KEYS_TO_KEEP}
     env: dict[str, str] = info_json["environment"]

--- a/cyberdrop_dl/crawlers/youjizz.py
+++ b/cyberdrop_dl/crawlers/youjizz.py
@@ -76,12 +76,12 @@ class YouJizzCrawler(Crawler):
 
 
 def _parse_video(soup: BeautifulSoup) -> Video:
-    js_text = css.select_one_get_text(soup, JS_SELECTOR)
+    js_text = css.select_text(soup, JS_SELECTOR)
     encodings_text = get_text_between(js_text, "var dataEncodings =", "var encodings").strip().removesuffix(";")
     data_encodings = json.loads(encodings_text)
     return Video(
         title=open_graph.title(soup),
-        date=css.select_one_get_text(soup, DATE_SELECTOR),
+        date=css.select_text(soup, DATE_SELECTOR),
         best_src=_get_best_src(data_encodings),
     )
 

--- a/cyberdrop_dl/utils/css.py
+++ b/cyberdrop_dl/utils/css.py
@@ -147,7 +147,7 @@ def page_title(soup: Tag, domain: str | None = None) -> str:
 
 
 def get_json_ld_date(soup: Tag) -> str:
-    return get_json_ld_value(soup, "uploadDate")
+    return get_json_ld(soup)["uploadDate"]
 
 
 def get_json_ld(soup: Tag, /, contains: str | None = None) -> dict[str, Any]:
@@ -160,11 +160,6 @@ def get_json_ld(soup: Tag, /, contains: str | None = None) -> dict[str, Any]:
         return ld_json[0]
 
     return ld_json
-
-
-def get_json_ld_value(soup: Tag, key: str) -> Any:
-    ld_json = get_json_ld(soup, key)
-    return ld_json[key]
 
 
 def unescape(html: str) -> str:

--- a/cyberdrop_dl/utils/css.py
+++ b/cyberdrop_dl/utils/css.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import functools
 import json
-from typing import TYPE_CHECKING, Any, NamedTuple, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, ParamSpec, TypeVar, overload
 
 import bs4.css
 from bs4 import BeautifulSoup
+from bs4.element import Tag
 
 from cyberdrop_dl.exceptions import ScrapeError
 
@@ -14,8 +15,8 @@ if TYPE_CHECKING:
 
     from bs4 import Tag
 
-P = ParamSpec("P")
-R = TypeVar("R")
+    _P = ParamSpec("_P")
+    _R = TypeVar("_R")
 
 
 class SelectorError(ScrapeError):
@@ -28,12 +29,12 @@ class CssAttributeSelector(NamedTuple):
     attribute: str = ""
 
     def __call__(self, soup: Tag) -> str:
-        return select_one_get_attr(soup, self.element, self.attribute)
+        return select(soup, self.element, self.attribute)
 
 
-def not_none(func: Callable[P, R | None]) -> Callable[P, R]:
+def not_none(func: Callable[_P, _R | None]) -> Callable[_P, _R]:
     @functools.wraps(func)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         result = func(*args, **kwargs)
         if result is None:
             raise SelectorError
@@ -43,14 +44,14 @@ def not_none(func: Callable[P, R | None]) -> Callable[P, R]:
 
 
 @not_none
-def select_one(tag: Tag, selector: str) -> Tag | None:
+def _select_one(tag: Tag, selector: str) -> Tag | None:
     """Same as `tag.select_one` but asserts the result is not `None`"""
     return tag.select_one(selector)
 
 
-def select_one_get_text(tag: Tag, selector: str, strip: bool = True, *, decompose: str | None = None) -> str:
+def select_text(tag: Tag, selector: str, strip: bool = True, *, decompose: str | None = None) -> str:
     """Same as `tag.select_one.get_text(strip=strip)` but asserts the result is not `None`"""
-    inner_tag = select_one(tag, selector)
+    inner_tag = select(tag, selector)
     if decompose:
         for trash in iselect(inner_tag, decompose):
             trash.decompose()
@@ -93,9 +94,18 @@ def get_attr(tag: Tag, attribute: str) -> str | None:
     return get_attr_or_none(tag, attribute)
 
 
-def select_one_get_attr(tag: Tag, selector: str, attribute: str) -> str:
-    """Same as `tag.select_one(selector)[attribute]` but asserts the result is not `None` and is a single string"""
-    inner_tag = select_one(tag, selector)
+@overload
+def select(tag: Tag, selector: str) -> Tag: ...
+
+
+@overload
+def select(tag: Tag, selector: str, attribute: str) -> str: ...
+
+
+def select(tag: Tag, selector: str, attribute: str | None = None) -> Tag | str:
+    inner_tag = _select_one(tag, selector)
+    if not attribute:
+        return inner_tag
     return get_attr(inner_tag, attribute)
 
 
@@ -139,7 +149,7 @@ def sanitize_page_title(title: str, domain: str) -> str:
 
 
 def page_title(soup: Tag, domain: str | None = None) -> str:
-    title = select_one_get_text(soup, "title")
+    title = select_text(soup, "title")
     if domain:
         return sanitize_page_title(title, domain)
     return title
@@ -154,7 +164,7 @@ def get_json_ld(soup: Tag, /, contains: str | None = None) -> dict[str, Any]:
     if contains:
         selector += f":-soup-contains('{contains}')"
 
-    ld_json = json.loads(select_one_get_text(soup, selector)) or {}
+    ld_json = json.loads(select_text(soup, selector)) or {}
     if isinstance(ld_json, list):
         return ld_json[0]
 

--- a/cyberdrop_dl/utils/css.py
+++ b/cyberdrop_dl/utils/css.py
@@ -58,8 +58,6 @@ def select_text(tag: Tag, selector: str, strip: bool = True, *, decompose: str |
     return get_text(inner_tag, strip)
 
 
-# TODO: Rename this to just get_attr
-# get_attr_no_error should be get_attr_or_none. `or_none` implies no error
 def get_attr_or_none(tag: Tag, attribute: str) -> str | None:
     """Same as `tag.get(attribute)` but asserts the result is a single str"""
     attribute_ = attribute
@@ -75,13 +73,6 @@ def get_attr_or_none(tag: Tag, attribute: str) -> str | None:
     if isinstance(value, list):
         raise SelectorError(f"Expected a single value for {attribute = !r}, got multiple")
     return value
-
-
-def get_attr_no_error(tag: Tag, attribute: str) -> str | None:
-    try:
-        return get_attr_or_none(tag, attribute)
-    except Exception:
-        return
 
 
 def get_text(tag: Tag, strip: bool = True) -> str:


### PR DESCRIPTION
- Unify `select_one` and `select_one_get_attr` into a single function with a smarter signature: `select`

- Rename `select_one_get_text` to `select_text`

- Remove redundant functions that are no longer used 
