### PR TITLE
Fix Postimg gallery scrape failure

### DIFF
--- a/cyberdrop_dl/crawlers/postimg.py
+++ b/cyberdrop_dl/crawlers/postimg.py
@@ -51,8 +51,8 @@ class PostImgCrawler(Crawler):
                 scrape_item.setup_as_album(title, album_id=album_id)
 
             for image in json_resp["images"]:
-                link = self.parse_url(image[4])
-                filename, ext = self.get_filename_and_ext(image[2])
+                link = self.parse_url(image[6])
+                filename, ext = self.get_filename_and_ext(link.name)
                 new_scrape_item = scrape_item.create_child(link)
                 await self.handle_file(link, new_scrape_item, filename, ext)
                 scrape_item.add_children()

--- a/cyberdrop_dl/crawlers/postimg.py
+++ b/cyberdrop_dl/crawlers/postimg.py
@@ -51,10 +51,8 @@ class PostImgCrawler(Crawler):
                 scrape_item.setup_as_album(title, album_id=album_id)
 
             for image in json_resp["images"]:
-                link = self.parse_url(image[6])
-                filename, ext = self.get_filename_and_ext(link.name)
-                new_scrape_item = scrape_item.create_child(link)
-                await self.handle_file(link, new_scrape_item, filename, ext)
+                link = PRIMARY_URL.with_path(image[0])
+                await self.image(scrape_item.create_child(link))
                 scrape_item.add_children()
 
             if not json_resp["has_page_next"]:

--- a/cyberdrop_dl/crawlers/postimg.py
+++ b/cyberdrop_dl/crawlers/postimg.py
@@ -51,8 +51,8 @@ class PostImgCrawler(Crawler):
                 scrape_item.setup_as_album(title, album_id=album_id)
 
             for image in json_resp["images"]:
-                link = PRIMARY_URL.with_path(image[0])
-                await self.image(scrape_item.create_child(link))
+                link = self.PRIMARY_URL / image[0]
+                self.create_task(self.run(scrape_item.create_child(link)))
                 scrape_item.add_children()
 
             if not json_resp["has_page_next"]:


### PR DESCRIPTION
Fixes #1582 

It seems the API response schema from `https://postimg.cc/json` to fetch the list of images from album is updated.

The image URL is now present at index 6, instead of index 4 as you can see in following screenshot.
<img width="4096" height="2304" alt="image" src="https://github.com/user-attachments/assets/369f664b-d28a-4f28-a4e8-4de52a48e782" />

Note: I also noticed that images downloaded from the album are lower quality than those from the direct image link . So I reused same logic for album links too.

Examples:
Image URL: `https://postimg.cc/svttNZMf`
Gallery URL: `https://postimg.cc/gallery/QVxMP2c`


