### PR TITLE
fix: Date Parsing Tests

### DIFF
--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -20,6 +20,6 @@ def test_parse_today_at_midnight() -> None:
 
 
 def test_parse_date_with_no_year() -> None:
-    expected = today_at_midnight().replace(month=10, day=14)
-    result = dates.parse_human("oct 14")
+    expected = today_at_midnight().replace(month=1, day=1)
+    result = dates.parse_human("jan 1")
     assert expected == result


### PR DESCRIPTION
Fix the test for parsing a date with no year. Previously it was set to parse for October 14th, but we have our parser set to prefer dates in the past.

October 14th hasn't come yet so we are given October 14th, 2025, but are checking for October 14th, 2026. The easiest solution is just to look for January 1st.