### PR TITLE
Scrape high-quality image URLs from data-object in CheveretoCrawler

### DIFF
--- a/cyberdrop_dl/crawlers/_chevereto.py
+++ b/cyberdrop_dl/crawlers/_chevereto.py
@@ -93,12 +93,6 @@ class CheveretoCrawler(Crawler, is_generic=True):
         return url.with_name(new_name)
 
     @classmethod
-    def _match_img(cls, url: AbsoluteHttpURL) -> AbsoluteHttpURL | None:
-        match url.parts[1:]:
-            case ["img" | "image" as part, image_slug, *_]:
-                return url.origin() / part / _id(image_slug)
-
-    @classmethod
     def transform_url(cls, url: AbsoluteHttpURL) -> AbsoluteHttpURL:
         url = super().transform_url(url)
         match url.parts[1:]:
@@ -158,7 +152,7 @@ class CheveretoCrawler(Crawler, is_generic=True):
     def _process_page(
         self, scrape_item: ScrapeItem, soup: BeautifulSoup, results: dict[str, int] | None = None
     ) -> None:
-        for web_url, src_url in self._get_image_urls_from_data_object(soup):
+        for web_url, src_url in self._get_album_files(soup):
             if results and self.check_album_results(web_url, results):
                 continue
             new_scrape_item = scrape_item.create_child(web_url)
@@ -207,9 +201,7 @@ class CheveretoCrawler(Crawler, is_generic=True):
             link_str = xor_decrypt(encrypted_url, _DECRYPTION_KEY)
         return super().parse_url(link_str, relative_to, trim=trim)
 
-    def _get_image_urls_from_data_object(
-        self, soup: BeautifulSoup
-    ) -> Generator[tuple[AbsoluteHttpURL, AbsoluteHttpURL]]:
+    def _get_album_files(self, soup: BeautifulSoup) -> Generator[tuple[AbsoluteHttpURL, AbsoluteHttpURL]]:
         for item in soup.select(".list-item[data-object]"):
             web_url = self.parse_url(css.select(item, "a.image-container", "href"))
             encoded_data = css.get_attr(item, "data-object")

--- a/cyberdrop_dl/crawlers/_chevereto.py
+++ b/cyberdrop_dl/crawlers/_chevereto.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import base64
+import urllib.parse
 from typing import TYPE_CHECKING, ClassVar, final
 
 from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import PasswordProtectedError
-from cyberdrop_dl.utils import css, open_graph
+from cyberdrop_dl.utils import css, json, open_graph
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, xor_decrypt
 
 if TYPE_CHECKING:
@@ -155,6 +156,16 @@ class CheveretoCrawler(Crawler, is_generic=True):
     def _process_page(
         self, scrape_item: ScrapeItem, soup: BeautifulSoup, results: dict[str, int] | None = None
     ) -> None:
+        # Scrape high-quality image urls from data-object if available
+        image_urls = self._get_image_urls_from_data_config(soup)
+        if len(image_urls) > 0:
+            for image_url in image_urls:
+                if results and self.check_album_results(image_url, results):
+                    continue
+                new_scrape_item = scrape_item.create_child(image_url)
+                self.create_task(self.direct_file(new_scrape_item, image_url))
+            return
+
         for thumb, new_scrape_item in self.iter_children(scrape_item, soup, Selector.ITEM):
             if image_url := self._match_img(new_scrape_item.url):
                 new_scrape_item.url = image_url
@@ -212,6 +223,21 @@ class CheveretoCrawler(Crawler, is_generic=True):
             encrypted_url = bytes.fromhex(base64.b64decode(link_str).decode())
             link_str = xor_decrypt(encrypted_url, _DECRYPTION_KEY)
         return super().parse_url(link_str, relative_to, trim=trim)
+
+    def _get_image_urls_from_data_config(self, soup: BeautifulSoup) -> list[AbsoluteHttpURL]:
+        image_urls: list[AbsoluteHttpURL] = []
+        album_images = soup.select("div[data-object]")
+        for image_data in album_images:
+            encoded_data = css.get_attr(image_data, "data-object")
+            if not encoded_data:
+                continue
+            # Decode URL-encoded JSON string
+            data = json.loads(urllib.parse.unquote(encoded_data))
+            if not data:
+                continue
+            image_url = self.parse_url(data["image"]["url"])
+            image_urls.append(image_url)
+        return image_urls
 
 
 def _is_password_protected(soup: BeautifulSoup) -> bool:

--- a/cyberdrop_dl/crawlers/_chevereto.py
+++ b/cyberdrop_dl/crawlers/_chevereto.py
@@ -11,6 +11,8 @@ from cyberdrop_dl.utils import css, json, open_graph
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, xor_decrypt
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from bs4 import BeautifulSoup
 
     from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL, ScrapeItem
@@ -156,31 +158,12 @@ class CheveretoCrawler(Crawler, is_generic=True):
     def _process_page(
         self, scrape_item: ScrapeItem, soup: BeautifulSoup, results: dict[str, int] | None = None
     ) -> None:
-        # Scrape high-quality image urls from data-object if available
-        image_urls = self._get_image_urls_from_data_config(soup)
-        if len(image_urls) > 0:
-            for image_url in image_urls:
-                if results and self.check_album_results(image_url, results):
-                    continue
-                new_scrape_item = scrape_item.create_child(image_url)
-                self.create_task(self.direct_file(new_scrape_item, image_url))
-            return
-
-        for thumb, new_scrape_item in self.iter_children(scrape_item, soup, Selector.ITEM):
-            if image_url := self._match_img(new_scrape_item.url):
-                new_scrape_item.url = image_url
-
-                if thumb:
-                    # for images, we can download the file from the thumbnail, skipping an additional request per img
-                    # cons: we won't get the upload date
-                    source = self._thumbnail_to_src(thumb)
-                    if results and self.check_album_results(source, results):
-                        continue
-
-                    self.create_task(self.direct_file(new_scrape_item, source))
-                    continue
-
-            self.create_task(self.run(new_scrape_item))
+        for web_url, src_url in self._get_image_urls_from_data_object(soup):
+            if results and self.check_album_results(web_url, results):
+                continue
+            new_scrape_item = scrape_item.create_child(web_url)
+            self.create_task(self.direct_file(new_scrape_item, src_url))
+            scrape_item.add_children()
 
     async def _unlock_password_protected_album(self, scrape_item: ScrapeItem) -> None:
         if not scrape_item.password:
@@ -224,20 +207,15 @@ class CheveretoCrawler(Crawler, is_generic=True):
             link_str = xor_decrypt(encrypted_url, _DECRYPTION_KEY)
         return super().parse_url(link_str, relative_to, trim=trim)
 
-    def _get_image_urls_from_data_config(self, soup: BeautifulSoup) -> list[AbsoluteHttpURL]:
-        image_urls: list[AbsoluteHttpURL] = []
-        album_images = soup.select("div[data-object]")
-        for image_data in album_images:
-            encoded_data = css.get_attr(image_data, "data-object")
-            if not encoded_data:
-                continue
-            # Decode URL-encoded JSON string
+    def _get_image_urls_from_data_object(
+        self, soup: BeautifulSoup
+    ) -> Generator[tuple[AbsoluteHttpURL, AbsoluteHttpURL]]:
+        for item in soup.select(".list-item[data-object]"):
+            web_url = self.parse_url(css.select(item, "a.image-container", "href"))
+            encoded_data = css.get_attr(item, "data-object")
             data = json.loads(urllib.parse.unquote(encoded_data))
-            if not data:
-                continue
-            image_url = self.parse_url(data["image"]["url"])
-            image_urls.append(image_url)
-        return image_urls
+            src_url = self.parse_url(data["image"]["url"])
+            yield web_url, src_url
 
 
 def _is_password_protected(soup: BeautifulSoup) -> bool:

--- a/cyberdrop_dl/crawlers/_chevereto.py
+++ b/cyberdrop_dl/crawlers/_chevereto.py
@@ -78,7 +78,7 @@ class CheveretoCrawler(Crawler, is_generic=True):
             case ["images", _, *_]:
                 return await self.direct_file(scrape_item)
             case [_, "albums"]:
-                return await self.profile(scrape_item)
+                return await self.profile(scrape_item, albums=True)
             case [_]:
                 return await self.profile(scrape_item)
             case _:
@@ -104,12 +104,19 @@ class CheveretoCrawler(Crawler, is_generic=True):
                 return url
 
     @error_handling_wrapper
-    async def profile(self, scrape_item: ScrapeItem) -> None:
+    async def profile(self, scrape_item: ScrapeItem, *, albums: bool = False) -> None:
         title: str = ""
         async for soup in self.web_pager(_sort_by_new(scrape_item.url), trim=False):
             if not title:
                 title = self.create_title(open_graph.title(soup))
                 scrape_item.setup_as_profile(title)
