### PR TITLE
refactor: rework crawler (bunkr)

### DIFF
--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 _DOWNLOAD_API_ENTRYPOINT = AbsoluteHttpURL("https://apidl.bunkr.ru/api/_001_v2")
 _STREAMING_API_ENTRYPOINT = AbsoluteHttpURL("https://bunkr.site/api/vs")
 _PRIMARY_URL = AbsoluteHttpURL("https://bunkr.site")
-_REINFORCED_URL_BASE = AbsoluteHttpURL("https://get.bunkr.su")
+_REINFORCED_URL_BASE = AbsoluteHttpURL("https://get.bunkrr.su")
 
 
 class Selector:

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -160,6 +160,10 @@ class BunkrrCrawler(Crawler):
     @auto_task_id
     @error_handling_wrapper
     async def _album_file(self, scrape_item: ScrapeItem, file: File, results: dict[str, int]) -> None:
+        db_url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
+        if await self.check_complete_from_referer(db_url):
+            return
+
         src = file.src()
         scrape_item.possible_datetime = self.parse_date(file.date, "%H:%M:%S %d/%m/%Y")
         if (

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -103,14 +103,11 @@ class File:
 
     def src(self) -> AbsoluteHttpURL:
         src_str = self.thumbnail.replace("/thumbs/", "/")
-        src = parse_url(src_str).with_suffix(self.suffix).with_query(None)
+        ext = Path(self.name).suffix
+        src = parse_url(src_str).with_suffix(ext).with_query(None)
         if src.suffix.lower() not in FILE_FORMATS["Images"]:
-            return src.with_host(src.host.replace("i-", ""))
-        return src
-
-    @property
-    def suffix(self) -> str:
-        return Path(self.name).suffix
+            src = src.with_host(src.host.replace("i-", ""))
+        return _override_cdn(src)
 
 
 class BunkrrCrawler(Crawler):
@@ -137,8 +134,8 @@ class BunkrrCrawler(Crawler):
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:
-            case ["file", id_] if scrape_item.url.host == _REINFORCED_URL_BASE.host:
-                return await self.reinforced_file(scrape_item, id_)
+            case ["file", file_id] if scrape_item.url.host == _REINFORCED_URL_BASE.host:
+                return await self.reinforced_file(scrape_item, file_id)
             case ["a", album_id]:
                 return await self.album(scrape_item, album_id)
             case ["v", _]:
@@ -152,9 +149,7 @@ class BunkrrCrawler(Crawler):
                 if self.is_subdomain(scrape_item.url):
                     return await self.handle_direct_link(scrape_item, scrape_item.url)
 
-                await self.file(scrape_item)
-            case _:
-                raise ValueError
+        raise ValueError
 
     @error_handling_wrapper
     async def album(self, scrape_item: ScrapeItem, album_id: str) -> None:
@@ -201,19 +196,19 @@ class BunkrrCrawler(Crawler):
             file_id = self.parse_url(dl_link).name
             link = await self._request_download(file_id)
 
-        title = open_graph.title(soup)  # See: https://github.com/jbsparrow/CyberDropDownloader/issues/929
-        await self.handle_direct_link(scrape_item, link, fallback_filename=title)
+        name = open_graph.title(soup)  # See: https://github.com/jbsparrow/CyberDropDownloader/issues/929
+        await self.handle_direct_link(scrape_item, link, name)
 
     @error_handling_wrapper
-    async def reinforced_file(self, scrape_item: ScrapeItem, id_: str) -> None:
+    async def reinforced_file(self, scrape_item: ScrapeItem, file_id: str) -> None:
         soup = await self.request_soup(scrape_item.url)
-        title = css.select_text(soup, "h1")
-        link = await self._request_download(file_id=id_)
-        await self.handle_direct_link(scrape_item, link, fallback_filename=title)
+        name = css.select_text(soup, "h1")
+        link = await self._request_download(file_id=file_id)
+        await self.handle_direct_link(scrape_item, link, name)
 
     @error_handling_wrapper
     async def handle_direct_link(
-        self, scrape_item: ScrapeItem, url: AbsoluteHttpURL, fallback_filename: str = ""
+        self, scrape_item: ScrapeItem, url: AbsoluteHttpURL, fallback_filename: str | None = None
     ) -> None:
         link = url
         name = link.query.get("n") or fallback_filename or link.name
@@ -283,3 +278,9 @@ def _is_stream_redirect(url: AbsoluteHttpURL) -> bool:
     if not prefix and number.isdigit():
         return True
     return any(part in url.host for part in ("cdn12", "cdn-")) or url.host == "cdn.bunkr.ru"
+
+
+def _override_cdn(url: AbsoluteHttpURL) -> AbsoluteHttpURL:
+    if "milkshake" in url.host:
+        return url.with_host("mlk-bk.cdn.gigachad-cdn.ru")
+    return url

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -11,7 +11,7 @@ from aiohttp import ClientConnectorError
 from cyberdrop_dl.constants import FILE_FORMATS
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedDomains, SupportedPaths, auto_task_id
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
-from cyberdrop_dl.exceptions import DDOSGuardError, ScrapeError
+from cyberdrop_dl.exceptions import DDOSGuardError
 from cyberdrop_dl.utils import aio, css, open_graph
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, parse_url, xor_decrypt
 
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 
 
 _DOWNLOAD_API_ENTRYPOINT = AbsoluteHttpURL("https://apidl.bunkr.ru/api/_001_v2")
-_STREAMING_API_ENTRYPOINT = AbsoluteHttpURL("https://bunkr.site/api/vs")
 _PRIMARY_URL = AbsoluteHttpURL("https://bunkr.site")
 _REINFORCED_URL_BASE = AbsoluteHttpURL("https://get.bunkrr.su")
 
@@ -52,7 +51,7 @@ class ApiResponse:
     timestamp: int
     url: str
 
-    def decrypt(self: ApiResponse) -> str:
+    def decrypt(self) -> str:
         if not self.encrypted:
             return self.url
 
@@ -121,16 +120,16 @@ class BunkrrCrawler(Crawler):
                 return await self.album(scrape_item, album_id)
             case ["v", _]:
                 return await self.follow_redirect(scrape_item)
-            case ["f", slug]:
-                return await self.file(scrape_item, slug)
-            case [slug]:
+            case ["f", _]:
+                return await self.file(scrape_item)
+            case [_]:
                 if _is_stream_redirect(scrape_item.url):
                     return await self.follow_redirect(scrape_item)
 
                 if self.is_subdomain(scrape_item.url):
                     return await self.handle_direct_link(scrape_item, scrape_item.url)
 
-                await self.file(scrape_item, slug)
+                await self.file(scrape_item)
             case _:
                 raise ValueError
 
@@ -170,7 +169,7 @@ class BunkrrCrawler(Crawler):
     ) -> AsyncGenerator[BeautifulSoup]:
         init_page = int(url.query.get("page") or 1)
         for page in itertools.count(init_page):
-            soup = await self.request_soup_lenient(url.with_query(page=page))
+            soup = await self._request_soup_lenient(url.with_query(page=page))
             yield soup
             has_next_page = soup.select_one(Selector.NEXT_PAGE)
             if not has_next_page:
@@ -190,32 +189,20 @@ class BunkrrCrawler(Crawler):
         await self.handle_direct_link(scrape_item, link, file.name)
 
     @error_handling_wrapper
-    async def file(self, scrape_item: ScrapeItem, slug: str) -> None:
+    async def file(self, scrape_item: ScrapeItem) -> None:
         link: AbsoluteHttpURL | None = None
         db_url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
         if await self.check_complete_from_referer(db_url):
             return
 
-        soup = await self.request_soup_lenient(scrape_item.url)
-
-        # Try image first to not make any additional request
+        soup = await self._request_soup_lenient(scrape_item.url)
         if image := soup.select_one(Selector.IMAGE_PREVIEW):
             link = self.parse_url(css.get_attr(image, "src"))
 
-        # Try to get download URL from streaming API. Should work for most files, even none video files
-        if not link:
-            try:
-                link = await self._request_download(slug=slug)
-            except Exception:
-                pass
-
-        if not link and (dl_button := soup.select_one(Selector.DOWNLOAD_BUTTON)):
-            id_ = self.parse_url(css.get_attr(dl_button, "href")).name
-            link = await self._request_download(id_=id_)
-
-        # Everything failed, abort
-        if not link:
-            raise ScrapeError(422, "Could not find source")
+        else:
+            dl_link = css.select(soup, Selector.DOWNLOAD_BUTTON, "href")
+            file_id = self.parse_url(dl_link).name
+            link = await self._request_download(file_id)
 
         title = open_graph.title(soup)  # See: https://github.com/jbsparrow/CyberDropDownloader/issues/929
         await self.handle_direct_link(scrape_item, link, fallback_filename=title)
