### PR TITLE
Fix Bunkr child album discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ venv
 
 # Compiled package
 /dist/
+/scripts/release/
 
 # MacOS system files
 **.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,18 @@
 
 # Python cache
 __pycache__
+/.pytest_cache/
+/.ruff_cache/
+/pytest-cache-files-*/
+
+# Local crawler debug/temp artifacts
+/bunkrr_*.txt
+/output_bunkrr*.txt
+/check_db.py
+/tmp_*/
+/tmp_*.html
+/tmp_*.js
+
 # venv
 .venv
 venv

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 
 _DOWNLOAD_API_ENTRYPOINT = AbsoluteHttpURL("https://bunkr.cr/api/vs")
+_DOWNLOAD_API_ENTRYPOINT_BY_ID = AbsoluteHttpURL("https://apidl.bunkr.ru/api/_001_v2")
 _REINFORCED_URL = AbsoluteHttpURL("https://get.bunkrr.su")
 
 
@@ -33,6 +34,7 @@ class Selector:
     ALBUM_FILES = "script:-soup-contains('window.albumFiles = ')"
     DOWNLOAD_BUTTON = "a.btn.ic-download-01"
     IMAGE_PREVIEW = "img.max-h-full.w-auto.object-cover.relative"
+    RELATED_ALBUM = ".files-album a[href]"
 
 
 VIDEO_AND_IMAGE_EXTS: set[str] = FILE_FORMATS["Images"] | FILE_FORMATS["Videos"]
@@ -66,6 +68,36 @@ def _make_album_parser(keys: tuple[str, ...]) -> Callable[[BeautifulSoup], Gener
         return decode(files)
 
     return parse
+
+
+def _get_download_button_details(
+    soup: BeautifulSoup,
+    parse_url: Callable[[str, AbsoluteHttpURL | None], AbsoluteHttpURL],
+    relative_to: AbsoluteHttpURL,
+) -> tuple[str | None, AbsoluteHttpURL | None]:
+    button = css.select(soup, Selector.DOWNLOAD_BUTTON)
+    if file_id := css.get_attr_or_none(button, "data-id"):
+        return file_id, None
+
+    href = css.get_attr_or_none(button, "href")
+    if not href:
+        raise ValueError("Bunkr download button is missing href")
+    return None, parse_url(href, relative_to)
+
+
+def _get_related_album_url(
+    soup: BeautifulSoup,
+    parse_url: Callable[[str, AbsoluteHttpURL | None], AbsoluteHttpURL],
+    relative_to: AbsoluteHttpURL,
+) -> AbsoluteHttpURL | None:
+    href = css.select_one_get_attr_or_none(soup, Selector.RELATED_ALBUM, "href")
+    if not href:
+        return None
+
+    album_url = parse_url(href, relative_to)
+    if album_url.parts[1:2] == ("a",):
+        return album_url
+    return None
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -148,6 +180,9 @@ class BunkrrCrawler(Crawler):
 
     @error_handling_wrapper
     async def album(self, scrape_item: ScrapeItem, album_id: str) -> None:
+        await self._album(scrape_item, album_id)
+
+    async def _album(self, scrape_item: ScrapeItem, album_id: str) -> None:
         soup = await self._request_soup_lenient(scrape_item.url.with_query(advanced=1))
         name = open_graph.title(soup)
         title = self.create_title(name, album_id)
@@ -197,6 +232,9 @@ class BunkrrCrawler(Crawler):
             return
 
         soup = await self._request_soup_lenient(scrape_item.url)
+        if await self._try_related_album(scrape_item, soup):
+            return
+
         src = None
         if image := soup.select_one(Selector.IMAGE_PREVIEW):
             src = self.parse_url(css.get_attr(image, "src"))
@@ -204,20 +242,32 @@ class BunkrrCrawler(Crawler):
                 src = None
 
         if not src:
-            dl_link = css.select(soup, Selector.DOWNLOAD_BUTTON, "href")
-            file_id = self.parse_url(dl_link).name
-            src = await self._request_download(file_id)
+            src = await self._resolve_download_src(scrape_item, soup)
 
         name = open_graph.title(soup)  # See: https://github.com/jbsparrow/CyberDropDownloader/issues/929
         await self._direct_file(scrape_item, src, name)
+
+    async def _try_related_album(self, scrape_item: ScrapeItem, soup: BeautifulSoup) -> bool:
+        if scrape_item.parents:
+            return False
+
+        album_url = _get_related_album_url(soup, self.parse_url, scrape_item.url)
+        if not album_url:
+            return False
+
+        album_item = scrape_item.create_new(album_url, add_parent=scrape_item.url)
+        try:
+            await self._album(album_item, album_url.name)
+        except Exception as e:
+            self.log(f"[{self.FOLDER_DOMAIN}] Failed to expand related album {album_url}: {e}", 30)
+            return False
+        return True
 
     @error_handling_wrapper
     async def reinforced_file(self, scrape_item: ScrapeItem, file_id: str) -> None:
         soup = await self.request_soup(scrape_item.url)
         name = css.select_text(soup, "h1")
-        dl_link = css.select(soup, Selector.DOWNLOAD_BUTTON, "href")
-        slug = self.parse_url(dl_link).parts[-1]
-        src = await self._request_download(slug)
+        src = await self._resolve_download_src(scrape_item, soup)
         await self._direct_file(scrape_item, src, name)
 
     @error_handling_wrapper
@@ -241,6 +291,29 @@ class BunkrrCrawler(Crawler):
             headers={"Referer": "https://bunkr.sk/"},
         )
         return self.parse_url(ApiResponse(**resp).decrypt())
