### PR TITLE
refactor: Refactor Download Management to Prevent Task Starvation

### DIFF
--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -7,7 +7,6 @@ import datetime
 import importlib
 import logging
 import pkgutil
-import random
 import re
 import weakref
 from abc import ABC, abstractmethod
@@ -449,23 +448,11 @@ class Crawler(HTTPClientProxy, HLSParser, ABC):
             "Referer": str(scrape_item.url),
         }
 
-    async def _fake_download(self, media_item: MediaItem) -> None:
-        with self.manager.scrape_mapper.tui.downloads.download_file(
-            media_item.filename,
-            media_item.domain,
-            total=(steps := int(1e10)),
-        ) as hook:
-            for _ in range(steps):
-                hook.advance(random.randint(0, int(1e4)))
-                await asyncio.sleep(0)
-
     @final
     async def _download(self, media_item: MediaItem, m3u8: m3u8.Rendition | None) -> None:
         try:
             if SKIP_DOWNLOAD.get():
                 return
-
-            return await self._fake_download(media_item)
 
             if m3u8:
                 await self.downloader.download_hls(media_item, m3u8)

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -7,6 +7,7 @@ import datetime
 import importlib
 import logging
 import pkgutil
+import random
 import re
 import weakref
 from abc import ABC, abstractmethod
@@ -448,11 +449,24 @@ class Crawler(HTTPClientProxy, HLSParser, ABC):
             "Referer": str(scrape_item.url),
         }
 
+    async def _fake_download(self, media_item: MediaItem) -> None:
+        with self.manager.scrape_mapper.tui.downloads.download_file(
+            media_item.filename,
+            media_item.domain,
+            total=(steps := int(1e10)),
+        ) as hook:
+            for _ in range(steps):
+                hook.advance(random.randint(0, int(1e4)))
+                await asyncio.sleep(0)
+
     @final
     async def _download(self, media_item: MediaItem, m3u8: m3u8.Rendition | None) -> None:
         try:
             if SKIP_DOWNLOAD.get():
                 return
+
+            return await self._fake_download(media_item)
+
             if m3u8:
                 await self.downloader.download_hls(media_item, m3u8)
             else:

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -219,10 +219,16 @@ class ScrapeMapper:
 
                         yield self
 
-                finally:
+                except BaseException:
+                    dispatcher.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await dispatcher
+                    raise
+                else:
                     self._done.set()
                     await self._pending_downloads.put(None)
                     await dispatcher
+                finally:
                     loop.set_task_factory(previous_factory)
 
     async def run(self) -> ScrapeStats:

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -6,7 +6,6 @@ import dataclasses
 import datetime
 import logging
 import re
-import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeVar
@@ -161,31 +160,25 @@ class ScrapeMapper:
 
         plugins.load(self.manager)
 
+    async def _download_worker(self) -> None:
+        while True:
+            coro = await self._pending_downloads.get()
+            if coro is None:
+                break
+            await coro
+
     async def _download_dispatcher(self) -> None:
-        active: set[asyncio.Task[None]] = set()
+        workers: list[asyncio.Task[None]] = []
         try:
-            while not self._done.is_set():
-                coro = await self._pending_downloads.get()
-                if coro is None:
-                    break
-                task = asyncio.create_task(coro)
-                active.add(task)
-                task.add_done_callback(active.discard)
-
+            max_workers = self.manager.config.global_settings.rate_limiting_options.max_simultaneous_downloads
+            workers = [asyncio.create_task(self._download_worker()) for _ in range(max_workers)]
+            await self._done.wait()
             self.tui.hide_scrape_panel()
-
-            while not self._pending_downloads.empty():
-                coro = self._pending_downloads.get_nowait()
-                if coro is not None:
-                    task = asyncio.create_task(coro)
-                    active.add(task)
-                    task.add_done_callback(active.discard)
-
-            if active:
-                await asyncio.gather(*active)
-
+            for _ in workers:
+                await self._pending_downloads.put(None)
+            await asyncio.gather(*workers)
         except (asyncio.CancelledError, KeyboardInterrupt):
-            for task in active:
+            for task in workers:
                 task.cancel()
             while not self._pending_downloads.empty():
                 coro = self._pending_downloads.get_nowait()
@@ -208,10 +201,6 @@ class ScrapeMapper:
                 storage.monitor(self.manager.config.global_settings.general.required_free_space),
                 self.manager.logs.task_group,
             ):