@@ -224,7 +211,7 @@ class BunkrrCrawler(Crawler):
     async def reinforced_file(self, scrape_item: ScrapeItem, id_: str) -> None:
         soup = await self.request_soup(scrape_item.url)
         title = css.select_text(soup, "h1")
-        link = await self._request_download(id_=id_)
+        link = await self._request_download(file_id=id_)
         await self.handle_direct_link(scrape_item, link, fallback_filename=title)
 
     @error_handling_wrapper
@@ -243,26 +230,11 @@ class BunkrrCrawler(Crawler):
             scrape_item.url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
         await self.handle_file(link, scrape_item, name, ext, custom_filename=filename)
 
-    async def _request_download(self, *, id_: str = "", slug: str = "") -> AbsoluteHttpURL:
-        """Gets the download link for a given URL
-
-        1. Reinforced URL (get.bunkr.su/file/<file_id>). or
-        2. Streaming URL (bunkr.site/f/<file_slug>)"""
-
-        if id_:
-            payload = {"id": id_}
-            api_url = _DOWNLOAD_API_ENTRYPOINT
-
-        else:
-            payload = {"slug": slug.encode().decode("unicode-escape")}
-            api_url = _STREAMING_API_ENTRYPOINT
-            if self.known_good_url:
-                api_url = _STREAMING_API_ENTRYPOINT.with_host(self.known_good_url.host)
-
+    async def _request_download(self, file_id: str) -> AbsoluteHttpURL:
         resp: dict[str, Any] = await self.request_json(
-            api_url,
+            _DOWNLOAD_API_ENTRYPOINT,
             "POST",
-            json=payload,
+            json={"id": file_id},
             headers={"Referer": str(_REINFORCED_URL_BASE)},
         )
         return self.parse_url(ApiResponse(**resp).decrypt())
@@ -281,7 +253,7 @@ class BunkrrCrawler(Crawler):
                 self.known_good_url = resp.url.origin()
             return soup
 
