### PR TITLE
fix: filter console logs on the main thread

### DIFF
--- a/cyberdrop_dl/logs.py
+++ b/cyberdrop_dl/logs.py
@@ -34,7 +34,7 @@ _MAIN_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_MAIN_LOGGER_LISTENE
 _CONSOLE_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_CONSOLE_LOGGER_LISTENER")
 
 MAIN_LOG_FILE: ContextVar[Path] = ContextVar("_MAIN_LOGGER_FILE")
-LOG_TO_CONSOLE: ContextVar[bool] = ContextVar("LOG_TO_CONSOLE", default=True)
+_LOG_TO_CONSOLE: ContextVar[bool] = ContextVar("LOG_TO_CONSOLE", default=True)
 
 
 if TYPE_CHECKING:
@@ -288,7 +288,7 @@ def setup_console_logging(level: int = logging.INFO) -> Generator[None]:
     logging.getLogger().setLevel(logging.DEBUG)
     try:
         with _threaded_logger(handler, context_var=_CONSOLE_LOG_LISTENER) as q_handler:
-            q_handler.addFilter(lambda _: LOG_TO_CONSOLE.get())
+            q_handler.addFilter(lambda _: _LOG_TO_CONSOLE.get())
             yield
     finally:
         # Re add it as a normal handler to make sure uncatched exceptions show up
@@ -380,6 +380,13 @@ def flush_logs() -> None:
     listener = _MAIN_LOG_LISTENER.get()
     listener.stop()
     listener.start()
+
+
+def disable_console_logging():
+    listener = _CONSOLE_LOG_LISTENER.get()
+    listener.stop()
+    listener.start()
+    return _enter_context(_LOG_TO_CONSOLE, False)
 
 
 @contextlib.contextmanager

--- a/cyberdrop_dl/logs.py
+++ b/cyberdrop_dl/logs.py
@@ -383,9 +383,13 @@ def flush_logs() -> None:
 
 
 def disable_console_logging():
-    listener = _CONSOLE_LOG_LISTENER.get()
-    listener.stop()
-    listener.start()
+    try:
+        listener = _CONSOLE_LOG_LISTENER.get()
+    except LookupError:
+        pass
+    else:
+        listener.stop()
+        listener.start()
     return _enter_context(_LOG_TO_CONSOLE, False)
 
 

--- a/cyberdrop_dl/logs.py
+++ b/cyberdrop_dl/logs.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from io import StringIO
 from logging.handlers import QueueHandler, QueueListener
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, final
+from typing import TYPE_CHECKING, ClassVar, TypeVar, final
 
 from rich._log_render import LogRender
 from rich.console import Console, Group
@@ -27,10 +27,12 @@ logger = logging.getLogger("cyberdrop_dl")
 for noisy_package in ("aiosqlite",):
     logging.getLogger(noisy_package).setLevel(logging.ERROR)
 
-
+_T = TypeVar("_T")
 _USER_NAME = Path.home().name
 _DEFAULT_CONSOLE_WIDTH = 240
 _MAIN_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_MAIN_LOGGER_LISTENER")
+_CONSOLE_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_CONSOLE_LOGGER_LISTENER")
+
 MAIN_LOG_FILE: ContextVar[Path] = ContextVar("_MAIN_LOGGER_FILE")
 LOG_TO_CONSOLE: ContextVar[bool] = ContextVar("LOG_TO_CONSOLE", default=True)
 
@@ -171,26 +173,36 @@ class BareQueueHandler(QueueHandler):
 
 
 @contextlib.contextmanager
-def _threaded_logger(log_handler: logging.Handler, *, is_main_log: bool = False) -> Generator[None]:
+def _threaded_logger(
+    log_handler: logging.Handler, *, context_var: ContextVar[QueueListener] | None = None
+) -> Generator[BareQueueHandler]:
     """Context-manager to process logs from this handler in another thread"""
     q: queue.Queue[logging.LogRecord] = queue.Queue()
     q_handler: BareQueueHandler = BareQueueHandler(q)
     q_listener: QueueListener = QueueListener(q, log_handler, respect_handler_level=True)
     q_listener.start()