+
+    async def _request_download_by_id(self, file_id: str) -> AbsoluteHttpURL:
+        resp: dict[str, Any] = await self.request_json(
+            _DOWNLOAD_API_ENTRYPOINT_BY_ID,
+            "POST",
+            json={"id": file_id},
+        )
+        return self.parse_url(ApiResponse(**resp).decrypt())
+
+    async def _resolve_download_src(self, scrape_item: ScrapeItem, soup: BeautifulSoup) -> AbsoluteHttpURL:
+        file_id, dl_link = _get_download_button_details(soup, self.parse_url, scrape_item.url.origin())
+        if file_id:
+            return await self._request_download_by_id(file_id)
+
+        assert dl_link is not None
+        if dl_link.host == _REINFORCED_URL.host and dl_link.parts[1:2] == ("file",):
+            return await self._request_download_by_id(dl_link.name)
+
+        # Some pages already expose a CDN URL directly; keep using it as-is.
+        if dl_link.host not in HOST_OPTIONS and dl_link.host != self.DATABASE_PRIMARY_HOST:
+            return dl_link
+
+        return await self._request_download(dl_link.name)
 
     async def _try_request_soup(self, url: AbsoluteHttpURL) -> BeautifulSoup | None:
         try:

--- a/cyberdrop_dl/crawlers/bunkrr.py
+++ b/cyberdrop_dl/crawlers/bunkrr.py
@@ -13,7 +13,7 @@ from aiohttp import ClientConnectorError
 from cyberdrop_dl.constants import FILE_FORMATS
 from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths, auto_task_id
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
-from cyberdrop_dl.exceptions import DDOSGuardError
+from cyberdrop_dl.exceptions import DDOSGuardError, ScrapeError
 from cyberdrop_dl.utils import aio, css, open_graph
 from cyberdrop_dl.utils.utilities import error_handling_wrapper, parse_url, xor_decrypt
 
@@ -32,6 +32,7 @@ _REINFORCED_URL = AbsoluteHttpURL("https://get.bunkrr.su")
 
 class Selector:
     ALBUM_FILES = "script:-soup-contains('window.albumFiles = ')"
+    ALBUM_PAGE_LINKS = "a[href*='page=']"
     DOWNLOAD_BUTTON = "a.btn.ic-download-01"
     IMAGE_PREVIEW = "img.max-h-full.w-auto.object-cover.relative"
     RELATED_ALBUM = ".files-album a[href]"
