### PR TITLE
fix: download of files with broken thumbnails (bunkr)

### DIFF
--- a/tests/crawlers/test_cases/bunkr.py
+++ b/tests/crawlers/test_cases/bunkr.py
@@ -88,7 +88,7 @@ TEST_CASES = [
         "https://bunkr.sk/f/summertimejames-pics--VocHZQ0K.rar",
         [
             {
-                "url": "https://kebab.bunkr.ru/summertimejames-pics--VocHZQ0K.rar?n=summertimejames(pics).rar",
+                "url": "re:/summertimejames-pics--VocHZQ0K.rar?n=summertimejames(pics).rar",
                 "filename": "summertimejames(pics).rar",
                 "referer": "https://bunkr.site/f/summertimejames-pics--VocHZQ0K.rar",
             }
@@ -98,7 +98,7 @@ TEST_CASES = [
         "https://kebab.bunkr.ru/summertimejames-pics--VocHZQ0K.rar",
         [
             {
-                "url": "https://kebab.bunkr.ru/summertimejames-pics--VocHZQ0K.rar?n=summertimejames-pics--VocHZQ0K.rar",
+                "url": "re:/summertimejames-pics--VocHZQ0K.rar?n=summertimejames-pics--VocHZQ0K.rar",
                 "filename": "summertimejames-pics--VocHZQ0K.rar",
                 "referer": "https://get.bunkrr.su",
             }
@@ -108,10 +108,12 @@ TEST_CASES = [
         "https://burger.bunkr.ru/9861917.mp4-PTaiPNai-CaBcktkP.mp4",
         [
             {
-                "url": "https://burger.bunkr.ru/9861917.mp4-PTaiPNai-CaBcktkP.mp4?n=9861917.mp4-PTaiPNai-CaBcktkP.mp4",
+                "url": "re:/9861917.mp4-PTaiPNai-CaBcktkP.mp4?n=9861917.mp4-PTaiPNai-CaBcktkP.mp4",
                 "filename": "9861917.mp4-PTaiPNai-CaBcktkP.mp4",
                 "referer": "https://get.bunkrr.su",
             }
         ],
     ),
+    ("https://bunkr.ws/a/z5Xt6NqH", [], 3),
+    ("https://bunkr.ws/a/aJHkJf3L", [], 172),
 ]


### PR DESCRIPTION
The script they are using to migrate the thumbnails is creating invalid URLs