### PR TITLE
fix: handle new video data formats  (xhamster)

### DIFF
--- a/cyberdrop_dl/crawlers/xhamster.py
+++ b/cyberdrop_dl/crawlers/xhamster.py
@@ -237,8 +237,8 @@ class XhamsterCrawler(Crawler):
 
 
 class Codec(IntEnum):
-    H265 = 1
-    H264 = 2
+    H264 = 1
+    H265 = 2
     AV1 = 3 if _ALLOW_AV1 else 0
 
 
@@ -302,6 +302,10 @@ def _parse_xplayer_sources(initials: dict[str, Any]) -> Iterable[Format]:
 
             seen_urls.add(url)
             res = Resolution.parse(quality)
+            if res == Resolution.unknown() and (multi := next((p for p in url.parts if p.startswith("multi=")), None)):
+                best = next(reversed(multi.split(",")))
+                res = Resolution.parse(best.partition(":")[0])
+
             yield Format(res, Codec[codec.upper()], url)
 
     standard_sources: dict[str, list[dict[str, Any]]] = xplayer_sources.get("standard", {})

--- a/cyberdrop_dl/crawlers/xhamster.py
+++ b/cyberdrop_dl/crawlers/xhamster.py
@@ -259,7 +259,7 @@ class Video:
 
 
 def _parse_video(initials: dict[str, Any]) -> Video:
-    video: dict[str, Any] = initials["videoPageComponent"]["videoInfo"]["videoInfo"]
+    video: dict[str, Any] = initials.get("videoModel") or initials["videoPageComponent"]["videoInfo"]["videoInfo"]
 
     hls_sources: list[Format] = []
     mp4_sources: list[Format] = []
@@ -271,9 +271,9 @@ def _parse_video(initials: dict[str, Any]) -> Video:
             mp4_sources.append(src)
 
     return Video(
-        id=video["videoIdHashSlug"],
+        id=video.get("idHashSlug") or video["videoIdHashSlug"],
         title=video["title"],
-        created=video["addTime"],
+        created=video.get("created") or video["addTime"],
         best_hls=max(hls_sources, default=None),
         best_mp4=max(mp4_sources),
     )

--- a/cyberdrop_dl/crawlers/xhamster.py
+++ b/cyberdrop_dl/crawlers/xhamster.py
@@ -26,7 +26,7 @@ _DECRYPTION_KEY = b"xh7999"
 
 class Selector:
     VIDEO = "a.video-thumb__image-container"
-    GALLERY = "a.gallery-thumb__link"
+    GALLERY = "[data-gallery-id] > a[href]"
     NEXT_PAGE = "a[data-page='next']"
 
 
@@ -133,29 +133,25 @@ class XhamsterCrawler(Crawler):
         if is_creator:
             info: dict[str, Any] = initials["infoComponent"]["displayUserModel"]
             web_page_url = self.parse_url(info["pageURL"])
-            has_videos = bool(initials["infoComponent"].get("pornstarTop", {}).get("videoCount", 0))
-            has_galleries = bool(initials.get("galleriesComponent", {}).get("galleriesTotal", 0))
 
         else:
             info = initials["displayUserModel"]
             web_page_url = canonical_url
-            has_videos = bool(initials["counters"]["videos"])
-            has_galleries = bool(initials["counters"]["galleries"])
 
         # every creator is an user, but not every user is a creator
         # the creator's name and the user_name are different for the same account
         # we will ignore the creator's name and always use the user_name
 
-        creator_name: str | None = info.get("pageTitle")  # noqa: F841
+        _creator_name: str | None = info.get("pageTitle")
         user_name: str = info.get("displayName") or info["name"]
         title = self.create_title(f"{user_name} [user]")
         scrape_item.setup_as_profile(title)
 
-        if has_videos and download_videos:
+        if download_videos:
             videos_url = web_page_url / "videos"
             await self._iter_profile_pages(scrape_item, videos_url, Selector.VIDEO, "videos")
 
-        if has_galleries and download_photos:
+        if download_photos:
             gallerys_url = web_page_url / "photos"
             await self._iter_profile_pages(scrape_item, gallerys_url, Selector.GALLERY, "galleries")
 
@@ -180,7 +176,7 @@ class XhamsterCrawler(Crawler):
         results = await self.get_album_results(gallery_id)
         n_pages: int = page_details["paginationProps"]["lastPageNumber"]
         index: int = 0
-        images: list[dict[str, Any]] = initials["photosGalleryModel"]["photos"]
+        images: list[dict[str, Any]] = gallery["photos"]
 
         for next_page in itertools.count(2):
             for img in images:

--- a/cyberdrop_dl/crawlers/xhamster.py
+++ b/cyberdrop_dl/crawlers/xhamster.py
@@ -264,9 +264,7 @@ def _parse_video(initials: dict[str, Any]) -> Video:
     hls_sources: list[Format] = []
     mp4_sources: list[Format] = []
 