-                loop = asyncio.get_running_loop()
-                previous_factory = loop.get_task_factory()
-                if sys.version_info >= (3, 12):
-                    loop.set_task_factory(asyncio.eager_task_factory)
                 dispatcher = asyncio.create_task(self._download_dispatcher())
                 try:
                     async with self._task_groups.scrape:
@@ -226,10 +215,7 @@ class ScrapeMapper:
                     raise
                 else:
                     self._done.set()
-                    await self._pending_downloads.put(None)
                     await dispatcher
-                finally:
-                    loop.set_task_factory(previous_factory)
 
     async def run(self) -> ScrapeStats:
         self._init_crawlers()

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -131,7 +131,7 @@ class ScrapeMapper:
         return sum(f.waiting_items for f in self._factory)
 
     def _download_queue(self):
-        total = sum(f.downloader.waiting_items for f in self._factory)
+        total = sum(f.downloader.waiting_items for f in self._factory) + self._pending_downloads.qsize()
         self.tui.files.stats.queued = total
         return total
 

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -105,7 +105,6 @@ class ScrapeStats:
 @dataclasses.dataclass(slots=True)
 class TaskGroups:
     scrape: asyncio.TaskGroup
-    downloads: asyncio.TaskGroup
 
 
 @dataclasses.dataclass(slots=True)
@@ -119,7 +118,7 @@ class ScrapeMapper:
     _jdownloader: JDownloader = dataclasses.field(init=False)
     _real_debrid: RealDebridCrawler = dataclasses.field(init=False)
     _task_groups: TaskGroups = dataclasses.field(
-        init=False, default_factory=lambda: TaskGroups(asyncio.TaskGroup(), asyncio.TaskGroup())
+        init=False, default_factory=lambda: TaskGroups(asyncio.TaskGroup())
     )
     _seen_urls: set[AbsoluteHttpURL] = dataclasses.field(init=False, default_factory=set)
     _crawlers_disabled_at_runtime: set[str] = dataclasses.field(init=False, default_factory=set)
@@ -191,8 +190,8 @@ class ScrapeMapper:
                 self.manager.client_manager,
                 storage.monitor(self.manager.config.global_settings.general.required_free_space),
                 self.manager.logs.task_group,
-                self._task_groups.downloads,
             ):
+                dispatcher = asyncio.create_task(self._download_dispatcher())
                 try:
                     async with self._task_groups.scrape:
                         self.manager.scrape_mapper = self
@@ -200,8 +199,9 @@ class ScrapeMapper:
                         yield self
 
                 finally:
-                    # The done event signals that all scraping is done, but there may still be downloads pending
                     self._done.set()
+                    await self._pending_downloads.put(None)
+                    await dispatcher
 
     async def run(self) -> ScrapeStats:
         self._init_crawlers()

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -220,6 +220,7 @@ class ScrapeMapper:
         source_name, source = _source(self.manager)
         async with contextlib.aclosing(source) as items:
             stats = ScrapeStats(source_name)
+            background_tasks = set()
 
             async def wait_until_scrape_is_done() -> None:
                 _ = await self._done.wait()
@@ -228,7 +229,8 @@ class ScrapeMapper:
                     (crawler.DOMAIN, count) for crawler in self._factory if (count := len(crawler._scraped_items))
                 )
 
-            _ = asyncio.create_task(wait_until_scrape_is_done())
+            task = asyncio.create_task(wait_until_scrape_is_done())
+            background_tasks.add(task)
 
             async for item in items:
                 item.children_limits = self.manager.config.settings.download_options.maximum_number_of_children

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -163,28 +163,37 @@ class ScrapeMapper:
 
     async def _download_dispatcher(self) -> None:
         active: set[asyncio.Task[None]] = set()
-
-        while not self._done.is_set():
-            coro = await self._pending_downloads.get()
-            if coro is None:
-                break
-            task = asyncio.create_task(coro)
-            active.add(task)
-            task.add_done_callback(active.discard)
-
-        self.tui.hide_scrape_panel()
-
-        while not self._pending_downloads.empty():
-            coro = self._pending_downloads.get_nowait()
-            if coro is not None:
+        try:
+            while not self._done.is_set():
+                coro = await self._pending_downloads.get()
+                if coro is None:
+                    break
                 task = asyncio.create_task(coro)
                 active.add(task)
                 task.add_done_callback(active.discard)
 