-    async def request_soup_lenient(self, url: AbsoluteHttpURL) -> BeautifulSoup:
+    async def _request_soup_lenient(self, url: AbsoluteHttpURL) -> BeautifulSoup:
         """Request soup with re-trying logic to use multiple hosts.
 
         We retry with a new host until we find one that's not DNS blocked nor DDoS-Guard protected

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -169,20 +169,19 @@ class BunkrrCrawler(Crawler):
     @auto_task_id
     @error_handling_wrapper
     async def _album_file(self, scrape_item: ScrapeItem, file: File, results: dict[str, int]) -> None:
-        link = file.src()
+        src = file.src()
         scrape_item.possible_datetime = self.parse_date(file.date, "%H:%M:%S %d/%m/%Y")
-        if link.suffix.lower() not in VIDEO_AND_IMAGE_EXTS or "no-image" in link.name or self.deep_scrape:
+        if src.suffix.lower() not in VIDEO_AND_IMAGE_EXTS or "no-image" in src.name or self.deep_scrape:
             self.create_task(self.run(scrape_item))
             return
 
-        if self.check_album_results(link, results):
+        if self.check_album_results(src, results):
             return
 
-        await self.handle_direct_link(scrape_item, link, file.name)
+        await self.handle_direct_link(scrape_item, src, file.name)
 
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem) -> None:
-        link: AbsoluteHttpURL | None = None
         db_url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
         if await self.check_complete_from_referer(db_url):
             return
@@ -203,14 +202,13 @@ class BunkrrCrawler(Crawler):
     async def reinforced_file(self, scrape_item: ScrapeItem, file_id: str) -> None:
         soup = await self.request_soup(scrape_item.url)
         name = css.select_text(soup, "h1")
-        link = await self._request_download(file_id=file_id)
+        link = await self._request_download(file_id)
         await self.handle_direct_link(scrape_item, link, name)
 
     @error_handling_wrapper
     async def handle_direct_link(
-        self, scrape_item: ScrapeItem, url: AbsoluteHttpURL, fallback_filename: str | None = None
+        self, scrape_item: ScrapeItem, link: AbsoluteHttpURL, fallback_filename: str | None = None
     ) -> None:
-        link = url
         name = link.query.get("n") or fallback_filename or link.name
         link = link.update_query(n=name)
         filename, ext = self.get_filename_and_ext(name, assume_ext=".mp4")

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -30,11 +30,12 @@ _REINFORCED_URL_BASE = AbsoluteHttpURL("https://get.bunkrr.su")
 
 
 class Selector:
-    ALBUM_ITEM = "div.theItem"
     FILE_NAME = "p.theName"
     FILE_DATE = "span.theDate"
-    DOWNLOAD_BUTTON = "a.btn.ic-download-01"
     FILE_THUMBNAIL = 'img[alt="image"]'
+
+    ALBUM_ITEM = "div.theItem"
+    DOWNLOAD_BUTTON = "a.btn.ic-download-01"
     IMAGE_PREVIEW = "img.max-h-full.w-auto.object-cover.relative"
     VIDEO = "video > source"
     NEXT_PAGE = "nav.pagination a[href]:-soup-contains('»')"
@@ -218,16 +219,14 @@ class BunkrrCrawler(Crawler):
     async def handle_direct_link(
         self, scrape_item: ScrapeItem, url: AbsoluteHttpURL, fallback_filename: str = ""
     ) -> None:
-        """Handles direct links (CDNs URLs) before sending them to the downloader.
-
-        `fallback_filename` will only be used if the link has no `n` query parameter"""
-
         link = url
         name = link.query.get("n") or fallback_filename or link.name
         link = link.update_query(n=name)
         filename, ext = self.get_filename_and_ext(name, assume_ext=".mp4")
         if not self.is_subdomain(scrape_item.url):
             scrape_item.url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
+        elif link.host == scrape_item.url.host:
+            scrape_item.url = _REINFORCED_URL_BASE
         await self.handle_file(link, scrape_item, name, ext, custom_filename=filename)
 
     async def _request_download(self, file_id: str) -> AbsoluteHttpURL:

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import base64
 import dataclasses
-import itertools
+import json
+import re
+from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -16,9 +18,9 @@ from cyberdrop_dl.utils import aio, css, open_graph
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, parse_url, xor_decrypt
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import Callable, Generator
 
-    from bs4 import BeautifulSoup, Tag
+    from bs4 import BeautifulSoup
 
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
     from cyberdrop_dl.utils.aio import WeakAsyncLocks
@@ -35,6 +37,8 @@ class Selector:
     FILE_THUMBNAIL = 'img[alt="image"]'
 
     ALBUM_ITEM = "div.theItem"
+    ALBUM_FILES = "script:-soup-contains('window.albumFiles = ')"
+
     DOWNLOAD_BUTTON = "a.btn.ic-download-01"
     IMAGE_PREVIEW = "img.max-h-full.w-auto.object-cover.relative"
     VIDEO = "video > source"
@@ -44,6 +48,34 @@ class Selector:
 VIDEO_AND_IMAGE_EXTS: set[str] = FILE_FORMATS["Images"] | FILE_FORMATS["Videos"]
 HOST_OPTIONS: set[str] = {"bunkr.site", "bunkr.cr", "bunkr.ph"}
 known_bad_hosts: set[str] = set()
+FILE_KEYS = "id", "name", "original", "slug", "type", "extension", "size", "timestamp", "thumbnail", "cdnEndpoint"
+
+
+def _make_album_parser(keys: tuple[str, ...]) -> Callable[[BeautifulSoup], Generator[File]]:
+    translation_map = {f"{key}: ": f'"{key}": ' for key in keys}
+    pattern = re.compile("|".join(sorted(translation_map, key=len, reverse=True)))
+
+    def decode(text: str) -> Generator[File]:
+        content = (
+            pattern.sub(lambda m: translation_map[m.group(0)], text)
+            .encode("raw_unicode_escape")
+            .decode("unicode-escape")
+        )
+
+        for file in json.loads(content):
+            yield File(
+                name=file.get("original") or file["name"],
+                slug=file["slug"],
+                thumbnail=file["thumbnail"],
+                date=file["timestamp"],
+            )
+
+    def parse(soup: BeautifulSoup) -> Generator[File]:
+        album_js = css.select_text(soup, Selector.ALBUM_FILES)
+        items = album_js[album_js.find("=") + 1 : album_js.rfind("];") + 1]
+        return decode(items)
+
+    return parse
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -67,18 +99,8 @@ class File:
     name: str
     thumbnail: str
     date: str
-    path_qs: str
+    slug: str
 
-    @staticmethod
-    def parse(tag: Tag) -> File:
-        return File(
-            name=css.select_text(tag, Selector.FILE_NAME),
-            thumbnail=css.select(tag, Selector.FILE_THUMBNAIL, "src"),
-            date=css.select_text(tag, Selector.FILE_DATE),
-            path_qs=css.select(tag, "a", "href"),
-        )
-
-    @property
     def src(self) -> AbsoluteHttpURL:
         src_str = self.thumbnail.replace("/thumbs/", "/")
         src = parse_url(src_str).with_suffix(self.suffix).with_query(None)
@@ -111,6 +133,7 @@ class BunkrrCrawler(Crawler):
     def __post_init__(self) -> None:
         self.switch_host_locks: WeakAsyncLocks[str] = aio.WeakAsyncLocks[str]()
         self.known_good_url: AbsoluteHttpURL | None = None
+        self._parse_album_files = _make_album_parser(FILE_KEYS)
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:
@@ -135,50 +158,24 @@ class BunkrrCrawler(Crawler):
 
     @error_handling_wrapper
     async def album(self, scrape_item: ScrapeItem, album_id: str) -> None:
-        title: str = ""
+        soup = await self._request_soup_lenient(scrape_item.url.with_query(advanced=1))
+        name = css.page_title(soup, "bunkr")
+        title = self.create_title(name, album_id)
+        scrape_item.setup_as_album(title, album_id=album_id)
+
+        origin = scrape_item.url.origin()
         results = await self.get_album_results(album_id)
-        seen: set[str] = set()
-        stuck_in_a_loop_msg = f"Found duplicate URLs processing {scrape_item.url}. Aborting to prevent infinite loop"
-
-        async for soup in self.web_pager(scrape_item.url):
-            if not title:
-                name = css.page_title(soup, "bunkr")
-                title = self.create_title(name, album_id)
-                scrape_item.setup_as_album(title, album_id=album_id)
-
-            for tag in soup.select(Selector.ALBUM_ITEM):
-                file = File.parse(tag)
-                if file.path_qs in seen:
-                    self.log(stuck_in_a_loop_msg, 40, bug=True)
-                    return
-
-                seen.add(file.path_qs)
-                link = self.parse_url(file.path_qs, relative_to=scrape_item.url.origin())
-                new_scrape_item = scrape_item.create_child(link)
-                new_scrape_item.possible_datetime = self.parse_date(file.date, "%H:%M:%S %d/%m/%Y")
-                self.create_task(self._album_file(new_scrape_item, file, results))
-                scrape_item.add_children()
-
-    async def web_pager(
-        self,
-        url: AbsoluteHttpURL,
-        next_page_selector: str | None = None,
-        *,
-        cffi: bool = False,
-        **kwargs: Any,
-    ) -> AsyncGenerator[BeautifulSoup]:
-        init_page = int(url.query.get("page") or 1)
-        for page in itertools.count(init_page):
-            soup = await self._request_soup_lenient(url.with_query(page=page))
-            yield soup
-            has_next_page = soup.select_one(Selector.NEXT_PAGE)
-            if not has_next_page:
-                break
+        for file in self._parse_album_files(soup):
+            web_url = origin / "f" / file.slug
+            new_scrape_item = scrape_item.create_child(web_url)
+            self.create_task(self._album_file(new_scrape_item, file, results))
+            scrape_item.add_children()
 
     @auto_task_id
     @error_handling_wrapper
     async def _album_file(self, scrape_item: ScrapeItem, file: File, results: dict[str, int]) -> None:
-        link = file.src
+        link = file.src()
+        scrape_item.possible_datetime = self.parse_date(file.date, "%H:%M:%S %d/%m/%Y")
         if link.suffix.lower() not in VIDEO_AND_IMAGE_EXTS or "no-image" in link.name or self.deep_scrape:
             self.create_task(self.run(scrape_item))
             return
@@ -249,6 +246,8 @@ class BunkrrCrawler(Crawler):
         else:
             if not self.known_good_url:
                 self.known_good_url = resp.url.origin()
+            if url.query.get("advanced") and url.query != resp.url.query:
+                soup = await self.request_soup(resp.url.with_query(url.query))
             return soup
 
     async def _request_soup_lenient(self, url: AbsoluteHttpURL) -> BeautifulSoup:

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -37,6 +37,7 @@ class Selector:
 
 VIDEO_AND_IMAGE_EXTS: set[str] = FILE_FORMATS["Images"] | FILE_FORMATS["Videos"]
 HOST_OPTIONS: set[str] = {"bunkr.site", "bunkr.cr", "bunkr.ph"}
+DEEP_SCRAPE_CDNS: set[str] = {"pizza", "wiener"}  # CDNs under maintanance, ignore them and try to get a cached URL
 FILE_KEYS = "id", "name", "original", "slug", "type", "extension", "size", "timestamp", "thumbnail", "cdnEndpoint"
 known_bad_hosts: set[str] = set()
 
@@ -161,7 +162,12 @@ class BunkrrCrawler(Crawler):
     async def _album_file(self, scrape_item: ScrapeItem, file: File, results: dict[str, int]) -> None:
         src = file.src()
         scrape_item.possible_datetime = self.parse_date(file.date, "%H:%M:%S %d/%m/%Y")
-        if src.suffix.lower() not in VIDEO_AND_IMAGE_EXTS or "no-image" in src.name or self.deep_scrape:
+        if (
+            src.suffix.lower() not in VIDEO_AND_IMAGE_EXTS
+            or "no-image" in src.name
+            or self.deep_scrape
+            or any(cdn in src.host for cdn in DEEP_SCRAPE_CDNS)
+        ):
             self.create_task(self.run(scrape_item))
             return
 

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -185,17 +185,13 @@ class BunkrrCrawler(Crawler):
         if self.check_album_results(link, results):
             return
 
-        if not link.query.get("n"):
-            link = link.update_query(n=file.name)
-
-        filename, ext = self.get_filename_and_ext(link.query["n"], assume_ext=".mp4")
-        await self.handle_file(link, scrape_item, link.name, ext, custom_filename=filename)
+        await self.handle_direct_link(scrape_item, link, file.name)
 
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem, slug: str) -> None:
         link: AbsoluteHttpURL | None = None
-        database_url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
-        if await self.check_complete_from_referer(database_url):
+        db_url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
+        if await self.check_complete_from_referer(db_url):
             return
 
         soup = await self.request_soup_lenient(scrape_item.url)
@@ -204,12 +200,12 @@ class BunkrrCrawler(Crawler):
         if image := soup.select_one(Selector.IMAGE_PREVIEW):
             link = self.parse_url(css.get_attr(image, "src"))
 
-        # Try to get downloadd URL from streaming API. Should work for most files, even none video files
+        # Try to get download URL from streaming API. Should work for most files, even none video files
         if not link:
-            slug = (_get_js_slug(soup) or scrape_item.url.name).encode().decode("unicode-escape")
-            base = self.known_good_url or scrape_item.url.origin()
-            slug_url = base / "f" / slug
-            link = await self._request_download(slug_url, slug=slug)
+            try:
+                link = await self._request_download(slug=slug)
+            except Exception:
+                pass
 
         # Fallback for everything else, try to get the download URL.
         # `handle_direct_link` will make the final request to the API
@@ -227,7 +223,7 @@ class BunkrrCrawler(Crawler):
     async def reinforced_file(self, scrape_item: ScrapeItem, id_: str) -> None:
         soup = await self.request_soup(scrape_item.url)
         title = css.select_text(soup, "h1")
-        link = await self._request_download(scrape_item.url, id_=id_)
+        link = await self._request_download(id_=id_)
         await self.handle_direct_link(scrape_item, link, fallback_filename=title)
 
     @error_handling_wrapper
@@ -246,7 +242,7 @@ class BunkrrCrawler(Crawler):
             scrape_item.url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
         await self.handle_file(link, scrape_item, name, ext, custom_filename=filename)
 
-    async def _request_download(self, url: AbsoluteHttpURL, *, id_: str = "", slug: str = "") -> AbsoluteHttpURL:
+    async def _request_download(self, *, id_: str = "", slug: str = "") -> AbsoluteHttpURL:
         """Gets the download link for a given URL
 
         1. Reinforced URL (get.bunkr.su/file/<file_id>). or
@@ -257,18 +253,18 @@ class BunkrrCrawler(Crawler):
             api_url = _DOWNLOAD_API_ENTRYPOINT
 
         else:
-            payload = {"slug": slug}
+            payload = {"slug": slug.encode().decode("unicode-escape")}
             api_url = _STREAMING_API_ENTRYPOINT
             if self.known_good_url:
                 api_url = _STREAMING_API_ENTRYPOINT.with_host(self.known_good_url.host)
 