-    token = _MAIN_LOG_LISTENER.set(q_listener) if is_main_log else None
-    logging.getLogger().addHandler(q_handler)
+
+    with _enter_context(context_var, q_listener) if context_var else contextlib.nullcontext():
+        logging.getLogger().addHandler(q_handler)
+        try:
+            yield q_handler
+        finally:
+            logging.getLogger().removeHandler(q_handler)
+            try:
+                q_handler.close()
+            finally:
+                q_listener.stop()
+                for handler in q_listener.handlers[:]:
+                    handler.close()
+
+
+@contextlib.contextmanager
+def _enter_context(context_var: ContextVar[_T], value: _T) -> Generator[None]:
+    token = context_var.set(value)
     try:
         yield
     finally:
-        logging.getLogger().removeHandler(q_handler)
-        try:
-            q_handler.close()
-        finally:
-            q_listener.stop()
-            for handler in q_listener.handlers[:]:
-                handler.close()
-            if token is not None:
-                _MAIN_LOG_LISTENER.reset(token)
+        context_var.reset(token)
 
 
 @final
@@ -274,9 +286,9 @@ def log_spacer(char: str = "-") -> None:
 def setup_console_logging(level: int = logging.INFO) -> Generator[None]:
     handler = LogHandler(level, show_time=False)
     logging.getLogger().setLevel(logging.DEBUG)
-    handler.addFilter(lambda _: LOG_TO_CONSOLE.get())
     try:
-        with _threaded_logger(handler):
+        with _threaded_logger(handler, context_var=_CONSOLE_LOG_LISTENER) as q_handler:
+            q_handler.addFilter(lambda _: LOG_TO_CONSOLE.get())
             yield
     finally:
         # Re add it as a normal handler to make sure uncatched exceptions show up
@@ -290,12 +302,12 @@ def setup_file_logging(file: Path, /, level: int = logging.DEBUG) -> Generator[N
         _setup_debug_logger() as debug_log_file,
         file.open("w", encoding="utf8") as fp,
         _threaded_logger(
-            is_main_log=True,
             log_handler=LogHandler(
                 level,
                 show_time=True,
                 console=RedactedConsole(file=fp, width=_DEFAULT_CONSOLE_WIDTH * 2),
             ),
+            context_var=_MAIN_LOG_LISTENER,
         ),
     ):
         logger.info(f"Debug log file: {debug_log_file}")

--- a/cyberdrop_dl/logs.py
+++ b/cyberdrop_dl/logs.py
@@ -33,7 +33,7 @@ _DEFAULT_CONSOLE_WIDTH = 240
 _MAIN_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_MAIN_LOGGER_LISTENER")
 _CONSOLE_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_CONSOLE_LOGGER_LISTENER")
 
-MAIN_LOG_FILE: ContextVar[Path] = ContextVar("_MAIN_LOGGER_FILE")
+MAIN_LOG_FILE: ContextVar[Path] = ContextVar("MAIN_LOG_FILE")
 _LOG_TO_CONSOLE: ContextVar[bool] = ContextVar("LOG_TO_CONSOLE", default=True)
 
 
@@ -283,7 +283,7 @@ def log_spacer(char: str = "-") -> None:
 
 
 @contextlib.contextmanager
-def setup_console_logging(level: int = logging.INFO) -> Generator[None]:
+def setup_console_logging(level: int = logging.INFO, *, remove: bool = False) -> Generator[None]:
     handler = LogHandler(level, show_time=False)
     logging.getLogger().setLevel(logging.DEBUG)
     try:
@@ -291,8 +291,9 @@ def setup_console_logging(level: int = logging.INFO) -> Generator[None]:
             q_handler.addFilter(lambda _: _LOG_TO_CONSOLE.get())
             yield
     finally:
-        # Re add it as a normal handler to make sure uncatched exceptions show up
-        logging.getLogger().addHandler(handler)
+        if not remove:
+            # Re add it as a normal handler to make sure uncatched exceptions show up
+            logging.getLogger().addHandler(handler)
 
 
 @contextlib.contextmanager

--- a/cyberdrop_dl/logs.py
+++ b/cyberdrop_dl/logs.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 import logging
 import queue
+import sys
 from contextvars import ContextVar
 from datetime import datetime
 from io import StringIO
@@ -283,7 +284,7 @@ def log_spacer(char: str = "-") -> None:
 
 
 @contextlib.contextmanager
-def setup_console_logging(level: int = logging.INFO, *, remove: bool = False) -> Generator[None]:
+def setup_console_logging(level: int = logging.INFO) -> Generator[None]:
     handler = LogHandler(level, show_time=False)
     logging.getLogger().setLevel(logging.DEBUG)
     try:
@@ -291,7 +292,7 @@ def setup_console_logging(level: int = logging.INFO, *, remove: bool = False) ->
             q_handler.addFilter(lambda _: _LOG_TO_CONSOLE.get())
             yield
     finally:
-        if not remove:
+        if "pytest" not in sys.modules:
             # Re add it as a normal handler to make sure uncatched exceptions show up
             logging.getLogger().addHandler(handler)
 

--- a/cyberdrop_dl/logs.py
+++ b/cyberdrop_dl/logs.py
@@ -22,7 +22,10 @@ from typing_extensions import override
 from cyberdrop_dl import env
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator, Iterable
+
+    from rich.console import ConsoleRenderable
+
 
 logger = logging.getLogger("cyberdrop_dl")
 for noisy_package in ("aiosqlite",):
@@ -31,17 +34,11 @@ for noisy_package in ("aiosqlite",):
 _T = TypeVar("_T")
 _USER_NAME = Path.home().name
 _DEFAULT_CONSOLE_WIDTH = 240
-_MAIN_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_MAIN_LOGGER_LISTENER")
-_CONSOLE_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_CONSOLE_LOGGER_LISTENER")
-
-MAIN_LOG_FILE: ContextVar[Path] = ContextVar("MAIN_LOG_FILE")
+_MAIN_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_MAIN_LOG_LISTENER")
+_CONSOLE_LOG_LISTENER: ContextVar[QueueListener] = ContextVar("_CONSOLE_LOG_LISTENER")
 _LOG_TO_CONSOLE: ContextVar[bool] = ContextVar("LOG_TO_CONSOLE", default=True)
 
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
-
-    from rich.console import ConsoleRenderable
+MAIN_LOG_FILE: ContextVar[Path] = ContextVar("MAIN_LOG_FILE")
 
 
 class RedactedConsole(Console):