@@ -81,8 +82,40 @@ def _get_download_button_details(
 
     href = css.get_attr_or_none(button, "href")
     if not href:
-        raise ValueError("Bunkr download button is missing href")
+        raise ScrapeError(422, "Bunkr download button is missing href")
     return None, parse_url(href, relative_to)
+
+
+def _album_page_url(url: AbsoluteHttpURL, page: int) -> AbsoluteHttpURL:
+    url = url.without_query_params("advanced", "page").update_query(advanced=1)
+    if page > 1:
+        return url.update_query(page=page)
+    return url
+
+
+def _get_album_last_page(
+    soup: BeautifulSoup,
+    parse_url: Callable[[str, AbsoluteHttpURL | None], AbsoluteHttpURL],
+    relative_to: AbsoluteHttpURL,
+) -> int | None:
+    last_page = None
+    for page_link in css.iselect(soup, Selector.ALBUM_PAGE_LINKS):
+        href = css.get_attr_or_none(page_link, "href")
+        if not href:
+            continue
+
+        page_url = parse_url(href, relative_to)
+        if page_url.parts[1:3] != relative_to.parts[1:3]:
+            continue
+
+        page = page_url.query.get("page")
+        try:
+            page_num = int(page) if page else 1
+        except ValueError:
+            continue
+
+        last_page = max(last_page or page_num, page_num)
+    return last_page
 
 
 def _get_related_album_url(
@@ -183,18 +216,51 @@ class BunkrrCrawler(Crawler):
         await self._album(scrape_item, album_id)
 
     async def _album(self, scrape_item: ScrapeItem, album_id: str) -> None:
-        soup = await self._request_soup_lenient(scrape_item.url.with_query(advanced=1))
+        soup = await self._request_soup_lenient(_album_page_url(scrape_item.url, 1))
         name = open_graph.title(soup)
         title = self.create_title(name, album_id)
         scrape_item.setup_as_album(title, album_id=album_id)
 
         origin = scrape_item.url.origin()
         results = await self.get_album_results(album_id)
-        for file in self._parse_album_files(soup):
-            web_url = origin / "f" / file.slug
-            new_scrape_item = scrape_item.create_child(web_url)
-            self.create_task(self._album_file(new_scrape_item, file, results))
-            scrape_item.add_children()
+        seen_slugs: set[str] = set()
+        last_page = _get_album_last_page(soup, self.parse_url, scrape_item.url)
+        page = 1
+
+        while True:
+            found_new_file = False
+            try:
+                page_files = self._parse_album_files(soup)
+            except ScrapeError:
+                if page == 1 or last_page is not None:
+                    raise
+                break
+
+            for file in page_files:
+                if file.slug in seen_slugs:
+                    continue
+
+                seen_slugs.add(file.slug)
+                found_new_file = True
+                web_url = origin / "f" / file.slug
+                new_scrape_item = scrape_item.create_child(web_url)
+                self.create_task(self._album_file(new_scrape_item, file, results))
+                scrape_item.add_children()
+
+            if not found_new_file or (last_page is not None and page >= last_page):
+                break
+
+            page += 1
+            page_url = _album_page_url(scrape_item.url, page)
+            try:
+                soup = await self._request_soup_lenient(page_url)
+            except ScrapeError:
+                if last_page is not None:
+                    raise
+                break
+
+            if page_last_page := _get_album_last_page(soup, self.parse_url, page_url):
+                last_page = max(last_page or page_last_page, page_last_page)
 
     @auto_task_id
     @error_handling_wrapper

--- a/cyberdrop_dl/crawlers/fileditch.py
+++ b/cyberdrop_dl/crawlers/fileditch.py
@@ -4,17 +4,26 @@ from typing import TYPE_CHECKING, ClassVar
 
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.data_structures.url_objects import AbsoluteHttpURL
-from cyberdrop_dl.exceptions import ScrapeError
+from cyberdrop_dl.exceptions import DDOSGuardError, ScrapeError
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.utilities import error_handling_wrapper
 
 if TYPE_CHECKING:
+    from bs4 import BeautifulSoup
+
     from cyberdrop_dl.data_structures.url_objects import ScrapeItem
 
 DOWNLOAD_SELECTOR = 'a.btn[href*="md5="]'
 HOMEPAGE_CATCHALL_FILE = "/s21/FHVZKQyAZlIsrneDAsp.jpeg"
+TURNSTILE_CHALLENGE_SELECTOR = "script[src*='challenges.cloudflare.com/turnstile'], .cf-turnstile, #turnstile-wrapper"
 
 PRIMARY_URL = AbsoluteHttpURL("https://fileditchfiles.me/")
+
+
+def _check_turnstile(soup: BeautifulSoup) -> None:
+    """Detect Cloudflare Turnstile challenge pages served with HTTP 200."""
+    if soup.select_one(TURNSTILE_CHALLENGE_SELECTOR):
+        raise DDOSGuardError("Cloudflare Turnstile challenge detected on Fileditch")
 
 
 class FileditchCrawler(Crawler):
@@ -31,6 +40,7 @@ class FileditchCrawler(Crawler):
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem) -> None:
         soup = await self.request_soup(scrape_item.url)
+        _check_turnstile(soup)
         link_str: str = css.select(soup, DOWNLOAD_SELECTOR, "href")
         link = self.parse_url(link_str)
         if link.path == HOMEPAGE_CATCHALL_FILE:

--- a/tests/crawlers/test_cases/bunkr.py
+++ b/tests/crawlers/test_cases/bunkr.py
@@ -28,6 +28,7 @@ TEST_CASES = [
         ],
         257,
     ),
