### PR TITLE
feat: add support to use impersonation while downloading 

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -4,8 +4,9 @@ import asyncio
 import contextlib
 import itertools
 import time
+from collections.abc import Generator
 from http import HTTPStatus
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiofiles
 
@@ -14,13 +15,13 @@ from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.constants import FILE_FORMATS
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, InvalidContentTypeError, SlowDownloadError
-from cyberdrop_dl.utils import dates
+from cyberdrop_dl.utils import aio, dates
 from cyberdrop_dl.utils.aio import WeakAsyncLocks
 from cyberdrop_dl.utils.logger import log, log_debug
 from cyberdrop_dl.utils.utilities import get_size_or_none
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Generator, Mapping
+    from collections.abc import AsyncGenerator, Callable, Coroutine, Generator, Mapping
     from pathlib import Path
     from typing import Any
 
@@ -38,6 +39,7 @@ _CHROME_ANDROID_USER_AGENT: str = (
 )
 _FREE_SPACE_CHECK_PERIOD: int = 5  # Check every 5 chunks
 _NULL_CONTEXT: contextlib.nullcontext[None] = contextlib.nullcontext()
+_USER_IMPERSONATION: set[str] = set()
 
 
 class DownloadClient:
@@ -172,8 +174,10 @@ class DownloadClient:
         return resp.content
 
     @contextlib.asynccontextmanager
-    async def __request_context(self, url: AbsoluteHttpURL, domain: str, headers: dict[str, str]):
-        if domain in ():
+    async def __request_context(
+        self, url: AbsoluteHttpURL, domain: str, headers: dict[str, str]
+    ) -> AsyncGenerator[AbstractResponse | aiohttp.ClientResponse]:
+        if domain in _USER_IMPERSONATION:
             resp = await self.client_manager._curl_session.get(str(url), stream=True, headers=headers)
             try:
                 yield AbstractResponse.from_resp(resp)
@@ -241,7 +245,7 @@ class DownloadClient:
                 self.manager.progress_manager.file_progress.advance_file(media_item.task_id, chunk_size)
                 check_download_speed()
 
-        self._post_download_check(media_item)
+        await self._post_download_check(media_item)
 
     def _pre_download_check(self, media_item: MediaItem) -> Coroutine[Any, Any, None]:
         def prepare() -> None:
@@ -251,10 +255,10 @@ class DownloadClient:
 
         return asyncio.to_thread(prepare)
 
-    def _post_download_check(self, media_item: MediaItem, *_) -> None:
-        if not media_item.partial_file.stat().st_size:
-            media_item.partial_file.unlink()
-            raise DownloadError(status=HTTPStatus.INTERNAL_SERVER_ERROR, message="File is empty")
+    async def _post_download_check(self, media_item: MediaItem, *_) -> None:
+        if not await aio.get_size(media_item.partial_file):
+            await aio.unlink(media_item.partial_file, missing_ok=True)
+            raise DownloadError(HTTPStatus.INTERNAL_SERVER_ERROR, message="File is empty")
 
     def make_free_space_checker(self, media_item: MediaItem) -> Callable[[], Coroutine[Any, Any, None]]:
         current_chunk = 0

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -171,20 +171,34 @@ class DownloadClient:
             return resp
         return resp.content
 
+    @contextlib.asynccontextmanager
+    async def __request_context(self, url: AbsoluteHttpURL, domain: str, headers: dict[str, str]):
+        if domain in ():
+            resp = await self.client_manager._curl_session.get(str(url), stream=True, headers=headers)
+            try:
+                yield AbstractResponse.from_resp(resp)
+            finally:
+                await resp.aclose()
+            return
+
+        async with self.client_manager._download_session.get(url, headers=headers) as resp:
+            yield resp
+
     async def _request_download(
         self,
         media_item: MediaItem,
         download_headers: dict[str, str],
-        process_response: Callable[[aiohttp.ClientResponse], Coroutine[None, None, bool]],
+        process_response: Callable[[aiohttp.ClientResponse | AbstractResponse], Coroutine[None, None, bool]],
     ) -> bool:
         download_url = media_item.debrid_link or media_item.url
         await self.manager.states.RUNNING.wait()
         fallback_url_generator = _fallback_generator(media_item)
         fallback_count = 0