-        if active:
-            async with asyncio.TaskGroup() as tg:
-                for pending in active:
-                    tg.create_task(asyncio.shield(pending))
+            self.tui.hide_scrape_panel()
+
+            while not self._pending_downloads.empty():
+                coro = self._pending_downloads.get_nowait()
+                if coro is not None:
+                    task = asyncio.create_task(coro)
+                    active.add(task)
+                    task.add_done_callback(active.discard)
+
+            if active:
+                async with asyncio.TaskGroup() as tg:
+                    for pending in active:
+                        tg.create_task(asyncio.shield(pending))
+
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            for task in active:
+                task.cancel()
+            while not self._pending_downloads.empty():
+                coro = self._pending_downloads.get_nowait()
+                if coro is not None:
+                    coro.close()
+            raise
 
     @contextlib.asynccontextmanager
     async def __call__(self) -> AsyncGenerator[Self]:

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -182,9 +182,7 @@ class ScrapeMapper:
                     task.add_done_callback(active.discard)
 
             if active:
-                async with asyncio.TaskGroup() as tg:
-                    for pending in active:
-                        tg.create_task(asyncio.shield(pending))
+                await asyncio.gather(*active)
 
         except (asyncio.CancelledError, KeyboardInterrupt):
             for task in active:

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -163,7 +163,7 @@ class ScrapeMapper:
     async def _download_dispatcher(self) -> None:
         active: set[asyncio.Task[None]] = set()
 
-        while True:
+        while not self._done.is_set():
             coro = await self._pending_downloads.get()
             if coro is None:
                 break
@@ -171,8 +171,17 @@ class ScrapeMapper:
             active.add(task)
             task.add_done_callback(active.discard)
 
+        while not self._pending_downloads.empty():
+            coro = self._pending_downloads.get_nowait()
+            if coro is not None:
+                task = asyncio.create_task(coro)
+                active.add(task)
+                task.add_done_callback(active.discard)
+
         if active:
-            await asyncio.gather(*active, return_exceptions=True)
+            async with asyncio.TaskGroup() as tg:
+                for pending in active:
+                    tg.create_task(asyncio.shield(pending))
 
     @contextlib.asynccontextmanager
     async def __call__(self) -> AsyncGenerator[Self]:

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -163,6 +163,20 @@ class ScrapeMapper:
 
         plugins.load(self.manager)
 
+    async def _download_dispatcher(self) -> None:
+        active: set[asyncio.Task[None]] = set()
+
+        while True:
+            coro = await self._pending_downloads.get()
+            if coro is None:
+                break
+            task = asyncio.create_task(coro)
+            active.add(task)
+            task.add_done_callback(active.discard)
+
+        if active:
+            await asyncio.gather(*active, return_exceptions=True)
+
     @contextlib.asynccontextmanager
     async def __call__(self) -> AsyncGenerator[Self]:
         assert not self._done.is_set()

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -171,6 +171,8 @@ class ScrapeMapper:
             active.add(task)
             task.add_done_callback(active.discard)
 
+        self.tui.hide_scrape_panel()
+
         while not self._pending_downloads.empty():
             coro = self._pending_downloads.get_nowait()
             if coro is not None:
@@ -227,17 +229,6 @@ class ScrapeMapper:
         source_name, source = _source(self.manager)
         async with contextlib.aclosing(source) as items:
             stats = ScrapeStats(source_name)
-            background_tasks = set()
-
-            async def wait_until_scrape_is_done() -> None:
-                _ = await self._done.wait()
-                self.tui.hide_scrape_panel()
-                stats.url_count.update(
-                    (crawler.DOMAIN, count) for crawler in self._factory if (count := len(crawler._scraped_items))
-                )
-
-            task = asyncio.create_task(wait_until_scrape_is_done())
-            background_tasks.add(task)
 
             async for item in items:
                 item.children_limits = self.manager.config.settings.download_options.maximum_number_of_children
@@ -246,6 +237,10 @@ class ScrapeMapper:
                         break
                     stats.update(item)
                     self.create_task(self._send_to_crawler(item))
+
+        stats.url_count.update(
+            (crawler.DOMAIN, count) for crawler in self._factory if (count := len(crawler._scraped_items))
+        )
 
         if not stats.count:
             logger.warning("No valid links found")

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -117,9 +117,7 @@ class ScrapeMapper:
     _direct_http: DirectHttpFile = dataclasses.field(init=False)
     _jdownloader: JDownloader = dataclasses.field(init=False)
     _real_debrid: RealDebridCrawler = dataclasses.field(init=False)