-        json_resp: dict[str, Any] = await self.request_json(
+        resp: dict[str, Any] = await self.request_json(
             api_url,
             "POST",
             json=payload,
-            headers={"Referer": str(url)},
+            headers={"Referer": str(_REINFORCED_URL_BASE)},
         )
-        return self.parse_url(ApiResponse(**json_resp).decrypt())
+        return self.parse_url(ApiResponse(**resp).decrypt())
 
     async def _try_request_soup(self, url: AbsoluteHttpURL) -> BeautifulSoup | None:
         try:

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from aiohttp import ClientConnectorError
 
 from cyberdrop_dl.constants import FILE_FORMATS
-from cyberdrop_dl.crawlers.crawler import Crawler, SupportedDomains, SupportedPaths, auto_task_id
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths, auto_task_id
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import DDOSGuardError
 from cyberdrop_dl.utils import aio, css, open_graph
@@ -92,7 +92,6 @@ class File:
 
 
 class BunkrrCrawler(Crawler):
-    SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = "bunkr", "bunkrr"
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Album": "/a/<album_id>",
         "Video": "/v/<slug>",
@@ -105,7 +104,7 @@ class BunkrrCrawler(Crawler):
 
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://bunkr.site")
     DATABASE_PRIMARY_HOST: ClassVar[str] = PRIMARY_URL.host
-    DOMAIN: ClassVar[str] = "bunkrr"
+    DOMAIN: ClassVar[str] = "bunkr"
     _RATE_LIMIT: ClassVar[tuple[float, float]] = 5, 1
     _USE_DOWNLOAD_SERVERS_LOCKS: ClassVar[bool] = True
 

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import base64
+import dataclasses
 import itertools
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from aiohttp import ClientConnectorError
 
@@ -13,7 +13,7 @@ from cyberdrop_dl.crawlers.crawler import Crawler, SupportedDomains, SupportedPa
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import DDOSGuardError, ScrapeError
 from cyberdrop_dl.utils import aio, css, open_graph
-from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_text_between, parse_url, xor_decrypt
+from cyberdrop_dl.utils.utilities import error_handling_wrapper, parse_url, xor_decrypt
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -31,14 +31,13 @@ _REINFORCED_URL_BASE = AbsoluteHttpURL("https://get.bunkrr.su")
 
 
 class Selector:
-    ALBUM_ITEM = "div[class*='relative group/item theItem']"
-    ITEM_NAME = "p[class*='theName']"
-    ITEM_DATE = 'span[class*="theDate"]'
+    ALBUM_ITEM = "div.theItem"
+    FILE_NAME = "p.theName"
+    FILE_DATE = "span.theDate"
     DOWNLOAD_BUTTON = "a.btn.ic-download-01"
-    THUMBNAIL = 'img[alt="image"]'
+    FILE_THUMBNAIL = 'img[alt="image"]'
     IMAGE_PREVIEW = "img.max-h-full.w-auto.object-cover.relative"
     VIDEO = "video > source"
-    JS_SLUG = "script:-soup-contains('jsSlug')"
     NEXT_PAGE = "nav.pagination a[href]:-soup-contains('»')"
 
 
@@ -47,7 +46,8 @@ HOST_OPTIONS: set[str] = {"bunkr.site", "bunkr.cr", "bunkr.ph"}
 known_bad_hosts: set[str] = set()
 
 
-class ApiResponse(NamedTuple):
+@dataclasses.dataclass(slots=True, frozen=True)
+class ApiResponse:
     encrypted: bool
     timestamp: int
     url: str
@@ -62,7 +62,7 @@ class ApiResponse(NamedTuple):
         return xor_decrypt(encrypted_url, secret_key.encode())
 
 
-@dataclass(frozen=True)
+@dataclasses.dataclass(slots=True, frozen=True)
 class File:
     name: str
     thumbnail: str
@@ -70,17 +70,18 @@ class File:
     path_qs: str
 
     @staticmethod
-    def from_tag(tag: Tag) -> File:
-        name = css.select_text(tag, Selector.ITEM_NAME)
-        thumbnail: str = css.select(tag, Selector.THUMBNAIL, "src")
-        date_str = css.select_text(tag, Selector.ITEM_DATE)
-        path_qs: str = css.select(tag, "a", "href")
-        return File(name, thumbnail, date_str, path_qs)
+    def parse(tag: Tag) -> File:
+        return File(
+            name=css.select_text(tag, Selector.FILE_NAME),
+            thumbnail=css.select(tag, Selector.FILE_THUMBNAIL, "src"),
+            date=css.select_text(tag, Selector.FILE_DATE),
+            path_qs=css.select(tag, "a", "href"),
+        )
 
     @property
     def src(self) -> AbsoluteHttpURL:
         src_str = self.thumbnail.replace("/thumbs/", "/")
-        src = parse_url(src_str, relative_to=_PRIMARY_URL).with_suffix(self.suffix).with_query(None)
+        src = parse_url(src_str).with_suffix(self.suffix).with_query(None)
         if src.suffix.lower() not in FILE_FORMATS["Images"]:
             return src.with_host(src.host.replace("i-", ""))
         return src
@@ -139,6 +140,7 @@ class BunkrrCrawler(Crawler):
         results = await self.get_album_results(album_id)
         seen: set[str] = set()
         stuck_in_a_loop_msg = f"Found duplicate URLs processing {scrape_item.url}. Aborting to prevent infinite loop"
+
         async for soup in self.web_pager(scrape_item.url):
             if not title:
                 name = css.page_title(soup, "bunkr")
@@ -146,7 +148,7 @@ class BunkrrCrawler(Crawler):
                 scrape_item.setup_as_album(title, album_id=album_id)
 
             for tag in soup.select(Selector.ALBUM_ITEM):
-                file = File.from_tag(tag)
+                file = File.parse(tag)
                 if file.path_qs in seen:
                     self.log(stuck_in_a_loop_msg, 40, bug=True)
                     return
@@ -207,10 +209,9 @@ class BunkrrCrawler(Crawler):
             except Exception:
                 pass
 
-        # Fallback for everything else, try to get the download URL.
-        # `handle_direct_link` will make the final request to the API
         if not link and (dl_button := soup.select_one(Selector.DOWNLOAD_BUTTON)):
-            link = self.parse_url(css.get_attr(dl_button, "href"))
+            id_ = self.parse_url(css.get_attr(dl_button, "href")).name
+            link = await self._request_download(id_=id_)
 
         # Everything failed, abort
         if not link:
@@ -313,8 +314,3 @@ def _is_stream_redirect(url: AbsoluteHttpURL) -> bool:
     if not prefix and number.isdigit():
         return True
     return any(part in url.host for part in ("cdn12", "cdn-")) or url.host == "cdn.bunkr.ru"
-
-
-def _get_js_slug(soup: BeautifulSoup) -> str | None:
-    if info_js := soup.select_one(Selector.JS_SLUG):
-        return get_text_between(info_js.get_text(), "jsSlug = '", "';")

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import asyncio
 import base64
 import itertools
-import re
-from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
@@ -15,7 +12,7 @@ from cyberdrop_dl.constants import FILE_FORMATS
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedDomains, SupportedPaths, auto_task_id
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import DDOSGuardError, ScrapeError
-from cyberdrop_dl.utils import css, open_graph
+from cyberdrop_dl.utils import aio, css, open_graph
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, get_text_between, parse_url, xor_decrypt
 
 if TYPE_CHECKING:
@@ -24,47 +21,16 @@ if TYPE_CHECKING:
     from bs4 import BeautifulSoup, Tag
 
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
+    from cyberdrop_dl.utils.aio import WeakAsyncLocks
 
 
-# CDNs
-BASE_CDNS = [
-    "bacon",
-    "beer",
-    "big-taco",
-    "burger",
-    "c",
-    "cdn",
-    "cheese",
-    "fries",
-    "kebab",
-    "meatballs",
-    "milkshake",
-    "nachos",
-    "nugget",
-    "pizza",
-    "ramen",
-    "rice",
-    "soup",
-    "sushi",
-    "taquito",
-    "wiener",
-    "wings",
-    "maple",
-    r"mlk-bk\.cdn\.gigachad-cdn",
-]
-EXTENDED_CDNS = [f"cdn-{cdn}" for cdn in BASE_CDNS]
-IMAGE_CDNS = [f"i-{cdn}" for cdn in BASE_CDNS]
-CDNS = BASE_CDNS + EXTENDED_CDNS + IMAGE_CDNS
-CDN_POSSIBILITIES = re.compile(r"^(?:(?:(" + "|".join(CDNS) + r")[0-9]{0,2}(?:redir)?))\.bunkr?\.[a-z]{2,3}$")
-
-# URLs
-DOWNLOAD_API_ENTRYPOINT = AbsoluteHttpURL("https://apidl.bunkr.ru/api/_001_v2")
-STREAMING_API_ENTRYPOINT = AbsoluteHttpURL("https://bunkr.site/api/vs")
-PRIMARY_URL = AbsoluteHttpURL("https://bunkr.site")
-REINFORCED_URL_BASE = AbsoluteHttpURL("https://get.bunkr.su")
+_DOWNLOAD_API_ENTRYPOINT = AbsoluteHttpURL("https://apidl.bunkr.ru/api/_001_v2")
+_STREAMING_API_ENTRYPOINT = AbsoluteHttpURL("https://bunkr.site/api/vs")
+_PRIMARY_URL = AbsoluteHttpURL("https://bunkr.site")
+_REINFORCED_URL_BASE = AbsoluteHttpURL("https://get.bunkr.su")
 
 
-class Selectors:
+class Selector:
     ALBUM_ITEM = "div[class*='relative group/item theItem']"
     ITEM_NAME = "p[class*='theName']"
     ITEM_DATE = 'span[class*="theDate"]'
@@ -76,7 +42,6 @@ class Selectors:
     NEXT_PAGE = "nav.pagination a[href]:-soup-contains('»')"
 
 
-_SELECTORS = Selectors()
 VIDEO_AND_IMAGE_EXTS: set[str] = FILE_FORMATS["Images"] | FILE_FORMATS["Videos"]
 HOST_OPTIONS: set[str] = {"bunkr.site", "bunkr.cr", "bunkr.ph"}
 known_bad_hosts: set[str] = set()
@@ -87,29 +52,38 @@ class ApiResponse(NamedTuple):
     timestamp: int
     url: str
 
+    def decrypt(self: ApiResponse) -> str:
+        if not self.encrypted:
+            return self.url
+
+        time_key = int(self.timestamp / 3600)
+        secret_key = f"SECRET_KEY_{time_key}"
+        encrypted_url = base64.b64decode(self.url)
+        return xor_decrypt(encrypted_url, secret_key.encode())
+
 
 @dataclass(frozen=True)
-class AlbumItem:
+class File:
     name: str
     thumbnail: str
     date: str
     path_qs: str
 
     @staticmethod
-    def from_tag(tag: Tag) -> AlbumItem:
-        name = css.select_text(tag, _SELECTORS.ITEM_NAME)
-        thumbnail: str = css.select(tag, _SELECTORS.THUMBNAIL, "src")
-        date_str = css.select_text(tag, _SELECTORS.ITEM_DATE)
+    def from_tag(tag: Tag) -> File:
+        name = css.select_text(tag, Selector.ITEM_NAME)
+        thumbnail: str = css.select(tag, Selector.THUMBNAIL, "src")
+        date_str = css.select_text(tag, Selector.ITEM_DATE)
         path_qs: str = css.select(tag, "a", "href")
-        return AlbumItem(name, thumbnail, date_str, path_qs)
+        return File(name, thumbnail, date_str, path_qs)
 
     @property
     def src(self) -> AbsoluteHttpURL:
         src_str = self.thumbnail.replace("/thumbs/", "/")
-        src = parse_url(src_str, relative_to=PRIMARY_URL).with_suffix(self.suffix).with_query(None)
+        src = parse_url(src_str, relative_to=_PRIMARY_URL).with_suffix(self.suffix).with_query(None)
         if src.suffix.lower() not in FILE_FORMATS["Images"]:
-            src = src.with_host(src.host.replace("i-", ""))
-        return override_cdn(src)
+            return src.with_host(src.host.replace("i-", ""))
+        return src
 
     @property
     def suffix(self) -> str:
@@ -119,54 +93,69 @@ class AlbumItem:
 class BunkrrCrawler(Crawler):
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = "bunkr", "bunkrr"
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
-        "Album": "/a/...",
-        "Video": "/v/...",
-        "File": "/f/...",
+        "Album": "/a/<album_id>",
+        "Video": "/v/<slug>",
+        "File": (
+            "/f/<slug>",
+            "/<slug>",
+        ),
         "Direct links": "",
     }