-    sources = itertools.chain(_parse_http_sources(initials), _parse_xplayer_sources(initials))
-
-    for src in sources:
+    for src in _parse_xplayer_sources(initials):
         if src.url.suffix == ".m3u8":
             hls_sources.append(src)
         else:
@@ -279,27 +277,6 @@ def _parse_video(initials: dict[str, Any]) -> Video:
         best_hls=max(hls_sources, default=None),
         best_mp4=max(mp4_sources),
     )
-
-
-def _parse_http_sources(initials: dict[str, Any]) -> Iterable[Format]:
-    seen_urls: set[AbsoluteHttpURL] = set()
-
-    http_sources: dict[str, dict[str, str]] = initials["videoModel"].get("sources") or {}
-    if not http_sources:
-        return
-
-    for codec, formats_dict in http_sources.items():
-        for quality, url in formats_dict.items():
-            if codec == "download":
-                continue
-
-            url = _parse_url(url)
-            if url in seen_urls:
-                continue
-
-            seen_urls.add(url)
-            resolution = Resolution.parse(quality)
-            yield Format(resolution, Codec[codec.upper()], url)
 
 
 def _parse_xplayer_sources(initials: dict[str, Any]) -> Iterable[Format]:
@@ -315,17 +292,17 @@ def _parse_xplayer_sources(initials: dict[str, Any]) -> Iterable[Format]:
             if not url:
                 continue
 
+            quality = format_dict.get("quality") or format_dict.get("label")
+            if quality == "auto":
+                quality = None
+
             url = _parse_url(url)
             if url in seen_urls:
                 continue
 
             seen_urls.add(url)
-            if url.suffix == ".m3u8":
-                res = 0
-            else:
-                res = format_dict.get("quality") or format_dict["label"]
-
-            yield Format(Resolution.parse(res), Codec[codec.upper()], url)
+            res = Resolution.parse(quality)
+            yield Format(res, Codec[codec.upper()], url)
 
     hls_sources: dict[str, dict[str, str]] = xplayer_sources.get("hls", {})
     for codec, format_dict in hls_sources.items():

--- a/cyberdrop_dl/crawlers/xhamster.py
+++ b/cyberdrop_dl/crawlers/xhamster.py
@@ -5,8 +5,9 @@ import codecs
 import dataclasses
 import itertools
 import json
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from cyberdrop_dl.compat import IntEnum
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.data_structures.mediaprops import Resolution
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
@@ -20,7 +21,6 @@ if TYPE_CHECKING:
 
 _PRIMARY_URL = AbsoluteHttpURL("https://xhamster.com/")
 _ALLOW_AV1 = False
-_ALLOW_HLS = False
 _DECRYPTION_KEY = b"xh7999"
 
 
@@ -218,7 +218,7 @@ class XhamsterCrawler(Crawler):
             video.title,
             ".mp4",
             file_id=video.id,