@@ -303,6 +300,7 @@ def setup_file_logging(file: Path, /, level: int = logging.DEBUG) -> Generator[N
     with (
         _setup_debug_logger() as debug_log_file,
         file.open("w", encoding="utf8") as fp,
+        _enter_context(MAIN_LOG_FILE, file),
         _threaded_logger(
             log_handler=LogHandler(
                 level,
@@ -313,11 +311,7 @@ def setup_file_logging(file: Path, /, level: int = logging.DEBUG) -> Generator[N
         ),
     ):
         logger.info(f"Debug log file: {debug_log_file}")
-        token = MAIN_LOG_FILE.set(file)
-        try:
-            yield
-        finally:
-            MAIN_LOG_FILE.reset(token)
+        yield
 
 
 @contextlib.contextmanager
@@ -392,7 +386,7 @@ def disable_console_logging():
     else:
         listener.stop()
         listener.start()
-    return _enter_context(_LOG_TO_CONSOLE, False)
+    return _enter_context(_LOG_TO_CONSOLE, value=False)
 
 
 @contextlib.contextmanager

--- a/cyberdrop_dl/progress/__init__.py
+++ b/cyberdrop_dl/progress/__init__.py
@@ -93,13 +93,13 @@ class LiveUI(ABC):
     def __rich__(self) -> RenderableType: ...
 
     @contextlib.contextmanager
-    def __call__(self, *, transient: bool = True) -> Generator[None]:
+    def __call__(self, *, transient: bool = True, force: bool = False) -> Generator[None]:
         if self.disabled:
             yield
             return
 
         with disable_console_logging():
-            if "pytest" in sys.modules:
+            if "pytest" in sys.modules and not force:
                 yield
                 return
 

--- a/cyberdrop_dl/progress/__init__.py
+++ b/cyberdrop_dl/progress/__init__.py
@@ -12,7 +12,7 @@ from rich.markup import escape
 from rich.progress import Progress, Task, TaskID
 from rich.text import Text
 
-from cyberdrop_dl.logs import LOG_TO_CONSOLE
+from cyberdrop_dl.logs import disable_console_logging
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable
@@ -94,12 +94,15 @@ class LiveUI(ABC):
 
     @contextlib.contextmanager
     def __call__(self, *, transient: bool = True) -> Generator[None]:
-        if self.disabled or "pytest" in sys.modules:
-            yield None
+        if self.disabled:
+            yield
             return
 
-        console_token = LOG_TO_CONSOLE.set(False)
-        try:
+        with disable_console_logging():
+            if "pytest" in sys.modules:
+                yield None
+                return
+
             with Live(
                 refresh_per_second=REFRESH_RATE.get(),
                 auto_refresh=True,
@@ -108,5 +111,3 @@ class LiveUI(ABC):
                 get_renderable=self.__rich__,
             ):
                 yield
-        finally:
-            LOG_TO_CONSOLE.reset(console_token)

--- a/cyberdrop_dl/progress/__init__.py
+++ b/cyberdrop_dl/progress/__init__.py
@@ -94,7 +94,7 @@ class LiveUI(ABC):
 
     @contextlib.contextmanager
     def __call__(self, *, transient: bool = True, force: bool = False) -> Generator[None]:
-        if self.disabled:
+        if self.disabled and not force:
             yield
             return
 

--- a/cyberdrop_dl/progress/__init__.py
+++ b/cyberdrop_dl/progress/__init__.py
@@ -100,7 +100,7 @@ class LiveUI(ABC):
 
         with disable_console_logging():
             if "pytest" in sys.modules:
-                yield None
+                yield
                 return
 
             with Live(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -70,7 +70,7 @@ def test_disable_console_logging() -> None:
     logger = logging.getLogger("cyberdrop_dl")
     console = get_console()
     console.record = True
-    with console, logs.setup_console_logging(remove=True):
+    with console, logs.setup_console_logging():
         logger.info("This msg should show up")
         with logs.disable_console_logging():
             logger.info("This msg should not show up")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -71,13 +71,13 @@ def test_disable_console_logging() -> None:
     console = get_console()
     console.record = True
     with console, logs.setup_console_logging():
-        logger.info("This msg should show up")
+        logger.info("This msg SHOULD show up")
         with logs.disable_console_logging():
-            logger.info("This msg should not show up")
+            logger.info("This msg SHOULD NOT show up")
 
-        logger.info("This msg should show up as well")
+        logger.info("This msg also SHOULD show up")
 
     text = console.export_text()
-    assert "This msg should show up" in text
-    assert "This msg should not show up" not in text
-    assert "This msg should show up as well" in text
+    assert "This msg SHOULD show up" in text
+    assert "This msg SHOULD NOT show up" not in text
+    assert "This msg also SHOULD show up" in text

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -2,8 +2,10 @@ import logging
 from pathlib import Path
 
 import pytest
+from rich import get_console
 
 from cyberdrop_dl import logs
+from cyberdrop_dl.progress import LiveUI
 
 TEXT = "\n".join(f"line {idx}" for idx in range(1, 5))
 
@@ -65,7 +67,6 @@ class TestBorrowLogger:
 
 
 def test_disable_console_logging() -> None:
-    from rich import get_console
 
     logger = logging.getLogger("cyberdrop_dl")
     console = get_console()
@@ -78,6 +79,29 @@ def test_disable_console_logging() -> None:
         logger.info("This msg also SHOULD show up")
 
     text = console.export_text()
+    assert "This msg SHOULD show up" in text
+    assert "This msg SHOULD NOT show up" not in text
+    assert "This msg also SHOULD show up" in text
+
+
+def test_entering_a_live_disables_console_logging() -> None:
+    logger = logging.getLogger("cyberdrop_dl")
+    console = get_console()
+    console.record = True
+
+    class DummyLiveUI(LiveUI):
+        def __rich__(self):
+            return "In Live"
+
+    with console, logs.setup_console_logging():
+        logger.info("This msg SHOULD show up")
+        with DummyLiveUI()(transient=False, force=True):
+            logger.info("This msg SHOULD NOT show up")
+
+        logger.info("This msg also SHOULD show up")
+
+    text = console.export_text()
+    assert "In Live" in text
     assert "This msg SHOULD show up" in text
     assert "This msg SHOULD NOT show up" not in text
     assert "This msg also SHOULD show up" in text

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -62,3 +62,22 @@ class TestBorrowLogger:
 
         assert other.handlers == [orig_handler]
         assert other.level == logging.CRITICAL
+
+
+def test_disable_console_logging() -> None:
+    from rich import get_console
+
+    logger = logging.getLogger("cyberdrop_dl")
+    console = get_console()
+    console.record = True
+    with console, logs.setup_console_logging(remove=True):
+        logger.info("This msg should show up")
+        with logs.disable_console_logging():
+            logger.info("This msg should not show up")
+
+        logger.info("This msg should show up as well")
+
+    text = console.export_text()
+    assert "This msg should show up" in text
+    assert "This msg should not show up" not in text
+    assert "This msg should show up as well" in text


### PR DESCRIPTION
We need to filter on the queued handler. The raw handler filter runs on a different thread which is not aware of when/if the UI from the main thread is running (different context vars)

- Related to #1705 