-    DATABASE_PRIMARY_HOST: ClassVar[str] = "bunkr.site"
-    PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL(f"https://{DATABASE_PRIMARY_HOST}")
+
+    PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://bunkr.site")
+    DATABASE_PRIMARY_HOST: ClassVar[str] = PRIMARY_URL.host
     DOMAIN: ClassVar[str] = "bunkrr"
     _RATE_LIMIT: ClassVar[tuple[float, float]] = 5, 1
     _USE_DOWNLOAD_SERVERS_LOCKS: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
-        self.switch_host_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self.switch_host_locks: WeakAsyncLocks[str] = aio.WeakAsyncLocks[str]()
         self.known_good_url: AbsoluteHttpURL | None = None
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
-        if is_reinforced_link(scrape_item.url):  #  get.bunkr.su/file/<file_id>
-            return await self.reinforced_file(scrape_item)
-        if "a" in scrape_item.url.parts:  #  bunkr.site/a/<album_id>
-            return await self.album(scrape_item)
-        if is_cdn(scrape_item.url) and not is_stream_redirect(scrape_item.url):  # kebab.bunkr.su/<uuid>
-            return await self.handle_direct_link(scrape_item, scrape_item.url, fallback_filename=scrape_item.url.name)
-        # bunkr.su/f/<filename>, bunkr.su/f/<file_slug>, bunkr.su/<short_file_id> or cdn.bunkr.su/<file_id> (stream redirect)
-        await self.file(scrape_item)
+        match scrape_item.url.parts[1:]:
+            case ["file", id_] if scrape_item.url.host == _REINFORCED_URL_BASE.host:
+                return await self.reinforced_file(scrape_item, id_)
+            case ["a", album_id]:
+                return await self.album(scrape_item, album_id)
+            case ["v", _]:
+                return await self.follow_redirect(scrape_item)
+            case ["f", slug]:
+                return await self.file(scrape_item, slug)
+            case [slug]:
+                if _is_stream_redirect(scrape_item.url):
+                    return await self.follow_redirect(scrape_item)
+
+                if self.is_subdomain(scrape_item.url):
+                    return await self.handle_direct_link(scrape_item, scrape_item.url)
+
+                await self.file(scrape_item, slug)
+            case _:
+                raise ValueError
 
     @error_handling_wrapper
-    async def album(self, scrape_item: ScrapeItem) -> None:
-        album_id = scrape_item.url.parts[2]
+    async def album(self, scrape_item: ScrapeItem, album_id: str) -> None:
         title: str = ""
         results = await self.get_album_results(album_id)
         seen: set[str] = set()
         stuck_in_a_loop_msg = f"Found duplicate URLs processing {scrape_item.url}. Aborting to prevent infinite loop"
         async for soup in self.web_pager(scrape_item.url):
             if not title:
-                title = css.page_title(soup, "bunkr")
-                title = self.create_title(title, album_id)
+                name = css.page_title(soup, "bunkr")
+                title = self.create_title(name, album_id)
                 scrape_item.setup_as_album(title, album_id=album_id)
 
-            for tag in soup.select(_SELECTORS.ALBUM_ITEM):
-                item = AlbumItem.from_tag(tag)
-                if item.path_qs in seen:
+            for tag in soup.select(Selector.ALBUM_ITEM):
+                file = File.from_tag(tag)
+                if file.path_qs in seen:
                     self.log(stuck_in_a_loop_msg, 40, bug=True)
                     return
-                seen.add(item.path_qs)
-                link = self.parse_url(item.path_qs, relative_to=scrape_item.url.origin())
+
+                seen.add(file.path_qs)
+                link = self.parse_url(file.path_qs, relative_to=scrape_item.url.origin())
                 new_scrape_item = scrape_item.create_child(link)