+    ("https://bunkr.cr/a/eccmqVJi", [], 11),
     (
         "https://bunkr.cr/a/TQAgjP8m",
         [

--- a/tests/test_bunkrr.py
+++ b/tests/test_bunkrr.py
@@ -2,11 +2,20 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from bs4 import BeautifulSoup
 
-from cyberdrop_dl.crawlers.bunkrr import BunkrrCrawler, _get_download_button_details, _get_related_album_url
+from cyberdrop_dl.crawlers.bunkrr import (
+    BunkrrCrawler,
+    File,
+    _album_page_url,
+    _get_album_last_page,
+    _get_download_button_details,
+    _get_related_album_url,
+)
 from cyberdrop_dl.data_structures import AbsoluteHttpURL
 from cyberdrop_dl.data_structures.url_objects import ScrapeItem
+from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.utils.utilities import parse_url
 
 
@@ -47,6 +56,45 @@ def test_get_download_button_details_reads_reinforced_href() -> None:
     assert download_url == AbsoluteHttpURL("https://get.bunkrr.su/file/11234941")
 
 
+def test_get_download_button_details_raises_scrape_error_without_href() -> None:
+    soup = BeautifulSoup('<a class="btn btn-main ic-download-01">Download</a>', "html.parser")
+
+    with pytest.raises(ScrapeError):
+        _get_download_button_details(
+            soup,
+            _parse_with_base,
+            AbsoluteHttpURL("https://bunkr.cr"),
+        )
+
+
+def test_album_page_url_normalizes_existing_page_query() -> None:
+    url = AbsoluteHttpURL("https://bunkr.cr/a/fQ6HHKtg?page=3")
+
+    assert _album_page_url(url, 1) == AbsoluteHttpURL("https://bunkr.cr/a/fQ6HHKtg?advanced=1")
+    assert _album_page_url(url, 6) == AbsoluteHttpURL("https://bunkr.cr/a/fQ6HHKtg?advanced=1&page=6")
+
+
+def test_get_album_last_page_reads_pagination_links() -> None:
+    soup = BeautifulSoup(
+        """
+        <nav>
+            <a href="/a/fQ6HHKtg?page=2">2</a>
+            <a href="/a/fQ6HHKtg?page=6">6</a>
+            <a href="/a/different?page=99">unrelated</a>
+        </nav>
+        """,
+        "html.parser",
+    )
+
+    last_page = _get_album_last_page(
+        soup,
+        _parse_with_base,
+        AbsoluteHttpURL("https://bunkr.cr/a/fQ6HHKtg"),
+    )
+
+    assert last_page == 6
+
+
 def test_get_related_album_url_reads_file_page_album_link() -> None:
     soup = BeautifulSoup(
         '<h2 class="files-album">More files in this <a href="../a/eccmqVJi">album</a></h2>',
@@ -60,6 +108,59 @@ def test_get_related_album_url_reads_file_page_album_link() -> None:
     )
 
     assert album_url == AbsoluteHttpURL("https://bunkr.cr/a/eccmqVJi")
+
+
+async def test_album_scrapes_paginated_album_pages() -> None:
+    crawler = BunkrrCrawler(mock.Mock())
+    url = AbsoluteHttpURL("https://bunkr.cr/a/fQ6HHKtg")
+    page_1 = BeautifulSoup(
+        """
+        <html>
+            <head><meta property="og:title" content="Bunkr Album"></head>
+            <body><a href="/a/fQ6HHKtg?page=2">2</a></body>
+        </html>
+        """,
+        "html.parser",
+    )
+    page_2 = BeautifulSoup(
+        """
+        <html>
+            <head><meta property="og:title" content="Bunkr Album"></head>
+            <body></body>
+        </html>
+        """,
+        "html.parser",
+    )
+    first_file = File(name="one.mp4", thumbnail="", date="12:00:00 01/01/2024", slug="one.mp4")
+    second_file = File(name="two.mp4", thumbnail="", date="12:00:00 01/01/2024", slug="two.mp4")
+    scheduled_coroutines = []
+
+    def close_scheduled_coroutine(coro):
+        scheduled_coroutines.append(coro)
+        coro.close()
+
+    crawler._request_soup_lenient = mock.AsyncMock(side_effect=[page_1, page_2])
+    crawler.get_album_results = mock.AsyncMock(return_value={})
+    crawler.create_title = mock.Mock(return_value="Bunkr Album")
+    crawler._parse_album_files = mock.Mock(side_effect=[iter([first_file]), iter([second_file])])
+    crawler._album_file = mock.AsyncMock()
+    crawler.create_task = mock.Mock(side_effect=close_scheduled_coroutine)
+
+    scrape_item = ScrapeItem(url=url)
+    await crawler._album(scrape_item, "fQ6HHKtg")
+
+    requested_urls = [call.args[0] for call in crawler._request_soup_lenient.await_args_list]
+    child_urls = [call.args[0].url for call in crawler._album_file.call_args_list]
+    assert requested_urls == [
+        AbsoluteHttpURL("https://bunkr.cr/a/fQ6HHKtg?advanced=1"),
+        AbsoluteHttpURL("https://bunkr.cr/a/fQ6HHKtg?advanced=1&page=2"),
+    ]
+    assert child_urls == [
+        AbsoluteHttpURL("https://bunkr.cr/f/one.mp4"),
+        AbsoluteHttpURL("https://bunkr.cr/f/two.mp4"),
+    ]
+    assert scrape_item.children == 2
+    assert len(scheduled_coroutines) == 2
 
 
 async def test_top_level_file_expands_related_album() -> None:

--- a/tests/test_bunkrr.py
+++ b/tests/test_bunkrr.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from bs4 import BeautifulSoup
+
+from cyberdrop_dl.crawlers.bunkrr import BunkrrCrawler, _get_download_button_details, _get_related_album_url
+from cyberdrop_dl.data_structures import AbsoluteHttpURL
+from cyberdrop_dl.data_structures.url_objects import ScrapeItem
+from cyberdrop_dl.utils.utilities import parse_url
+
+
+def _parse_with_base(link: str, relative_to: AbsoluteHttpURL | None) -> AbsoluteHttpURL:
+    assert relative_to is not None
+    return parse_url(link, relative_to)
+
+
+def test_get_download_button_details_reads_file_id() -> None:
+    soup = BeautifulSoup(
+        '<a id="download-btn" class="btn btn-main ic-download-01" href="#" data-id="11234941">Download</a>',
+        "html.parser",
+    )
+
+    file_id, download_url = _get_download_button_details(
+        soup,
+        _parse_with_base,
+        AbsoluteHttpURL("https://get.bunkrr.su"),
+    )
+
+    assert file_id == "11234941"
+    assert download_url is None
+
+
+def test_get_download_button_details_reads_reinforced_href() -> None:
+    soup = BeautifulSoup(
+        '<a class="btn btn-main ic-download-01" href="https://get.bunkrr.su/file/11234941">Download</a>',
+        "html.parser",
+    )
+
+    file_id, download_url = _get_download_button_details(
+        soup,
+        _parse_with_base,
+        AbsoluteHttpURL("https://bunkr.cr"),
+    )
+
+    assert file_id is None
+    assert download_url == AbsoluteHttpURL("https://get.bunkrr.su/file/11234941")
+
+
+def test_get_related_album_url_reads_file_page_album_link() -> None:
+    soup = BeautifulSoup(
+        '<h2 class="files-album">More files in this <a href="../a/eccmqVJi">album</a></h2>',
+        "html.parser",
+    )
+
+    album_url = _get_related_album_url(
+        soup,
+        _parse_with_base,
+        AbsoluteHttpURL("https://bunkr.cr/f/8-16-8out556m95_30UUdVDDAQ-HnEfe1zW.mp4"),
+    )
+
+    assert album_url == AbsoluteHttpURL("https://bunkr.cr/a/eccmqVJi")
+
+
+async def test_top_level_file_expands_related_album() -> None:
+    crawler = BunkrrCrawler(mock.Mock())
+    file_url = AbsoluteHttpURL("https://bunkr.cr/f/8-16-8out556m95_30UUdVDDAQ-HnEfe1zW.mp4")
+    soup = BeautifulSoup(
+        """
+        <html>
+            <head><meta property="og:title" content="8 16 8out556m95_30UUdVDDAQ.mp4"></head>
+            <body>
+                <h2 class="files-album">More files in this <a href="../a/eccmqVJi">album</a></h2>
+                <a class="btn btn-main ic-download-01" href="https://get.bunkrr.su/file/11234941">Download</a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    crawler._album = mock.AsyncMock()
+
+    expanded = await crawler._try_related_album(ScrapeItem(url=file_url), soup)
+
+    assert expanded is True
+    crawler._album.assert_awaited_once()
+    album_item, album_id = crawler._album.await_args.args
+    assert album_item.url == AbsoluteHttpURL("https://bunkr.cr/a/eccmqVJi")
+    assert album_item.parents == [file_url]
+    assert album_id == "eccmqVJi"

--- a/tests/test_fileditch_turnstile.py
+++ b/tests/test_fileditch_turnstile.py
@@ -1,0 +1,89 @@
+"""Tests for Fileditch Cloudflare Turnstile challenge detection."""
+
+import pytest
+from bs4 import BeautifulSoup
+
+from cyberdrop_dl.crawlers.fileditch import _check_turnstile
+from cyberdrop_dl.exceptions import DDOSGuardError
+
+# HTML that represents a Cloudflare Turnstile challenge page (as seen at fileditchfiles.me)
+TURNSTILE_CHALLENGE_HTML = """
+<!DOCTYPE html>
+<html>
+<head><title>File Viewer</title></head>
+<body>
+    <div class="modal">
+        <h2>Quick security check</h2>
+        <p>Complete the challenge below to access this file.</p>
+        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+        <div class="cf-turnstile" data-sitekey="0x4AAAAAACr63gPSW1yJcW8o"></div>
+    </div>
+</body>
+</html>
+"""
+
+# HTML with turnstile-wrapper element
+TURNSTILE_WRAPPER_HTML = """
+<!DOCTYPE html>
+<html>
+<head><title>File Viewer</title></head>
+<body>
+    <div id="turnstile-wrapper">
+        <p>Verify you are human</p>
+    </div>
+</body>
+</html>
+"""
+
+# Normal download page HTML (no challenge)
+NORMAL_DOWNLOAD_HTML = """
+<!DOCTYPE html>
+<html>
+<head><title>File Viewer</title></head>
+<body>
+    <div class="file-info">
+        <a class="btn" href="https://thegumonmyshoe.me/b71/FrmLzfLKUHBWDTQfqaTZ.mp4?md5=abc123&expires=999">Download</a>
+    </div>
+</body>
+</html>
+"""
+
+
+def test_check_turnstile_detects_challenge_script() -> None:
+    """Turnstile challenge with script tag should raise DDOSGuardError."""
+    soup = BeautifulSoup(TURNSTILE_CHALLENGE_HTML, "html.parser")
+    with pytest.raises(DDOSGuardError, match="Cloudflare Turnstile challenge detected"):
+        _check_turnstile(soup)
+
+
+def test_check_turnstile_detects_cf_turnstile_element() -> None:
+    """Turnstile challenge with cf-turnstile element should raise DDOSGuardError."""
+    # HTML with only the cf-turnstile element, no script tag
+    html = """
+    <html><body>
+        <div class="cf-turnstile" data-sitekey="test"></div>
+    </body></html>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    with pytest.raises(DDOSGuardError):
+        _check_turnstile(soup)
+
+
+def test_check_turnstile_detects_wrapper_element() -> None:
+    """Turnstile challenge with #turnstile-wrapper should raise DDOSGuardError."""
+    soup = BeautifulSoup(TURNSTILE_WRAPPER_HTML, "html.parser")
+    with pytest.raises(DDOSGuardError):
+        _check_turnstile(soup)
+
+
+def test_check_turnstile_allows_normal_page() -> None:
+    """Normal download page should NOT raise DDOSGuardError."""
+    soup = BeautifulSoup(NORMAL_DOWNLOAD_HTML, "html.parser")
+    # Should not raise - returns None
+    _check_turnstile(soup)
+
+
+def test_check_turnstile_allows_empty_page() -> None:
+    """Empty/minimal HTML should NOT raise DDOSGuardError."""
+    soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+    _check_turnstile(soup)


### PR DESCRIPTION
- Issues related to the previous fix on Bunkrr 404 not found errors, there was an error with the scraper ignoring child items in a perfectly fine/downloadable bunkrr album
- Fix bunkrr scraper not looking at other pages within the same album