+
         while True:
             resp = None
             try:
-                async with self.client_manager._download_session.get(download_url, headers=download_headers) as resp:
+                async with self.__request_context(download_url, media_item.domain, download_headers) as resp:
                     return await process_response(resp)
             except (DownloadError, DDOSGuardError):
                 if resp is None:

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import aiofiles
 
 from cyberdrop_dl import constants
+from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.constants import FILE_FORMATS
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, InvalidContentTypeError, SlowDownloadError
@@ -105,58 +106,70 @@ class DownloadClient:
 
         await asyncio.sleep(self.manager.config_manager.global_settings_data.rate_limiting_options.total_delay)
 
-        async def process_response(resp: aiohttp.ClientResponse) -> bool:
-            if resp.status == HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
-                await asyncio.to_thread(media_item.partial_file.unlink)
-
-            await self.client_manager.check_http_status(resp, download=True)
-
-            if not media_item.is_segment:
-                _ = get_content_type(media_item.ext, resp.headers)
-
-            media_item.filesize = int(resp.headers.get("Content-Length", "0")) or None
-            if not media_item.complete_file:
-                proceed, skip = await self.get_final_file_info(media_item, domain)
-                self.client_manager.check_content_length(resp.headers)
-                if skip:
-                    self.manager.progress_manager.download_progress.add_skipped()
-                    return False
-                if not proceed:
-                    if media_item.is_segment:
-                        return True
-                    log(f"Skipping {media_item.url} as it has already been downloaded", 10)
-                    self.manager.progress_manager.download_progress.add_previously_completed(False)
-                    await self.process_completed(media_item, domain)
-                    await self.handle_media_item_completion(media_item, downloaded=False)
-
-                    return False
-
-            if resp.status != HTTPStatus.PARTIAL_CONTENT:
-                await asyncio.to_thread(media_item.partial_file.unlink, missing_ok=True)
-
-            if (
-                not media_item.is_segment
-                and not media_item.datetime
-                and (last_modified := get_last_modified(resp.headers))
-            ):
-                msg = f"Unable to parse upload date for {media_item.url}, using `Last-Modified` header as file datetime"
-                log(msg, 30)
-                media_item.datetime = last_modified
-
-            task_id = media_item.task_id
-            if task_id is None:
-                size = (media_item.filesize + resume_point) if media_item.filesize is not None else None
-                task_id = self.manager.progress_manager.file_progress.add_task(
-                    domain=domain, filename=media_item.filename, expected_size=size
-                )
-                media_item.set_task_id(task_id)
-
-            self.manager.progress_manager.file_progress.advance_file(task_id, resume_point)
-
-            await self._append_content(media_item, resp.content)
-            return True
+        def process_response(resp: aiohttp.ClientResponse | AbstractResponse):
+            return self._process_response(media_item, domain, resume_point, resp)
 
         return await self._request_download(media_item, download_headers, process_response)