+
+            if albums:
+                for _, sub_album in self.iter_children(scrape_item, soup, Selector.ITEM):
+                    self.create_task(self.run(sub_album))
+
+                return
+
             self._process_page(scrape_item, soup)
 
     async def _get_final_album_url(self, url: AbsoluteHttpURL) -> AbsoluteHttpURL:
@@ -152,9 +159,11 @@ class CheveretoCrawler(Crawler, is_generic=True):
     def _process_page(
         self, scrape_item: ScrapeItem, soup: BeautifulSoup, results: dict[str, int] | None = None
     ) -> None:
+        results = results or {}
         for web_url, src_url in self._get_album_files(soup):
-            if results and self.check_album_results(web_url, results):
+            if self.check_album_results(web_url, results):
                 continue
+
             new_scrape_item = scrape_item.create_child(web_url)
             self.create_task(self.direct_file(new_scrape_item, src_url))
             scrape_item.add_children()
@@ -207,7 +216,7 @@ class CheveretoCrawler(Crawler, is_generic=True):
             encoded_data = css.get_attr(item, "data-object")
             data = json.loads(urllib.parse.unquote(encoded_data))
             src_url = self.parse_url(data["image"]["url"])
-            yield web_url, src_url
+            yield self.transform_url(web_url), src_url
 
 
 def _is_password_protected(soup: BeautifulSoup) -> bool:

--- a/cyberdrop_dl/crawlers/imgbb.py
+++ b/cyberdrop_dl/crawlers/imgbb.py
@@ -40,9 +40,3 @@ class ImgBBCrawler(CheveretoCrawler):
                 return await self.media(scrape_item)
             case _:
                 raise ValueError
-
-    @classmethod
-    def _match_img(cls, url: AbsoluteHttpURL) -> AbsoluteHttpURL | None:
-        match url.parts[1:]:
-            case [_]:
-                return url

--- a/tests/crawlers/test_cases/imgbb.py
+++ b/tests/crawlers/test_cases/imgbb.py
@@ -36,4 +36,70 @@ TEST_CASES = [
         ],
         1537,
     ),
+    (
+        "https://ibb.co/album/DDcTkZ",
+        [
+            {
+                "url": "https://i.ibb.co/xSSVZ3TF/FOISTUDIOS-arna-SET2-16.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-16.jpg",
+                "referrer": "https://ibb.co/WWWSCsJV",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/3ytgckZy/FOISTUDIOS-arna-SET2-14.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-14.jpg",
+                "referrer": "https://ibb.co/wND54YmN",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/gF3fc73F/FOISTUDIOS-arna-SET2-3.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-3.jpg",
+                "referrer": "https://ibb.co/93N1dvN3",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/tPzBWLjm/FOISTUDIOS-arna-SET2-10.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-10.jpg",
+                "referrer": "https://ibb.co/Z1Sdk24L",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/tTgcj5k9/FOISTUDIOS-arna-SET2-6.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-6.jpg",
+                "referrer": "https://ibb.co/5gmvpVtP",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/sdMsb0YW/FOISTUDIOS-arna-SET2-7.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-7.jpg",
+                "referrer": "https://ibb.co/Mx3PZY0B",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/sd5z3Mj5/FOISTUDIOS-arna-SET2-12.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-12.jpg",
+                "referrer": "https://ibb.co/PvT0CfxT",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/nqMZF2ts/FOISTUDIOS-arna-SET2-17.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-17.jpg",
+                "referrer": "https://ibb.co/7xt8qcLJ",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/G428GCFC/FOISTUDIOS-arna-SET2-13.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-13.jpg",
+                "referrer": "https://ibb.co/wFWP8pYp",
+                "album_id": "DDcTkZ",
+            },
+            {
+                "url": "https://i.ibb.co/JF0FWGXz/FOISTUDIOS-arna-SET2-9.jpg",
+                "filename": "FOISTUDIOS-arna-SET2-9.jpg",
+                "referrer": "https://ibb.co/zHjHWBKS",
+                "album_id": "DDcTkZ",
+            },
+        ],
+        10,
+    ),
 ]


### PR DESCRIPTION
Fixes #1598 

Parsing and url-decoding all the `div[data-object]` in the album page to get the list of original high-resolution image URLs.
<img width="2128" height="1504" alt="image" src="https://github.com/user-attachments/assets/fddd7a68-65ff-4f71-846e-da687087c93e" />