-    _task_groups: TaskGroups = dataclasses.field(
-        init=False, default_factory=lambda: TaskGroups(asyncio.TaskGroup())
-    )
+    _task_groups: TaskGroups = dataclasses.field(init=False, default_factory=lambda: TaskGroups(asyncio.TaskGroup()))
     _seen_urls: set[AbsoluteHttpURL] = dataclasses.field(init=False, default_factory=set)
     _crawlers_disabled_at_runtime: set[str] = dataclasses.field(init=False, default_factory=set)
     _factory: CrawlerFactory = dataclasses.field(init=False)

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -6,6 +6,7 @@ import dataclasses
 import datetime
 import logging
 import re
+import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeVar
@@ -200,6 +201,10 @@ class ScrapeMapper:
                 storage.monitor(self.manager.config.global_settings.general.required_free_space),
                 self.manager.logs.task_group,
             ):
+                loop = asyncio.get_running_loop()
+                previous_factory = loop.get_task_factory()
+                if sys.version_info >= (3, 12):
+                    loop.set_task_factory(asyncio.eager_task_factory)
                 dispatcher = asyncio.create_task(self._download_dispatcher())
                 try:
                     async with self._task_groups.scrape:
@@ -211,6 +216,7 @@ class ScrapeMapper:
                     self._done.set()
                     await self._pending_downloads.put(None)
                     await dispatcher
+                    loop.set_task_factory(previous_factory)
 
     async def run(self) -> ScrapeStats:
         self._init_crawlers()

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -228,7 +228,7 @@ class ScrapeMapper:
                     (crawler.DOMAIN, count) for crawler in self._factory if (count := len(crawler._scraped_items))
                 )
 
-            self.create_download_task(wait_until_scrape_is_done())
+            _ = asyncio.create_task(wait_until_scrape_is_done())
 
             async for item in items:
                 item.children_limits = self.manager.config.settings.download_options.maximum_number_of_children

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -126,6 +126,9 @@ class ScrapeMapper:
     _factory: CrawlerFactory = dataclasses.field(init=False)
     tui: ScrapingUI = dataclasses.field(init=False, default_factory=ScrapingUI)
     _done: asyncio.Event = dataclasses.field(init=False, default_factory=asyncio.Event)
+    _pending_downloads: asyncio.Queue[Coroutine[Any, Any, Any] | None] = dataclasses.field(
+        init=False, default_factory=asyncio.Queue
+    )
 
     def _scrape_queue(self) -> int:
         return sum(f.waiting_items for f in self._factory)
@@ -147,7 +150,7 @@ class ScrapeMapper:
         _ = self._task_groups.scrape.create_task(coro)
 
     def create_download_task(self, coro: Coroutine[Any, Any, _T]) -> None:
-        _ = self._task_groups.downloads.create_task(coro)
+        self._pending_downloads.put_nowait(coro)
 
     def _init_crawlers(self) -> None:
 


### PR DESCRIPTION
This is my take on trying to solve #1702 

Replaces the TaskGroup in scrape_mapper.py with an unbounded asyncio. Queue and a background Task Dispatcher. This architectural shift ensures that file downloads are scheduled immediately, solving the starvation issues encountered when scraping high volumes of data.

Instead of batching downloads within a TaskGroup, we now pipe them into an internal queue. A dedicated dispatcher task consumes this queue in a loop, spawning a new independent asyncio.Task for every download.

- Immediate Start: Downloads begin the moment the scraper identifies a file.
- Fair Scheduling: Each download is an independent task, preventing the scraper loop from "starving" the download processes.
- Controlled Concurrency: We still rely on the existing three-level semaphore system (server, domain, global) to handle rate limiting.
- Graceful Shutdown: The system uses a None sentinel to signal the dispatcher to stop only after the queue is empty.
-  Minimal Footprint: Changes are localized to scrape_mapper.py.

# Discarded Approaches

- Fixed Worker Pool: Rejected because a few workers stuck on a single domain's semaphore would block downloads for all other domains (head-of-line blocking).
- asyncio.PriorityQueue: Rejected because asyncio doesn't support native task-level priority. Reimplementing the scheduler would be overly invasive and could lead to scraper starvation.
- Scraping Semaphore: Rejected because limiting scraping tasks reduces overall throughput without fixing the underlying scheduling conflict.
- Thread Pool: Rejected because downloads are I/O-bound and already use aiohttp. Adding threads would break integration with existing asyncio semaphores and introduce unnecessary complexity.