### PR TITLE
perf: replace basic lru_cache with normal cache

### DIFF
--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -217,7 +217,7 @@ class StorageManager:
             await asyncio.sleep(_CHECK_PERIOD)
 
 
-@functools.cache
+@functools.lru_cache
 def _get_mount_point(folder: Path, all_mounts: tuple[Path, ...]) -> Path | None:
     # Cached for performance.
     # It's not an expensive operation nor IO blocking, but it's very common for multiple files to share the same download folder

--- a/cyberdrop_dl/managers/storage_manager.py
+++ b/cyberdrop_dl/managers/storage_manager.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import itertools
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
-from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, NamedTuple
 
@@ -217,7 +217,7 @@ class StorageManager:
             await asyncio.sleep(_CHECK_PERIOD)
 
 
-@lru_cache
+@functools.cache
 def _get_mount_point(folder: Path, all_mounts: tuple[Path, ...]) -> Path | None:
     # Cached for performance.
     # It's not an expensive operation nor IO blocking, but it's very common for multiple files to share the same download folder

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from functools import lru_cache
+import functools
 from typing import NamedTuple
 
 from rich.console import Group
@@ -168,7 +168,7 @@ class ScrapeStatsProgress(StatsProgress):
             self.unsupported_urls_skipped += 1
 
 
-@lru_cache
+@functools.cache
 def get_pretty_failure(failure: str) -> str:
     with contextlib.suppress(KeyError):
         return FAILURE_OVERRIDES[failure]

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -168,7 +168,7 @@ class ScrapeStatsProgress(StatsProgress):
             self.unsupported_urls_skipped += 1
 
 
-@functools.cache
+@functools.lru_cache
 def get_pretty_failure(failure: str) -> str:
     with contextlib.suppress(KeyError):
         return FAILURE_OVERRIDES[failure]

--- a/cyberdrop_dl/utils/ffmpeg.py
+++ b/cyberdrop_dl/utils/ffmpeg.py
@@ -62,11 +62,13 @@ def which_ffprobe() -> str | None:
         return
 
 
+@functools.cache
 def get_ffmpeg_version() -> str | None:
     if bin_path := which_ffmpeg():
         return _get_bin_version(bin_path)
 
 
+@functools.cache
 def get_ffprobe_version() -> str | None:
     if bin_path := which_ffprobe():
         return _get_bin_version(bin_path)
@@ -160,7 +162,6 @@ async def _merge(input_files: Sequence[Path], output_file: Path) -> SubProcessRe
     return await _run_command(command)
 
 
-@functools.cache
 def _get_bin_version(bin_path: str) -> str | None:
     try:
         cmd = bin_path, "-version"

--- a/cyberdrop_dl/utils/ffmpeg.py
+++ b/cyberdrop_dl/utils/ffmpeg.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import itertools
 import json
 import shutil
@@ -8,7 +9,6 @@ import subprocess
 from dataclasses import asdict, dataclass
 from datetime import timedelta
 from fractions import Fraction
-from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Required, Self, TypeAlias, TypedDict, overload
 
@@ -50,12 +50,12 @@ def check_is_available() -> None:
         raise RuntimeError("ffprobe is not available")
 
 
-@lru_cache
+@functools.cache
 def which_ffmpeg() -> str | None:
     return shutil.which("ffmpeg")
 
 
-@lru_cache
+@functools.cache
 def which_ffprobe() -> str | None:
     global _FFPROBE_AVAILABLE
     try:
@@ -164,7 +164,7 @@ async def _merge(input_files: Sequence[Path], output_file: Path) -> SubProcessRe
     return await _run_command(command)
 
 
-@lru_cache
+@functools.cache
 def _get_bin_version(bin_path: str) -> str | None:
     try:
         cmd = bin_path, "-version"

--- a/cyberdrop_dl/utils/ffmpeg.py
+++ b/cyberdrop_dl/utils/ffmpeg.py
@@ -39,7 +39,6 @@ class Args:
 
 _FFMPEG_CALL_PREFIX = "ffmpeg", "-y", "-loglevel", "error"
 _FFPROBE_CALL_PREFIX = "ffprobe", "-hide_banner", "-loglevel", "error", "-show_streams", "-print_format", "json"
-_FFPROBE_AVAILABLE = False
 _EMPTY_FFPROBE_OUTPUT: FFprobeOutput = {"streams": []}
 
 
@@ -57,11 +56,8 @@ def which_ffmpeg() -> str | None:
 
 @functools.cache
 def which_ffprobe() -> str | None:
-    global _FFPROBE_AVAILABLE
     try:
-        bin_path = shutil.which("ffprobe") or _builtin_ffprobe()
-        _FFPROBE_AVAILABLE = True  # pyright: ignore[reportConstantRedefinition]
-        return bin_path
+        return shutil.which("ffprobe") or _builtin_ffprobe()
     except RuntimeError:
         return
 
@@ -107,7 +103,7 @@ async def probe(input: AbsoluteHttpURL, /, *, headers: Mapping[str, str] | None 
 
 
 async def probe(input: Path | AbsoluteHttpURL, /, *, headers: Mapping[str, str] | None = None) -> FFprobeResult:
-    assert _FFPROBE_AVAILABLE
+    assert which_ffprobe()
     if isinstance(input, URL):
         assert is_absolute_http_url(input)
 

--- a/cyberdrop_dl/utils/text_editor.py
+++ b/cyberdrop_dl/utils/text_editor.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import functools
 import os
 import platform
 import shutil
 import subprocess
-from functools import lru_cache
 from pathlib import Path
 
 import rich
@@ -48,14 +48,14 @@ def open_in_text_editor(file_path: Path) -> bool | None:
     subprocess.call(cmd, stderr=subprocess.DEVNULL)
 
 
-@lru_cache
+@functools.cache
 def _find_text_editor() -> str | None:
     for editor in _TEXT_EDITORS:
         if bin_path := shutil.which(editor):
             return bin_path
 
 
-@lru_cache
+@functools.lru_cache
 def _xdg_set_default_if_none(file: Path) -> bool:
     """
     Ensures a file's MIME type has a default XDG app, falling back to whatever app is currently set for 'text/plain'

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import functools
 import inspect
 import itertools
 import os
@@ -10,7 +11,7 @@ import re
 import sys
 import unicodedata
 from collections.abc import Generator, Mapping
-from functools import lru_cache, partial, wraps
+from functools import partial, wraps
 from pathlib import Path
 from stat import S_ISREG
 from typing import (
@@ -454,7 +455,7 @@ async def close_if_defined(obj: C) -> C:
     return constants.NOT_DEFINED
 
 
-@lru_cache
+@functools.cache
 def get_system_information() -> str:
     def get_common_name() -> str:
         system = platform.system()


### PR DESCRIPTION
Use normal cache for functions that do not take any params. It's the same cache logic but a bit faster cause it skips some checks and does not use a thread lock