-            video_codec=video.best_mp4.codec,
+            video_codec=video.best_mp4.codec.name.lower(),
             resolution=video.best_mp4.resolution,
         )
         await self.handle_file(
@@ -236,9 +236,16 @@ class XhamsterCrawler(Crawler):
         return json.loads(initials)
 
 
-class Format(NamedTuple):
+class Codec(IntEnum):
+    H265 = 1
+    H264 = 2
+    AV1 = 3 if _ALLOW_AV1 else 0
+
+
+@dataclasses.dataclass(frozen=True, order=True, slots=True)
+class Format:
     resolution: Resolution
-    codec: str  #  h264 > av1
+    codec: Codec
     url: AbsoluteHttpURL
 
 
@@ -260,11 +267,7 @@ def _parse_video(initials: dict[str, Any]) -> Video:
     sources = itertools.chain(_parse_http_sources(initials), _parse_xplayer_sources(initials))
 
     for src in sources:
-        if src.codec == "av1" and not _ALLOW_AV1:
-            continue
         if src.url.suffix == ".m3u8":
-            if not _ALLOW_HLS:
-                continue
             hls_sources.append(src)
         else:
             mp4_sources.append(src)
@@ -296,11 +299,11 @@ def _parse_http_sources(initials: dict[str, Any]) -> Iterable[Format]:
 
             seen_urls.add(url)
             resolution = Resolution.parse(quality)
-            yield Format(resolution, codec, url)
+            yield Format(resolution, Codec[codec.upper()], url)
 
 
 def _parse_xplayer_sources(initials: dict[str, Any]) -> Iterable[Format]:
-    xplayer_sources: dict[str, Any] = initials.get("xplayerSettings", {}).get("sources", {})
+    xplayer_sources: dict[str, Any] = initials.get("xplayerSettings2", {}).get("sources", {})
     if not xplayer_sources:
         return
 
@@ -322,7 +325,7 @@ def _parse_xplayer_sources(initials: dict[str, Any]) -> Iterable[Format]:
             else:
                 res = format_dict.get("quality") or format_dict["label"]
 
-            yield Format(Resolution.parse(res), codec, url)
+            yield Format(Resolution.parse(res), Codec[codec.upper()], url)
 
     hls_sources: dict[str, dict[str, str]] = xplayer_sources.get("hls", {})
     for codec, format_dict in hls_sources.items():

--- a/cyberdrop_dl/crawlers/xhamster.py
+++ b/cyberdrop_dl/crawlers/xhamster.py
@@ -222,7 +222,7 @@ class XhamsterCrawler(Crawler):
             resolution=video.best_mp4.resolution,
         )
         await self.handle_file(
-            video.url,
+            scrape_item.url,
             scrape_item,
             filename=video.id + ".mp4",
             custom_filename=custom_filename,
@@ -247,13 +247,12 @@ class Video:
     id: str
     title: str
     created: int
-    url: AbsoluteHttpURL
     best_hls: Format | None
     best_mp4: Format
 
 
 def _parse_video(initials: dict[str, Any]) -> Video:
-    video: dict[str, Any] = initials["videoModel"]
+    video: dict[str, Any] = initials["videoPageComponent"]["videoInfo"]["videoInfo"]
 
     hls_sources: list[Format] = []
     mp4_sources: list[Format] = []
@@ -271,10 +270,9 @@ def _parse_video(initials: dict[str, Any]) -> Video:
             mp4_sources.append(src)
 
     return Video(
-        id=video["idHashSlug"],
+        id=video["videoIdHashSlug"],
         title=video["title"],
-        created=video["created"],
-        url=_parse_url(video["pageURL"]),
+        created=video["addTime"],
         best_hls=max(hls_sources, default=None),
         best_mp4=max(mp4_sources),
     )
@@ -309,7 +307,7 @@ def _parse_xplayer_sources(initials: dict[str, Any]) -> Iterable[Format]:
     seen_urls: set[AbsoluteHttpURL] = set()
 
     def parse_format(format_dict: dict[str, str], codec: str):
-        for key in ("url", "fallback"):
+        for key in ("url",):
             url = format_dict.get(key)
             if not url:
                 continue

--- a/cyberdrop_dl/crawlers/xhamster.py
+++ b/cyberdrop_dl/crawlers/xhamster.py
@@ -304,14 +304,14 @@ def _parse_xplayer_sources(initials: dict[str, Any]) -> Iterable[Format]:
             res = Resolution.parse(quality)
             yield Format(res, Codec[codec.upper()], url)
 
-    hls_sources: dict[str, dict[str, str]] = xplayer_sources.get("hls", {})
-    for codec, format_dict in hls_sources.items():
-        yield from parse_format(format_dict, codec)
-
     standard_sources: dict[str, list[dict[str, Any]]] = xplayer_sources.get("standard", {})
     for codec, formats_list in standard_sources.items():
         for format_dict in formats_list:
             yield from parse_format(format_dict, codec)
+
+    hls_sources: dict[str, dict[str, str]] = xplayer_sources.get("hls", {})
+    for codec, format_dict in hls_sources.items():
+        yield from parse_format(format_dict, codec)
 
 
 def _ensure_signed_32int(int32: int) -> int:

--- a/tests/crawlers/test_cases/xhamster.py
+++ b/tests/crawlers/test_cases/xhamster.py
@@ -62,21 +62,16 @@ TEST_CASES = [
         "https://xhamster.com/creators/danielagomezz",
         [
             {
-                "url": "https://ic-ph-nss.xhcdn.com/a/Mzc4ODY4M2VkNzM0ZTM3OGVjMGQ1ZTFjZGU1MzhhZDU/webp/000/517/308/699_1000.jpg",
-                "filename": "002 - 699_1000 [517308699].jpg",
-                "original_filename": "699_1000.jpg",
-                "referer": "https://xhamster.com/photos/gallery/16252066/517308699",
-                "download_folder": r"re:DanielaGomezx \[user\] \(xHamster\)/galleries/New image change",
-                "album_id": "16252066",
-                "datetime": 1738917721,
+                "url": "ANY",
+                "download_folder": r"re:DanielaGomezx \[user\] \(xHamster\)",
             },
         ],
-        38,
+        range(50, 60),
     ),
     (
         "https://xhamster.com/creators/danielagomezz/exclusive",
         [],
-        36,
+        range(50, 60),
     ),
     (
         "https://xhamster.com/creators/danielagomezz/photos",


### PR DESCRIPTION
- Fix parsing on newer videos
- Parse resolution of every format
- Fix galleries downloads

They also have AV1 and H265 sources now. The current code is able to parse them but at the end it always downloads the best H264 as that's the only direct download. The others are HLS

H264 is capped at 720p. I will make a different PR to always downloads an HLS source