-                new_scrape_item.possible_datetime = self.parse_date(item.date, "%H:%M:%S %d/%m/%Y")
-                self.create_task(self._process_album_item_task(new_scrape_item, item, results))
+                new_scrape_item.possible_datetime = self.parse_date(file.date, "%H:%M:%S %d/%m/%Y")
+                self.create_task(self._album_file(new_scrape_item, file, results))
                 scrape_item.add_children()
 
     async def web_pager(
@@ -181,13 +170,14 @@ class BunkrrCrawler(Crawler):
         for page in itertools.count(init_page):
             soup = await self.request_soup_lenient(url.with_query(page=page))
             yield soup
-            has_next_page = soup.select_one(_SELECTORS.NEXT_PAGE)
+            has_next_page = soup.select_one(Selector.NEXT_PAGE)
             if not has_next_page:
                 break
 
+    @auto_task_id
     @error_handling_wrapper
-    async def _process_album_item(self, scrape_item: ScrapeItem, item: AlbumItem, results: dict) -> None:
-        link = item.src
+    async def _album_file(self, scrape_item: ScrapeItem, file: File, results: dict[str, int]) -> None:
+        link = file.src
         if link.suffix.lower() not in VIDEO_AND_IMAGE_EXTS or "no-image" in link.name or self.deep_scrape:
             self.create_task(self.run(scrape_item))
             return
@@ -196,47 +186,35 @@ class BunkrrCrawler(Crawler):
             return
 
         if not link.query.get("n"):
-            link = link.update_query(n=item.name)
+            link = link.update_query(n=file.name)
 
         filename, ext = self.get_filename_and_ext(link.query["n"], assume_ext=".mp4")
         await self.handle_file(link, scrape_item, link.name, ext, custom_filename=filename)
 
-    _process_album_item_task = auto_task_id(_process_album_item)
-
     @error_handling_wrapper
-    async def file(self, scrape_item: ScrapeItem) -> None:
+    async def file(self, scrape_item: ScrapeItem, slug: str) -> None:
         link: AbsoluteHttpURL | None = None
-        soup: BeautifulSoup | None = None
-        if is_stream_redirect(scrape_item.url):
-            async with self.request(scrape_item.url) as resp:
-                soup = await resp.soup()
-                scrape_item.url = resp.url
-
         database_url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
         if await self.check_complete_from_referer(database_url):
             return
 
-        if not soup:
-            soup = await self.request_soup_lenient(scrape_item.url)
-
-        image_container = soup.select_one(_SELECTORS.IMAGE_PREVIEW)
-        download_link_container = soup.select_one(_SELECTORS.DOWNLOAD_BUTTON)
+        soup = await self.request_soup_lenient(scrape_item.url)
 
         # Try image first to not make any additional request
-        if image_container:
-            link = self.parse_url(css.get_attr(image_container, "src"))
+        if image := soup.select_one(Selector.IMAGE_PREVIEW):
+            link = self.parse_url(css.get_attr(image, "src"))
 
         # Try to get downloadd URL from streaming API. Should work for most files, even none video files
-        if not link and "f" in scrape_item.url.parts:
-            slug = get_slug_from_soup(soup) or scrape_item.url.name or scrape_item.url.parent.name
+        if not link:
+            slug = (_get_js_slug(soup) or scrape_item.url.name).encode().decode("unicode-escape")
             base = self.known_good_url or scrape_item.url.origin()
-            slug_url = base / "f" / slug.encode().decode("unicode-escape")
-            link = await self.get_download_url_from_api(slug_url)
+            slug_url = base / "f" / slug
+            link = await self._request_download(slug_url, slug=slug)
 
         # Fallback for everything else, try to get the download URL.
         # `handle_direct_link` will make the final request to the API
-        if not link and download_link_container:
-            link = self.parse_url(css.get_attr(download_link_container, "href"))
+        if not link and (dl_button := soup.select_one(Selector.DOWNLOAD_BUTTON)):
+            link = self.parse_url(css.get_attr(dl_button, "href"))
 
         # Everything failed, abort
         if not link:
@@ -246,12 +224,10 @@ class BunkrrCrawler(Crawler):
         await self.handle_direct_link(scrape_item, link, fallback_filename=title)
 
     @error_handling_wrapper
-    async def reinforced_file(self, scrape_item: ScrapeItem) -> None:
+    async def reinforced_file(self, scrape_item: ScrapeItem, id_: str) -> None:
         soup = await self.request_soup(scrape_item.url)
         title = css.select_text(soup, "h1")
-        link = await self.get_download_url_from_api(scrape_item.url)
-        if not link:
-            raise ScrapeError(422)
+        link = await self._request_download(scrape_item.url, id_=id_)
         await self.handle_direct_link(scrape_item, link, fallback_filename=title)
 
     @error_handling_wrapper
@@ -263,39 +239,28 @@ class BunkrrCrawler(Crawler):
         `fallback_filename` will only be used if the link has no `n` query parameter"""
 
         link = url
-        if is_reinforced_link(link):
-            scrape_item.url = link
-            link = await self.get_download_url_from_api(link)
+        name = link.query.get("n") or fallback_filename or link.name
+        link = link.update_query(n=name)
+        filename, ext = self.get_filename_and_ext(name, assume_ext=".mp4")
+        if not self.is_subdomain(scrape_item.url):
+            scrape_item.url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
+        await self.handle_file(link, scrape_item, name, ext, custom_filename=filename)
 
-        if not link:
-            raise ScrapeError(422)
-
-        link = override_cdn(link)
-
-        if not link.query.get("n"):
-            link = link.update_query(n=fallback_filename)
-
-        custom_filename, ext = self.get_filename_and_ext(link.query["n"], assume_ext=".mp4")
-        if is_cdn(scrape_item.url) and not is_reinforced_link(scrape_item.url):
-            # Using a CDN as referer gets a 403 response
-            scrape_item.url = REINFORCED_URL_BASE
-
-        await self.handle_file(link, scrape_item, link.name, ext, custom_filename=custom_filename)
-
-    async def get_download_url_from_api(self, url: AbsoluteHttpURL) -> AbsoluteHttpURL | None:
+    async def _request_download(self, url: AbsoluteHttpURL, *, id_: str = "", slug: str = "") -> AbsoluteHttpURL:
         """Gets the download link for a given URL
 
         1. Reinforced URL (get.bunkr.su/file/<file_id>). or
         2. Streaming URL (bunkr.site/f/<file_slug>)"""
 
-        api_url = DOWNLOAD_API_ENTRYPOINT
-        if is_reinforced_link(url):
-            payload = {"id": get_part_next_to(url, "file")}
+        if id_:
+            payload = {"id": id_}
+            api_url = _DOWNLOAD_API_ENTRYPOINT
+
         else:
-            payload = {"slug": get_part_next_to(url, "f")}
-            api_url = STREAMING_API_ENTRYPOINT
+            payload = {"slug": slug}
+            api_url = _STREAMING_API_ENTRYPOINT
             if self.known_good_url:
-                api_url = STREAMING_API_ENTRYPOINT.with_host(self.known_good_url.host)
+                api_url = _STREAMING_API_ENTRYPOINT.with_host(self.known_good_url.host)
 
         json_resp: dict[str, Any] = await self.request_json(
             api_url,
@@ -303,33 +268,13 @@ class BunkrrCrawler(Crawler):
             json=payload,
             headers={"Referer": str(url)},
         )
-        api_response = ApiResponse(**json_resp)
-        link_str = decrypt_api_response(api_response)
-        link = self.parse_url(link_str)
-        if link != PRIMARY_URL:  # We got an empty response
-            return link
-
-    async def handle_file(
-        self,
-        url: AbsoluteHttpURL,
-        scrape_item: ScrapeItem,
-        filename: str,
-        ext: str,
-        *,
-        custom_filename: str | None = None,
-        debrid_link: AbsoluteHttpURL | None = None,
-    ) -> None:
-        """Overrides primary host before before calling base crawler's `handle_file`"""
-        if is_root_domain(scrape_item.url):
-            scrape_item.url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
-        await super().handle_file(
-            url, scrape_item, filename, ext, custom_filename=custom_filename, debrid_link=debrid_link
-        )
+        return self.parse_url(ApiResponse(**json_resp).decrypt())
 
     async def _try_request_soup(self, url: AbsoluteHttpURL) -> BeautifulSoup | None:
         try:
             async with self.request(url) as resp:
                 soup = await resp.soup()
+
         except (ClientConnectorError, DDOSGuardError):
             known_bad_hosts.add(url.host)
             if not HOST_OPTIONS - known_bad_hosts:
@@ -346,9 +291,6 @@ class BunkrrCrawler(Crawler):
 
         If we find one, keep a reference to it and use it for all future requests"""
 
-        if not is_root_domain(url):
-            return await self.request_soup(url)
-
         if self.known_good_url:
             return await self.request_soup(url.with_host(self.known_good_url.host))
 
@@ -361,6 +303,7 @@ class BunkrrCrawler(Crawler):
             async with self.switch_host_locks[host]:
                 if host in known_bad_hosts:
                     continue
+
                 if soup := await self._try_request_soup(url.with_host(host)):
                     return soup
 
@@ -368,12 +311,7 @@ class BunkrrCrawler(Crawler):
         return await self.request_soup(url)
 
 
-def get_part_next_to(url: AbsoluteHttpURL, part: str) -> str:
-    part_index = url.parts.index(part) + 1
-    return url.parts[part_index]
-
-
-def is_stream_redirect(url: AbsoluteHttpURL) -> bool:
+def _is_stream_redirect(url: AbsoluteHttpURL) -> bool:
     first_subdomain = url.host.split(".")[0]
     prefix, _, number = first_subdomain.partition("cdn")
     if not prefix and number.isdigit():
@@ -381,36 +319,6 @@ def is_stream_redirect(url: AbsoluteHttpURL) -> bool:
     return any(part in url.host for part in ("cdn12", "cdn-")) or url.host == "cdn.bunkr.ru"
 
 
-def is_cdn(url: AbsoluteHttpURL) -> bool:
-    return bool(CDN_POSSIBILITIES.match(url.host))
-
-
-def override_cdn(url: AbsoluteHttpURL) -> AbsoluteHttpURL:
-    if "milkshake" in url.host:
-        return url.with_host("mlk-bk.cdn.gigachad-cdn.ru")
-    return url
-
-
-def is_reinforced_link(url: AbsoluteHttpURL) -> bool:
-    return url.host.startswith("get.") and "file" in url.parts
-
-
-def decrypt_api_response(api_response: ApiResponse) -> str:
-    if not api_response.encrypted:
-        return api_response.url
-
-    time_key = int(api_response.timestamp / 3600)
-    secret_key = f"SECRET_KEY_{time_key}"
-    encrypted_url = base64.b64decode(api_response.url)
-    return xor_decrypt(encrypted_url, secret_key.encode())
-
-
-def get_slug_from_soup(soup: BeautifulSoup) -> str | None:
-    info_js = soup.select_one(_SELECTORS.JS_SLUG)
-    if not info_js:
-        return
-    return get_text_between(info_js.get_text(), "jsSlug = '", "';")
-
-
-def is_root_domain(url: AbsoluteHttpURL) -> bool:
-    return "bunkr" in url.host and url.host.removeprefix("www.").count(".") == 1
+def _get_js_slug(soup: BeautifulSoup) -> str | None:
+    if info_js := soup.select_one(Selector.JS_SLUG):
+        return get_text_between(info_js.get_text(), "jsSlug = '", "';")

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from aiohttp import ClientConnectorError
 
 from cyberdrop_dl.constants import FILE_FORMATS
-from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths, auto_task_id
+from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths, auto_task_id
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import DDOSGuardError
 from cyberdrop_dl.utils import aio, css, open_graph
@@ -23,32 +23,22 @@ if TYPE_CHECKING:
     from bs4 import BeautifulSoup
 
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
-    from cyberdrop_dl.utils.aio import WeakAsyncLocks
 
 
 _DOWNLOAD_API_ENTRYPOINT = AbsoluteHttpURL("https://apidl.bunkr.ru/api/_001_v2")
-_PRIMARY_URL = AbsoluteHttpURL("https://bunkr.site")
-_REINFORCED_URL_BASE = AbsoluteHttpURL("https://get.bunkrr.su")
+_REINFORCED_URL = AbsoluteHttpURL("https://get.bunkrr.su")
 
 
 class Selector:
-    FILE_NAME = "p.theName"
-    FILE_DATE = "span.theDate"
-    FILE_THUMBNAIL = 'img[alt="image"]'
-
-    ALBUM_ITEM = "div.theItem"
     ALBUM_FILES = "script:-soup-contains('window.albumFiles = ')"
-
     DOWNLOAD_BUTTON = "a.btn.ic-download-01"
     IMAGE_PREVIEW = "img.max-h-full.w-auto.object-cover.relative"
-    VIDEO = "video > source"
-    NEXT_PAGE = "nav.pagination a[href]:-soup-contains('»')"
 
 
 VIDEO_AND_IMAGE_EXTS: set[str] = FILE_FORMATS["Images"] | FILE_FORMATS["Videos"]
 HOST_OPTIONS: set[str] = {"bunkr.site", "bunkr.cr", "bunkr.ph"}
-known_bad_hosts: set[str] = set()
 FILE_KEYS = "id", "name", "original", "slug", "type", "extension", "size", "timestamp", "thumbnail", "cdnEndpoint"
+known_bad_hosts: set[str] = set()
 
 
 def _make_album_parser(keys: tuple[str, ...]) -> Callable[[BeautifulSoup], Generator[File]]:
@@ -72,8 +62,8 @@ def _make_album_parser(keys: tuple[str, ...]) -> Callable[[BeautifulSoup], Gener
 
     def parse(soup: BeautifulSoup) -> Generator[File]:
         album_js = css.select_text(soup, Selector.ALBUM_FILES)
-        items = album_js[album_js.find("=") + 1 : album_js.rfind("];") + 1]
-        return decode(items)
+        files = album_js[album_js.find("=") + 1 : album_js.rfind("];") + 1]
+        return decode(files)
 
     return parse
 
@@ -88,7 +78,7 @@ class ApiResponse:
         if not self.encrypted:
             return self.url
 
-        time_key = int(self.timestamp / 3600)
+        time_key = self.timestamp // 3600
         secret_key = f"SECRET_KEY_{time_key}"
         encrypted_url = base64.b64decode(self.url)
         return xor_decrypt(encrypted_url, secret_key.encode())
@@ -124,17 +114,17 @@ class BunkrrCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://bunkr.site")
     DATABASE_PRIMARY_HOST: ClassVar[str] = PRIMARY_URL.host
     DOMAIN: ClassVar[str] = "bunkr"
-    _RATE_LIMIT: ClassVar[tuple[float, float]] = 5, 1
+    _RATE_LIMIT: ClassVar[RateLimit] = 5, 1
     _USE_DOWNLOAD_SERVERS_LOCKS: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
-        self.switch_host_locks: WeakAsyncLocks[str] = aio.WeakAsyncLocks[str]()
+        self.switch_host_locks: aio.WeakAsyncLocks[str] = aio.WeakAsyncLocks()
         self.known_good_url: AbsoluteHttpURL | None = None
         self._parse_album_files = _make_album_parser(FILE_KEYS)
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:
-            case ["file", file_id] if scrape_item.url.host == _REINFORCED_URL_BASE.host:
+            case ["file", file_id] if scrape_item.url.host == _REINFORCED_URL.host:
                 return await self.reinforced_file(scrape_item, file_id)
             case ["a", album_id]:
                 return await self.album(scrape_item, album_id)
@@ -147,14 +137,14 @@ class BunkrrCrawler(Crawler):
                     return await self.follow_redirect(scrape_item)
 
                 if self.is_subdomain(scrape_item.url):
-                    return await self.handle_direct_link(scrape_item, scrape_item.url)
+                    return await self._direct_file(scrape_item, scrape_item.url)
 
         raise ValueError
 
     @error_handling_wrapper
     async def album(self, scrape_item: ScrapeItem, album_id: str) -> None:
         soup = await self._request_soup_lenient(scrape_item.url.with_query(advanced=1))
-        name = css.page_title(soup, "bunkr")
+        name = open_graph.title(soup)
         title = self.create_title(name, album_id)
         scrape_item.setup_as_album(title, album_id=album_id)
 
@@ -178,7 +168,7 @@ class BunkrrCrawler(Crawler):
         if self.check_album_results(src, results):
             return
 
-        await self.handle_direct_link(scrape_item, src, file.name)
+        await self._direct_file(scrape_item, src, file.name)
 
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem) -> None:
@@ -188,25 +178,25 @@ class BunkrrCrawler(Crawler):
 
         soup = await self._request_soup_lenient(scrape_item.url)
         if image := soup.select_one(Selector.IMAGE_PREVIEW):
-            link = self.parse_url(css.get_attr(image, "src"))
+            src = self.parse_url(css.get_attr(image, "src"))
 
         else:
             dl_link = css.select(soup, Selector.DOWNLOAD_BUTTON, "href")
             file_id = self.parse_url(dl_link).name
-            link = await self._request_download(file_id)
+            src = await self._request_download(file_id)
 
         name = open_graph.title(soup)  # See: https://github.com/jbsparrow/CyberDropDownloader/issues/929
-        await self.handle_direct_link(scrape_item, link, name)
+        await self._direct_file(scrape_item, src, name)
 
     @error_handling_wrapper
     async def reinforced_file(self, scrape_item: ScrapeItem, file_id: str) -> None:
         soup = await self.request_soup(scrape_item.url)
         name = css.select_text(soup, "h1")
-        link = await self._request_download(file_id)
-        await self.handle_direct_link(scrape_item, link, name)
+        src = await self._request_download(file_id)
+        await self._direct_file(scrape_item, src, name)
 
     @error_handling_wrapper
-    async def handle_direct_link(
+    async def _direct_file(
         self, scrape_item: ScrapeItem, link: AbsoluteHttpURL, fallback_filename: str | None = None
     ) -> None:
         name = link.query.get("n") or fallback_filename or link.name
@@ -215,7 +205,7 @@ class BunkrrCrawler(Crawler):
         if not self.is_subdomain(scrape_item.url):
             scrape_item.url = scrape_item.url.with_host(self.DATABASE_PRIMARY_HOST)
         elif link.host == scrape_item.url.host:
-            scrape_item.url = _REINFORCED_URL_BASE
+            scrape_item.url = _REINFORCED_URL
         await self.handle_file(link, scrape_item, name, ext, custom_filename=filename)
 
     async def _request_download(self, file_id: str) -> AbsoluteHttpURL:
@@ -223,7 +213,7 @@ class BunkrrCrawler(Crawler):
             _DOWNLOAD_API_ENTRYPOINT,
             "POST",
             json={"id": file_id},
-            headers={"Referer": str(_REINFORCED_URL_BASE)},
+            headers={"Referer": str(_REINFORCED_URL)},
         )
         return self.parse_url(ApiResponse(**resp).decrypt())
 

--- a/cyberdrop_dl/database/tables/history.py
+++ b/cyberdrop_dl/database/tables/history.py
@@ -61,6 +61,7 @@ class HistoryTable:
 
     async def run_updates(self) -> None:
         updates = (
+            "UPDATE OR REPLACE media SET domain = 'bunkr' WHERE domain = 'bunkrr';"
             "UPDATE OR REPLACE media SET domain = 'jpg5.su' WHERE domain = 'sharex';"
             "UPDATE OR REPLACE media SET domain = 'nudostar.tv' WHERE domain = 'nudostartv';"
             "UPDATE OR REPLACE media SET referer = FIX_REDGIFS_REFERER(referer) WHERE domain = 'redgifs';"

--- a/tests/crawlers/test_cases/bunkr.py
+++ b/tests/crawlers/test_cases/bunkr.py
@@ -1,4 +1,4 @@
-DOMAIN = "bunkrr"
+DOMAIN = "bunkr"
 TEST_CASES = [
     (
         "https://bunkr.pk/f/k3B4hDIRexYfV",

--- a/tests/crawlers/test_cases/bunkr.py
+++ b/tests/crawlers/test_cases/bunkr.py
@@ -1,13 +1,12 @@
 DOMAIN = "bunkrr"
 TEST_CASES = [
     (
-        # No datetime info
         "https://bunkr.pk/f/k3B4hDIRexYfV",
         [
             {
                 "url": "re:Stepmom.+Best.Friend.mp4",
-                "filename": "Katalina Kyle, Savanah Storm - What If She Hears Us! Caught Fucking My Stepmoms Best Friend.mp4",
-                "original_filename": "4260d330-9881-4324-8bf4-87657e5c11c5.mp4",
+                "filename": "Katalina Kyle, Savanah Storm - “What If She Hears Us!” Caught Fucking My Stepmom’s Best Friend.mp4",  # noqa: RUF001
+                "original_filename": "Katalina Kyle, Savanah Storm - “What If She Hears Us!?” Caught Fucking My Stepmom’s Best Friend.mp4",  # noqa: RUF001
                 "referer": "https://bunkr.site/f/k3B4hDIRexYfV",
                 "datetime": None,
             }
@@ -18,24 +17,25 @@ TEST_CASES = [
         "https://bunkr.cr/a/5aZU25Cb",
         [
             {
-                "url": "https://mlk-bk.cdn.gigachad-cdn.ru/01101506-9a96-4379-a226-c27f128923f6.jpg?n=xl_g_elin_maddie150.jpg",
+                # "url": "https://mlk-bk.cdn.gigachad-cdn.ru/01101506-9a96-4379-a226-c27f128923f6.jpg?n=xl_g_elin_maddie150.jpg",
+                "url": "https://i-milkshake.bunkr.ru/01101506-9a96-4379-a226-c27f128923f6.jpg?n=xl_g_elin_maddie150.jpg",
                 "filename": "xl_g_elin_maddie150.jpg",
-                "original_filename": "01101506-9a96-4379-a226-c27f128923f6.jpg",
+                "original_filename": "xl_g_elin_maddie150.jpg",
                 "referer": "https://bunkr.site/f/1EhT44cSv6Dlq",
                 "download_folder": r"re:abbywinters - Elin & Maddie \(Girl - Girl Extra Large\)",
                 "album_id": "5aZU25Cb",
                 "datetime": 1755391253,
             }
         ],
-        258,
+        257,
     ),
     (
         "https://bunkr.cr/a/TQAgjP8m",
         [
             {
                 "url": "re:2020-01-09---Fake-Porn-Star-Orders-Pizza-NAKED-Prank----6dh068JH.mp4",
+                "original_filename": "2020-01-09 - Fake Porn Star Orders Pizza NAKED Prank 🍕.mp4",
                 "filename": "2020-01-09 - Fake Porn Star Orders Pizza NAKED Prank 🍕.mp4",
-                "original_filename": "2020-01-09---Fake-Porn-Star-Orders-Pizza-NAKED-Prank----6dh068JH.mp4",
                 "referer": "https://bunkr.site/f/UAvbs2GPhWOGc",
                 "download_folder": r"re:NerdballerTV - Videos \(2018-2023\) \[Complete\]",
                 "album_id": "TQAgjP8m",
@@ -49,7 +49,7 @@ TEST_CASES = [
         # This test is to make sure CDL does not get stuck in an infinite loop while doing album pagination
         "https://bunkrrr.org/a/n12rHpzB",
         [],
-        142,
+        141,
     ),
     (
         "https://bunkr.ax/v/rFicV4QnhSHBE",
@@ -57,7 +57,18 @@ TEST_CASES = [
             {
                 "url": r"re:1df93418-5063-4e1b-851e-9470cb8fc5c6\.mp4",
                 "filename": "MysteriousProd.24.09.06.April.Olsen.Rebel.Rhyder.All.About.Fucking.720p.mp4",
-                "original_filename": "1df93418-5063-4e1b-851e-9470cb8fc5c6.mp4",
+                "referer": "https://bunkr.site/f/rFicV4QnhSHBE",
+                "album_id": None,
+                "datetime": None,
+            }
+        ],
+    ),
+    (
+        "https://get.bunkrr.su/file/41348624",
+        [
+            {
+                "url": r"re:1df93418-5063-4e1b-851e-9470cb8fc5c6\.mp4",
+                "filename": "MysteriousProd.24.09.06.April.Olsen.Rebel.Rhyder.All.About.Fucking.720p.mp4",
                 "referer": "https://get.bunkrr.su/file/41348624",
                 "album_id": None,
                 "datetime": None,

--- a/tests/crawlers/test_cases/bunkr.py
+++ b/tests/crawlers/test_cases/bunkr.py
@@ -85,4 +85,34 @@ TEST_CASES = [
             }
         ],
     ),
+    (
+        "https://bunkr.sk/f/summertimejames-pics--VocHZQ0K.rar",
+        [
+            {
+                "url": "https://kebab.bunkr.ru/summertimejames-pics--VocHZQ0K.rar?n=summertimejames(pics).rar",
+                "filename": "summertimejames(pics).rar",
+                "referer": "https://bunkr.site/f/summertimejames-pics--VocHZQ0K.rar",
+            }
+        ],
+    ),
+    (
+        "https://kebab.bunkr.ru/summertimejames-pics--VocHZQ0K.rar",
+        [
+            {
+                "url": "https://kebab.bunkr.ru/summertimejames-pics--VocHZQ0K.rar?n=summertimejames-pics--VocHZQ0K.rar",
+                "filename": "summertimejames-pics--VocHZQ0K.rar",
+                "referer": "https://get.bunkrr.su",
+            }
+        ],
+    ),
+    (
+        "https://burger.bunkr.ru/9861917.mp4-PTaiPNai-CaBcktkP.mp4",
+        [
+            {
+                "url": "https://burger.bunkr.ru/9861917.mp4-PTaiPNai-CaBcktkP.mp4?n=9861917.mp4-PTaiPNai-CaBcktkP.mp4",
+                "filename": "9861917.mp4-PTaiPNai-CaBcktkP.mp4",
+                "referer": "https://get.bunkrr.su",
+            }
+        ],
+    ),
 ]

--- a/tests/crawlers/test_cases/bunkr.py
+++ b/tests/crawlers/test_cases/bunkr.py
@@ -17,8 +17,7 @@ TEST_CASES = [
         "https://bunkr.cr/a/5aZU25Cb",
         [
             {
-                # "url": "https://mlk-bk.cdn.gigachad-cdn.ru/01101506-9a96-4379-a226-c27f128923f6.jpg?n=xl_g_elin_maddie150.jpg",
-                "url": "https://i-milkshake.bunkr.ru/01101506-9a96-4379-a226-c27f128923f6.jpg?n=xl_g_elin_maddie150.jpg",
+                "url": "https://mlk-bk.cdn.gigachad-cdn.ru/01101506-9a96-4379-a226-c27f128923f6.jpg?n=xl_g_elin_maddie150.jpg",
                 "filename": "xl_g_elin_maddie150.jpg",
                 "original_filename": "xl_g_elin_maddie150.jpg",
                 "referer": "https://bunkr.site/f/1EhT44cSv6Dlq",

--- a/tests/crawlers/test_cases/bunkr.py
+++ b/tests/crawlers/test_cases/bunkr.py
@@ -75,4 +75,14 @@ TEST_CASES = [
             }
         ],
     ),
+    (
+        "https://cdn9.bunkr.ru/24578-hd-kEMMY0JH.mp4",
+        [
+            {
+                "url": r"re:24578-hd-kEMMY0JH.mp4",
+                "filename": "24578-hd.mp4",
+                "referer": "https://bunkr.site/f/24578-hd-kEMMY0JH.mp4",
+            }
+        ],
+    ),
 ]


### PR DESCRIPTION
- Remove duplicated/unused code
- Make a single request for albums with 100+ items

Also fixes some files always being re-downloaded. The URL path of a file may change if they changed cached CDN so we need to always check the referer first