### PR TITLE
fix: make a value for `--impersonate` mandatory

### DIFF
--- a/cyberdrop_dl/cli.py
+++ b/cyberdrop_dl/cli.py
@@ -67,7 +67,6 @@ class CLIargs(BaseModel):
             "chrome_android",
             "firefox",
         ]
-        | bool
         | None
     ) = Field(
         default=None,


### PR DESCRIPTION
cyclopts does not support optional conditional flags

- Fixes #1777