+
+    async def _process_response(
+        self,
+        media_item: MediaItem,
+        domain: str,
+        resume_point: int,
+        resp: aiohttp.ClientResponse | AbstractResponse,
+    ) -> bool:
+        if resp.status == HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
+            await asyncio.to_thread(media_item.partial_file.unlink)
+
+        await self.client_manager.check_http_status(resp, download=True)
+
+        if not media_item.is_segment:
+            _ = get_content_type(media_item.ext, resp.headers)
+
+        media_item.filesize = int(resp.headers.get("Content-Length", "0")) or None
+        if not media_item.complete_file:
+            proceed, skip = await self.get_final_file_info(media_item, domain)
+            self.client_manager.check_content_length(resp.headers)
+            if skip:
+                self.manager.progress_manager.download_progress.add_skipped()
+                return False
+            if not proceed:
+                if media_item.is_segment:
+                    return True
+                log(f"Skipping {media_item.url} as it has already been downloaded", 10)
+                self.manager.progress_manager.download_progress.add_previously_completed(False)
+                await self.process_completed(media_item, domain)
+                await self.handle_media_item_completion(media_item, downloaded=False)
+
+                return False
+
+        if resp.status != HTTPStatus.PARTIAL_CONTENT:
+            await asyncio.to_thread(media_item.partial_file.unlink, missing_ok=True)
+
+        if not media_item.is_segment and not media_item.datetime and (last_modified := get_last_modified(resp.headers)):
+            msg = f"Unable to parse upload date for {media_item.url}, using `Last-Modified` header as file datetime"
+            log(msg, 30)
+            media_item.datetime = last_modified
+
+        task_id = media_item.task_id
+        if task_id is None:
+            size = (media_item.filesize + resume_point) if media_item.filesize is not None else None
+            task_id = self.manager.progress_manager.file_progress.add_task(
+                domain=domain, filename=media_item.filename, expected_size=size
+            )
+            media_item.set_task_id(task_id)
+
+        self.manager.progress_manager.file_progress.advance_file(task_id, resume_point)
+
+        await self._append_content(media_item, self._get_resp_reader(resp))
+        return True
+
+    def _get_resp_reader(
+        self, resp: aiohttp.ClientResponse | AbstractResponse
+    ) -> AbstractResponse | aiohttp.StreamReader:
+        if isinstance(resp, AbstractResponse):
+            return resp
+        return resp.content
 
     async def _request_download(
         self,
@@ -195,7 +208,7 @@ class DownloadClient:
                     continue
                 raise
 
-    async def _append_content(self, media_item: MediaItem, content: aiohttp.StreamReader) -> None:
+    async def _append_content(self, media_item: MediaItem, content: aiohttp.StreamReader | AbstractResponse) -> None:
         """Appends content to a file."""
 
         assert media_item.task_id is not None
@@ -214,7 +227,7 @@ class DownloadClient:
                 self.manager.progress_manager.file_progress.advance_file(media_item.task_id, chunk_size)
                 check_download_speed()
 
-        self._post_download_check(media_item, content)
+        self._post_download_check(media_item)
 
     def _pre_download_check(self, media_item: MediaItem) -> Coroutine[Any, Any, None]:
         def prepare() -> None:
@@ -224,8 +237,8 @@ class DownloadClient:
 
         return asyncio.to_thread(prepare)
 
-    def _post_download_check(self, media_item: MediaItem, content: aiohttp.StreamReader) -> None:
-        if not content.total_bytes and not media_item.partial_file.stat().st_size:
+    def _post_download_check(self, media_item: MediaItem, *_) -> None:
+        if not media_item.partial_file.stat().st_size:
             media_item.partial_file.unlink()
             raise DownloadError(status=HTTPStatus.INTERNAL_SERVER_ERROR, message="File is empty")
 

--- a/cyberdrop_dl/downloader/mega_nz.py
+++ b/cyberdrop_dl/downloader/mega_nz.py
@@ -844,12 +844,13 @@ class MegaDownloadClient(DownloadClient):
                 chunk = chunk_decryptor.decrypt(raw_chunk)
                 await check_free_space()
                 chunk_size = len(chunk)
+
                 await self.client_manager.speed_limiter.acquire(chunk_size)
                 await f.write(chunk)
                 self.manager.progress_manager.file_progress.advance_file(media_item.task_id, chunk_size)
                 check_download_speed()
 
-        self._post_download_check(media_item, content)
+        self._post_download_check(media_item)
         chunk_decryptor.check_mac_integrity()
 
     def _pre_download_check(self, media_item: MediaItem) -> Coroutine[Any, Any, None]:

--- a/cyberdrop_dl/downloader/mega_nz.py
+++ b/cyberdrop_dl/downloader/mega_nz.py
@@ -850,7 +850,7 @@ class MegaDownloadClient(DownloadClient):
                 self.manager.progress_manager.file_progress.advance_file(media_item.task_id, chunk_size)
                 check_download_speed()
 
-        self._post_download_check(media_item)
+        await self._post_download_check(media_item)
         chunk_decryptor.check_mac_integrity()
 
     def _pre_download_check(self, media_item: MediaItem) -> Coroutine[Any, Any, None]:


### PR DESCRIPTION
Add support to use impersonation on the final request to download the actual file.

There no logic to actually decide if it should be used nor a way for the crawler to selected for the downloader. The crawler domain needs to be hardcoded for now