### PR TITLE
refactor: remove client manager (part1)

### DIFF
--- a/cyberdrop_dl/clients/__init__.py
+++ b/cyberdrop_dl/clients/__init__.py
@@ -82,10 +82,9 @@ class HTTPClient:
 
     @contextlib.asynccontextmanager
     async def _limiter(self, domain: str) -> AsyncGenerator[None]:
-        with self.client_manager.request_context(domain):
-            domain_limiter = self.client_manager.get_rate_limiter(domain)
-            async with self.client_manager.global_rate_limiter, domain_limiter:
-                yield
+        domain_limiter = self.client_manager.get_rate_limiter(domain)
+        async with self.client_manager.global_rate_limiter, domain_limiter:
+            yield
 
     def _prepare_headers(self, headers: Mapping[str, str] | None = None) -> CIMultiDict[str]:
         """Add default headers and transform it to CIMultiDict"""

--- a/cyberdrop_dl/clients/__init__.py
+++ b/cyberdrop_dl/clients/__init__.py
@@ -167,7 +167,7 @@ class HTTPClient:
         The reverse (sync `aiohttp` -> `curl`) is not needed at the moment, so it is skipped
         """
         now = time.time()
-        for cookie in self.client_manager._curl_session.cookies.jar:
+        for cookie in self.client_manager.curl_session.cookies.jar:
             simple_cookie = make_simple_cookie(cookie, now)
             self.client_manager.cookies.update_cookies(simple_cookie, url)
 
@@ -192,7 +192,7 @@ class HTTPClient:
         try:
             if impersonate:
                 async with contextlib.aclosing(
-                    await self.client_manager._curl_session.request(method, str(url), stream=True, **request_params)
+                    await self.client_manager.curl_session.request(method, str(url), stream=True, **request_params)
                 ) as curl_resp:
                     resp = AbstractResponse.create(curl_resp)
                     yield resp

--- a/cyberdrop_dl/clients/__init__.py
+++ b/cyberdrop_dl/clients/__init__.py
@@ -4,7 +4,6 @@ import asyncio
 import contextlib
 import dataclasses
 import logging
-import platform
 import time
 import uuid
 from pathlib import Path
@@ -15,7 +14,7 @@ from multidict import CIMultiDict
 from cyberdrop_dl import constants, ddos_guard, signature
 from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.cookies import make_simple_cookie
-from cyberdrop_dl.exceptions import DDOSGuardError, ScrapeError
+from cyberdrop_dl.exceptions import DDOSGuardError
 from cyberdrop_dl.utils import truncated_preview
 from cyberdrop_dl.utils.filepath import sanitize_filename
 
@@ -28,12 +27,6 @@ if TYPE_CHECKING:
     from cyberdrop_dl.clients import flaresolverr
     from cyberdrop_dl.managers.client_manager import ClientManager
     from cyberdrop_dl.url_objects import AbsoluteHttpURL
-
-_curl_import_error = None
-try:
-    from curl_cffi.requests import AsyncSession  # pyright: ignore[reportUnusedImport]  # noqa: F401
-except ImportError as e:
-    _curl_import_error = e
 
 
 logger = logging.getLogger(__name__)
@@ -131,7 +124,6 @@ class HTTPClient:
 
         impersonate = self.client_manager.manager.cli_args.impersonate or impersonate
         if impersonate:
-            _check_curl_cffi_is_available()
             if impersonate is True:
                 impersonate = "chrome"
             request_params["impersonate"] = impersonate
@@ -324,14 +316,3 @@ class HTTPClientProxy:
     async def request_text(self, *args, **kwargs) -> str:
         async with self.request(*args, **kwargs) as resp:
             return await resp.text()
-
-
-def _check_curl_cffi_is_available() -> None:
-    if _curl_import_error is None:
-        return
-
-    msg = (
-        f"curl_cffi is required to scrape this URL but a dependency it's not available on {platform.system()}.\n"
-        f"See: https://github.com/lexiforest/curl_cffi/issues/74#issuecomment-1849365636\n{_curl_import_error!r}"
-    )
-    raise ScrapeError("Missing Dependency", msg)

--- a/cyberdrop_dl/clients/__init__.py
+++ b/cyberdrop_dl/clients/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import dataclasses
 import logging
+import platform
 import time
 import uuid
 from pathlib import Path
@@ -14,7 +15,7 @@ from multidict import CIMultiDict
 from cyberdrop_dl import constants, ddos_guard, signature
 from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.cookies import make_simple_cookie
-from cyberdrop_dl.exceptions import DDOSGuardError
+from cyberdrop_dl.exceptions import DDOSGuardError, ScrapeError
 from cyberdrop_dl.utils import truncated_preview
 from cyberdrop_dl.utils.filepath import sanitize_filename
 
@@ -27,6 +28,12 @@ if TYPE_CHECKING:
     from cyberdrop_dl.clients import flaresolverr
     from cyberdrop_dl.managers.client_manager import ClientManager
     from cyberdrop_dl.url_objects import AbsoluteHttpURL
+
+_curl_import_error = None
+try:
+    from curl_cffi.requests import AsyncSession  # pyright: ignore[reportUnusedImport]  # noqa: F401
+except ImportError as e:
+    _curl_import_error = e
 
 
 logger = logging.getLogger(__name__)
@@ -124,7 +131,7 @@ class HTTPClient:
 
         impersonate = self.client_manager.manager.cli_args.impersonate or impersonate
         if impersonate:
-            self.client_manager.check_curl_cffi_is_available()
+            _check_curl_cffi_is_available()
             if impersonate is True:
                 impersonate = "chrome"
             request_params["impersonate"] = impersonate
@@ -317,3 +324,14 @@ class HTTPClientProxy:
     async def request_text(self, *args, **kwargs) -> str:
         async with self.request(*args, **kwargs) as resp:
             return await resp.text()
+
+
+def _check_curl_cffi_is_available() -> None:
+    if _curl_import_error is None:
+        return
+
+    msg = (
+        f"curl_cffi is required to scrape this URL but a dependency it's not available on {platform.system()}.\n"
+        f"See: https://github.com/lexiforest/curl_cffi/issues/74#issuecomment-1849365636\n{_curl_import_error!r}"
+    )
+    raise ScrapeError("Missing Dependency", msg)

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -99,7 +99,7 @@ class DownloadClient:
         media_item.filesize = int(resp.headers.get("Content-Length", "0")) or None
         if not media_item.path:
             proceed, skip = await self.get_final_file_info(media_item, domain)
-            self.client_manager.check_content_length(resp.headers)
+            _check_content_length(resp.headers)
             if skip:
                 self.manager.scrape_mapper.tui.files.stats.skipped += 1
                 return False
@@ -510,3 +510,13 @@ def _fallback_generator(media_item: MediaItem):
     gen = gen_fallback()
     _ = next(gen)
     return gen
+
+
+def _check_content_length(headers: Mapping[str, Any]) -> None:
+    content_length, content_type = headers.get("Content-Length"), headers.get("Content-Type")
+    if content_length is None or content_type is None:
+        return
+    if content_length == "322509" and content_type == "video/mp4":
+        raise DownloadError(status="Bunkr Maintenance", message="Bunkr under maintenance")
+    if content_length == "73003" and content_type == "video/mp4":
+        raise DownloadError(410)  # Placeholder video with text "Video removed" (efukt)

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -55,11 +55,6 @@ class DownloadClient:
 
         return self._server_locks[server]
 
-    @contextlib.asynccontextmanager
-    async def _track_errors(self, domain: str):
-        with self.client_manager.request_context(domain):
-            yield
-
     async def _download(self, domain: str, media_item: MediaItem) -> bool:
         """Downloads a file."""
         downloaded_filename = await self.manager.database.history.get_downloaded_filename(domain, media_item)
@@ -265,8 +260,7 @@ class DownloadClient:
             await self.process_completed(media_item, domain)
             return False
 
-        async with self._track_errors(domain):
-            downloaded = await self._download(domain, media_item)
+        downloaded = await self._download(domain, media_item)
 
         if downloaded:
             await aio.move(media_item.partial_file, media_item.path)

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -154,9 +154,9 @@ class DownloadClient:
     @contextlib.asynccontextmanager
     async def __request_context(
         self, url: AbsoluteHttpURL, domain: str, headers: dict[str, str]
-    ) -> AsyncGenerator[AbstractResponse | aiohttp.ClientResponse]:
+    ) -> AsyncGenerator[AbstractResponse[Any] | aiohttp.ClientResponse]:
         if domain in _USE_IMPERSONATION:
-            resp = await self.client_manager._curl_session.get(str(url), stream=True, headers=headers)
+            resp = await self.client_manager.curl_session.get(str(url), stream=True, headers=headers)
             try:
                 yield AbstractResponse.create(resp)
             finally:

--- a/cyberdrop_dl/crawlers/pixeldrain.py
+++ b/cyberdrop_dl/crawlers/pixeldrain.py
@@ -10,7 +10,7 @@ from cyberdrop_dl import env
 from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedDomains, SupportedPaths, auto_task_id
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
-from cyberdrop_dl.utils import error_handling_wrapper
+from cyberdrop_dl.utils import basic_auth, error_handling_wrapper
 
 if TYPE_CHECKING:
     from cyberdrop_dl.clients.response import AbstractResponse
@@ -108,10 +108,7 @@ class PixelDrainCrawler(Crawler):
     def __post_init__(self) -> None:
         self._headers: dict[str, str] = {}
         if api_key := self.manager.config.auth.pixeldrain.api_key:
-            self._headers["Authorization"] = self.manager.client_manager.basic_auth(
-                "Cyberdrop-DL",
-                api_key,
-            )
+            self._headers["Authorization"] = basic_auth("Cyberdrop-DL", api_key)
 
     @classmethod
     def __json_resp_check__(cls, json_resp: dict[str, Any], resp: AbstractResponse[Any]) -> None:

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -66,7 +66,7 @@ class Downloader:
 
         self._additional_headers = {}
         self._current_attempt_filesize: dict[str, int] = {}
-        self._file_lock_vault = manager.client_manager.file_locks
+        self._file_lock_vault = aio.WeakAsyncLocks()
         self._ignore_history = manager.config.settings.runtime_options.ignore_history
         self._semaphore: asyncio.Semaphore = field(init=False)
 

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -19,7 +19,6 @@ from cyberdrop_dl.exceptions import (
     RestrictedDateRangeError,
     RestrictedFiletypeError,
     SkipDownloadError,
-    TooManyCrawlerErrors,
 )
 from cyberdrop_dl.url_objects import HlsSegment, MediaItem
 from cyberdrop_dl.utils import dates, error_handling_wrapper, parse_url
@@ -326,11 +325,6 @@ class Downloader:
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
     async def start_download(self, media_item: MediaItem) -> bool:
-        try:
-            self.client.client_manager.check_domain_errors(self.domain)
-        except TooManyCrawlerErrors:
-            return False
-
         if not media_item.is_segment:
             logger.info(f"{self.log_prefix} starting: {media_item.url}")
 
@@ -347,7 +341,6 @@ class Downloader:
         if url_as_str in KNOWN_BAD_URLS:
             raise DownloadError(KNOWN_BAD_URLS[url_as_str])
         try:
-            self.client.client_manager.check_domain_errors(self.domain)
             media_item.attempts = media_item.attempts or 1
             if not media_item.is_segment:
                 media_item.duration = await self.manager.database.history.get_duration(self.domain, media_item)

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -23,10 +23,8 @@ from cyberdrop_dl.exceptions import (
 from cyberdrop_dl.url_objects import HlsSegment, MediaItem
 from cyberdrop_dl.utils import dates, error_handling_wrapper, parse_url
 
-logger = logging.getLogger(__name__)
-
-
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Generator
     from pathlib import Path
 
@@ -35,13 +33,15 @@ if TYPE_CHECKING:
     from cyberdrop_dl.manager import Manager
     from cyberdrop_dl.utils.m3u8 import M3U8, Rendition
 
+logger = logging.getLogger(__name__)
+
 
 class SegmentDownloadResult(NamedTuple):
     item: MediaItem
     downloaded: bool
 
 
-KNOWN_BAD_URLS = {
+_KNOWN_BAD_URLS = {
     "https://i.imgur.com/removed.png": 404,
     "https://saint2.su/assets/notfound.gif": 404,
     "https://bnkr.b-cdn.net/maintenance-vid.mp4": 503,
@@ -51,7 +51,7 @@ KNOWN_BAD_URLS = {
 }
 
 
-GENERIC_CRAWLERS = ".", "no_crawler"
+_GENERIC_CRAWLERS = ".", "no_crawler"
 
 
 class Downloader:
@@ -60,14 +60,13 @@ class Downloader:
         self.domain: str = domain
 
         self.client: DownloadClient = field(init=False)
-        self.log_prefix = "Download attempt (unsupported domain)" if domain in GENERIC_CRAWLERS else "Download"
-        self.processed_items: set[str] = set()
+        self._log_prefix = "Download attempt (unsupported domain)" if domain in _GENERIC_CRAWLERS else "Download"
+        self._processed_items: set[str] = set()
         self.waiting_items = 0
 
-        self._additional_headers = {}
         self._current_attempt_filesize: dict[str, int] = {}
-        self._file_lock_vault = aio.WeakAsyncLocks()
-        self._ignore_history = manager.config.settings.runtime_options.ignore_history
+        self._file_locks: aio.WeakAsyncLocks[str] = aio.WeakAsyncLocks()
+        self._ignore_history: bool = manager.config.settings.runtime_options.ignore_history
         self._semaphore: asyncio.Semaphore = field(init=False)
 
     @error_handling_wrapper
@@ -83,16 +82,16 @@ class Downloader:
                 if e.status != 999:
                     media_item.attempts += 1
 
-                logger.error(f"{self.log_prefix} failed: {media_item.url} with error: {e!s}")
+                logger.error(f"{self._log_prefix} failed: {media_item.url} with error: {e!s}")
                 if media_item.attempts >= self.max_attempts:
                     raise
 
                 logger.info(
-                    f"Retrying {self.log_prefix.lower()}: {media_item.url} , retry attempt: {media_item.attempts + 1}"
+                    f"Retrying {self._log_prefix.lower()}: {media_item.url}, retry attempt: {media_item.attempts + 1}"
                 )
 
     @property
-    def max_attempts(self):
+    def max_attempts(self) -> int:
         if self.manager.config.settings.download_options.disable_download_attempt_limit:
             return 1
         return self.manager.config.global_settings.rate_limiting_options.download_attempts
@@ -125,14 +124,14 @@ class Downloader:
         )
 
         async with server_limit, domain_limit, global_limit:
-            self.processed_items.add(media_item.db_path)
+            self._processed_items.add(media_item.db_path)
             self.waiting_items -= 1
             yield
 
     async def run(self, media_item: MediaItem) -> bool:
         """Runs the download loop."""
 
-        if media_item.url.path in self.processed_items and not self._ignore_history:
+        if media_item.url.path in self._processed_items and not self._ignore_history:
             return False
 
         async with self._download_context(media_item):
@@ -140,7 +139,7 @@ class Downloader:
 
     @error_handling_wrapper
     async def download_hls(self, media_item: MediaItem, m3u8_group: Rendition) -> None:
-        if media_item.url.path in self.processed_items and not self._ignore_history:
+        if media_item.url.path in self._processed_items and not self._ignore_history:
             return
 
         if not ffmpeg.is_installed():
@@ -300,7 +299,7 @@ class Downloader:
             raise RestrictedFiletypeError(origin=media_item)
         if not await self.manager.client_manager.check_file_duration(media_item):
             raise DurationError(origin=media_item)
-        if not _check_allowed_date_range(media_item, self.manager.config):
+        if not _is_allowed_date_range(media_item, self.manager.config):
             raise RestrictedDateRangeError(origin=media_item)
 
     async def set_file_datetime(self, media_item: MediaItem, complete_file: Path) -> None:
@@ -327,9 +326,9 @@ class Downloader:
 
     async def start_download(self, media_item: MediaItem) -> bool:
         if not media_item.is_segment:
-            logger.info(f"{self.log_prefix} starting: {media_item.url}")
+            logger.info(f"{self._log_prefix} starting: {media_item.url}")
 
-        async with self._file_lock_vault[media_item.filename]:
+        async with self._file_locks[media_item.filename]:
             logger.debug(f"Lock for '{media_item.filename}' acquired")
             try:
                 return bool(await self.download(media_item))
@@ -339,8 +338,8 @@ class Downloader:
     async def _download(self, media_item: MediaItem) -> bool | None:
         """Downloads the media item."""
         url_as_str = str(media_item.url)
-        if url_as_str in KNOWN_BAD_URLS:
-            raise DownloadError(KNOWN_BAD_URLS[url_as_str])
+        if url_as_str in _KNOWN_BAD_URLS:
+            raise DownloadError(_KNOWN_BAD_URLS[url_as_str])
         try:
             media_item.attempts = media_item.attempts or 1
             if not media_item.is_segment:
@@ -374,7 +373,7 @@ class Downloader:
             ui_message = getattr(e, "status", type(e).__name__)
             if media_item.partial_file and (size := await aio.get_size(media_item.partial_file)):
                 if self._current_attempt_filesize.get(media_item.filename, 0) >= size:
-                    raise DownloadError(ui_message, message=f"{self.log_prefix} failed", retry=True) from None
+                    raise DownloadError(ui_message, message=f"{self._log_prefix} failed", retry=True) from None
 
                 self._current_attempt_filesize[media_item.filename] = size
                 raise DownloadError(status=999, message="Download timeout reached, retrying", retry=True) from None
@@ -389,7 +388,7 @@ class Downloader:
         exc_info: Exception | None = None,
     ) -> None:
         logger.error(
-            f"{self.log_prefix} Failed: {media_item.url} ({error_log_msg.main_log_msg}) \n -> Referer: {media_item.referer}",
+            f"{self._log_prefix} Failed: {media_item.url} ({error_log_msg.main_log_msg}) \n -> Referer: {media_item.referer}",
             exc_info=exc_info,
         )
         self.manager.logs.write_download_error(media_item, error_log_msg.csv_log_msg)
@@ -409,13 +408,15 @@ def _is_allowed_filetype(media_item: MediaItem, config: Config) -> bool:
     )
 
 
-def _check_allowed_date_range(media_item: MediaItem, config: Config) -> bool:
-    """Checks if the file was uploaded within the config date range"""
-    datetime = media_item.uploaded_at_date
-    if not datetime:
+def _is_allowed_date_range(media_item: MediaItem, config: Config) -> bool:
+    if not media_item.uploaded_at_date:
         return True
 
-    item_date = datetime.date()
+    return _filter_by_date(media_item.uploaded_at_date, config)
+
+
+def _filter_by_date(item_datetime: datetime.datetime, config: Config) -> bool:
+    item_date = item_datetime.date()
     ignore_options = config.settings.ignore_options
 
     if ignore_options.exclude_before and item_date < ignore_options.exclude_before:

--- a/cyberdrop_dl/downloader/downloader.py
+++ b/cyberdrop_dl/downloader/downloader.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from cyberdrop_dl.clients.download_client import DownloadClient
+    from cyberdrop_dl.config import Config
     from cyberdrop_dl.manager import Manager
     from cyberdrop_dl.utils.m3u8 import M3U8, Rendition
 
@@ -295,11 +296,11 @@ class Downloader:
         """Checks if the file can be downloaded."""
         if not await storage.has_sufficient_space(media_item.download_folder):
             raise InsufficientFreeSpaceError(media_item)
-        if not self.manager.client_manager.is_allowed_filetype(media_item):
+        if not _is_allowed_filetype(media_item, self.manager.config):
             raise RestrictedFiletypeError(origin=media_item)
         if not await self.manager.client_manager.check_file_duration(media_item):
             raise DurationError(origin=media_item)
-        if not self.manager.client_manager.check_allowed_date_range(media_item):
+        if not _check_allowed_date_range(media_item, self.manager.config):
             raise RestrictedDateRangeError(origin=media_item)
 
     async def set_file_datetime(self, media_item: MediaItem, complete_file: Path) -> None:
@@ -394,3 +395,31 @@ class Downloader:
         self.manager.logs.write_download_error(media_item, error_log_msg.csv_log_msg)
         self.manager.scrape_mapper.tui.files.stats.failed += 1
         self.manager.scrape_mapper.tui.download_errors.add(error_log_msg.ui_failure)
+
+
+def _is_allowed_filetype(media_item: MediaItem, config: Config) -> bool:
+    ignore_options = config.settings.ignore_options
+    ext = media_item.ext.lower()
+
+    return not (
+        (ignore_options.exclude_images and ext in constants.FileExt.IMAGE)
+        or (ignore_options.exclude_videos and ext in constants.FileExt.VIDEO)
+        or (ignore_options.exclude_audio and ext in constants.FileExt.AUDIO)
+        or (ignore_options.exclude_other and ext not in constants.FileExt.MEDIA)
+    )
+
+
+def _check_allowed_date_range(media_item: MediaItem, config: Config) -> bool:
+    """Checks if the file was uploaded within the config date range"""
+    datetime = media_item.uploaded_at_date
+    if not datetime:
+        return True
+
+    item_date = datetime.date()
+    ignore_options = config.settings.ignore_options
+
+    if ignore_options.exclude_before and item_date < ignore_options.exclude_before:
+        return False
+    if ignore_options.exclude_after and item_date > ignore_options.exclude_after:
+        return False
+    return True

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -24,16 +24,15 @@ from cyberdrop_dl.constants import FileExt
 from cyberdrop_dl.cookies import export_cookies, extract_cookies, filter_cookies, read_netscape_files
 from cyberdrop_dl.exceptions import DownloadError, ScrapeError
 from cyberdrop_dl.ffmpeg import probe
-from cyberdrop_dl.url_objects import AbsoluteHttpURL, MediaItem
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable, Mapping
-    from http.cookies import BaseCookie
+    from collections.abc import Callable, Generator, Mapping
 
     from curl_cffi.requests import AsyncSession
     from curl_cffi.requests.models import Response as CurlResponse
 
     from cyberdrop_dl.manager import Manager
+    from cyberdrop_dl.url_objects import MediaItem
 
 
 logger = logging.getLogger(__name__)
@@ -177,42 +176,6 @@ class ClientManager:
         instances = self.download_slots.get(domain, self.rate_limiting_options.max_simultaneous_downloads_per_domain)
 
         return min(instances, self.rate_limiting_options.max_simultaneous_downloads_per_domain)
-
-    def is_allowed_filetype(self, media_item: MediaItem) -> bool:
-
-        ignore_options = self.manager.config.settings.ignore_options
-        ext = media_item.ext.lower()
-
-        return not (
-            (ignore_options.exclude_images and ext in FileExt.IMAGE)
-            or (ignore_options.exclude_videos and ext in FileExt.VIDEO)
-            or (ignore_options.exclude_audio and ext in FileExt.AUDIO)
-            or (ignore_options.exclude_other and ext not in FileExt.MEDIA)
-        )
-
-    def check_allowed_date_range(self, media_item: MediaItem) -> bool:
-        """Checks if the file was uploaded within the config date range"""
-        datetime = media_item.uploaded_at_date
-        if not datetime:
-            return True
-
-        item_date = datetime.date()
-        ignore_options = self.manager.config.settings.ignore_options
-
-        if ignore_options.exclude_before and item_date < ignore_options.exclude_before:
-            return False
-        if ignore_options.exclude_after and item_date > ignore_options.exclude_after:
-            return False
-        return True
-
-    def filter_cookies_by_word_in_domain(self, word: str) -> Iterable[tuple[str, BaseCookie[str]]]:
-        """Yields pairs of `[domain, BaseCookie]` for every cookie with a domain that has `word` in it"""
-        if not self.cookies:
-            return
-        self.cookies._do_expiration()
-        for domain, _ in self.cookies._cookies:
-            if word in domain:
-                yield domain, self.cookies.filter_cookies(AbsoluteHttpURL(f"https://{domain}"))
 
     def _create_curl_session(self) -> AsyncSession[CurlResponse]:
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -5,7 +5,6 @@ import contextlib
 import logging
 import platform
 import ssl
-from base64 import b64encode
 from collections import defaultdict
 from collections.abc import Generator
 from contextvars import ContextVar
@@ -19,19 +18,18 @@ from aiohttp import ClientResponse, ClientSession
 from aiolimiter import AsyncLimiter
 
 from cyberdrop_dl import ddos_guard, env
-from cyberdrop_dl.aio import WeakAsyncLocks
 from cyberdrop_dl.clients import HTTPClient
 from cyberdrop_dl.clients.download_client import DownloadClient
 from cyberdrop_dl.clients.flaresolverr import FlareSolverrClient
 from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.constants import FileExt
 from cyberdrop_dl.cookies import export_cookies, extract_cookies, filter_cookies, read_netscape_files
-from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, ScrapeError, TooManyCrawlerErrors
+from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, TooManyCrawlerErrors
 from cyberdrop_dl.ffmpeg import probe
 from cyberdrop_dl.url_objects import AbsoluteHttpURL, MediaItem
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable, Mapping
+    from collections.abc import Callable, Generator, Iterable
     from http.cookies import BaseCookie
 
     from curl_cffi.requests import AsyncSession
@@ -90,18 +88,18 @@ class DownloadSpeedLimiter(AsyncLimiter):
         return f"{self.__class__.__name__}(speed_limit={self.max_rate}, chunk_size={self.chunk_size})"
 
 
-def _make_ssl_context(ssl_context: str | None) -> ssl.SSLContext | Literal[False]:
-    if not ssl_context:
+def _make_ssl_context(name: str | None) -> ssl.SSLContext | Literal[False]:
+    if not name:
         return False
-    if ssl_context == "certifi":
+    if name == "certifi":
         return ssl.create_default_context(cafile=certifi.where())
-    if ssl_context == "truststore":
+    if name == "truststore":
         return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    if ssl_context == "truststore+certifi":
+    if name == "truststore+certifi":
         ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.load_verify_locations(cafile=certifi.where())
         return ctx
-    raise ValueError(ssl_context)
+    raise ValueError(name)
 
 
 class ClientManager:
@@ -119,7 +117,7 @@ class ClientManager:
         self.speed_limiter = DownloadSpeedLimiter(self.rate_limiting_options.download_speed_limit)
         self.download_client = DownloadClient(manager, self)
         self._flaresolverr: FlareSolverrClient | None = None
-        self.file_locks: WeakAsyncLocks[str] = WeakAsyncLocks()
+
         self._session: aiohttp.ClientSession
         self._download_session: aiohttp.ClientSession
         self._curl_session: AsyncSession[CurlResponse]
@@ -184,26 +182,8 @@ class ClientManager:
 
         return min(instances, self.rate_limiting_options.max_simultaneous_downloads_per_domain)
 
-    @staticmethod
-    def check_curl_cffi_is_available() -> None:
-        if _curl_import_error is None:
-            return
-
-        system = "Android" if env.RUNNING_IN_TERMUX else "the system"
-        msg = (
-            f"curl_cffi is required to scrape this URL but a dependency it's not available on {system}.\n"
-            f"See: https://github.com/lexiforest/curl_cffi/issues/74#issuecomment-1849365636\n{_curl_import_error!r}"
-        )
-        raise ScrapeError("Missing Dependency", msg)
-
-    @staticmethod
-    def basic_auth(username: str, password: str) -> str:
-        """Returns a basic auth token."""
-        token = b64encode(f"{username}:{password}".encode()).decode("ascii")
-        return f"Basic {token}"
-
     def is_allowed_filetype(self, media_item: MediaItem) -> bool:
-        """Checks if the file type is allowed to download."""
+
         ignore_options = self.manager.config.settings.ignore_options
         ext = media_item.ext.lower()
 
@@ -371,16 +351,6 @@ class ClientManager:
             check(await response.json(), response)
             return
 
-    @staticmethod
-    def check_content_length(headers: Mapping[str, Any]) -> None:
-        content_length, content_type = headers.get("Content-Length"), headers.get("Content-Type")
-        if content_length is None or content_type is None:
-            return
-        if content_length == "322509" and content_type == "video/mp4":
-            raise DownloadError(status="Bunkr Maintenance", message="Bunkr under maintenance")
-        if content_length == "73003" and content_type == "video/mp4":
-            raise DownloadError(410)  # Placeholder video with text "Video removed" (efukt)
-
     async def check_file_duration(self, media_item: MediaItem) -> bool:
         """Checks the file runtime against the config runtime limits."""
         if media_item.is_segment:
@@ -459,7 +429,7 @@ async def _get_dns_resolver(
             _ = await resolver.query_dns("github.com", "A")
 
     except Exception as e:
-        logger.warning(f"Unable to setup asynchronous DNS resolver. Falling back to thread based resolver: {e}")
+        logger.warning(f"Unable to setup asynchronous DNS resolver. Falling back to thread based resolver: {e!r}")
         return aiohttp.ThreadedResolver
 
     else:

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -24,7 +24,7 @@ from cyberdrop_dl.clients.flaresolverr import FlareSolverrClient
 from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.constants import FileExt
 from cyberdrop_dl.cookies import export_cookies, extract_cookies, filter_cookies, read_netscape_files
-from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, TooManyCrawlerErrors
+from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, ScrapeError, TooManyCrawlerErrors
 from cyberdrop_dl.ffmpeg import probe
 from cyberdrop_dl.url_objects import AbsoluteHttpURL, MediaItem
 
@@ -224,12 +224,19 @@ class ClientManager:
                 yield domain, self.cookies.filter_cookies(AbsoluteHttpURL(f"https://{domain}"))
 
     def _create_curl_session(self) -> AsyncSession[CurlResponse]:
-        # Calling code should have validated if curl is actually available
-        import warnings
 
-        from curl_cffi.aio import AsyncCurl
-        from curl_cffi.requests import AsyncSession
-        from curl_cffi.utils import CurlCffiWarning
+        try:
+            from curl_cffi.aio import AsyncCurl
+            from curl_cffi.requests import AsyncSession
+            from curl_cffi.utils import CurlCffiWarning
+        except ImportError:
+            msg = (
+                f"curl_cffi is required to scrape this URL but a dependency it's not available on {platform.system()}.\n"
+                f"See: https://github.com/lexiforest/curl_cffi/issues/74#issuecomment-1849365636\n{_curl_import_error!r}"
+            )
+            raise ScrapeError("Missing Dependency", msg) from None
+
+        import warnings
 
         loop = asyncio.get_running_loop()
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -120,7 +120,14 @@ class ClientManager:
 
         self._session: aiohttp.ClientSession
         self._download_session: aiohttp.ClientSession
-        self._curl_session: AsyncSession[CurlResponse]
+
+        self._curl_session: AsyncSession[CurlResponse] | None = None
+
+    @property
+    def curl_session(self) -> AsyncSession[CurlResponse]:
+        if self._curl_session is None:
+            self._curl_session = self._create_curl_session()
+        return self._curl_session
 
     @property
     def cookies(self) -> aiohttp.CookieJar:
@@ -150,8 +157,6 @@ class ClientManager:
 
         self._session = self.create_aiohttp_session()
         self._download_session = self.create_aiohttp_session()
-        if _curl_import_error is None:
-            self._curl_session = self.new_curl_cffi_session()
         return self
 
     async def __aexit__(self, *_) -> None:
@@ -161,11 +166,11 @@ class ClientManager:
             if self._flaresolverr is not None:
                 tg.create_task(self._flaresolverr.aclose())
 
-            if _curl_import_error is None:
+            if (curl := self._curl_session) is not None:
 
                 async def close_curl() -> None:
                     try:
-                        await self._curl_session.close()
+                        await curl.close()
                     except Exception:
                         pass
 
@@ -218,7 +223,7 @@ class ClientManager:
             if word in domain:
                 yield domain, self.cookies.filter_cookies(AbsoluteHttpURL(f"https://{domain}"))
 
-    def new_curl_cffi_session(self) -> AsyncSession[CurlResponse]:
+    def _create_curl_session(self) -> AsyncSession[CurlResponse]:
         # Calling code should have validated if curl is actually available
         import warnings
 

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -27,7 +27,7 @@ from cyberdrop_dl.ffmpeg import probe
 from cyberdrop_dl.url_objects import AbsoluteHttpURL, MediaItem
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable
+    from collections.abc import Callable, Generator, Iterable, Mapping
     from http.cookies import BaseCookie
 
     from curl_cffi.requests import AsyncSession
@@ -301,12 +301,9 @@ class ClientManager:
 
         message = None
 
-        def check_etag() -> None:
-            if download and (e_tag := response.headers.get("ETag", "").strip('"')) in _DOWNLOAD_ERROR_ETAGS:
-                message = _DOWNLOAD_ERROR_ETAGS[e_tag]
-                raise DownloadError(HTTPStatus.NOT_FOUND, message=message)
+        if download:
+            _check_etag(response.headers)
 
-        check_etag()
         if HTTPStatus.OK <= response.status < HTTPStatus.BAD_REQUEST:
             # Check DDosGuard even on successful pages
             await ddos_guard.check(response)
@@ -408,3 +405,9 @@ async def _get_dns_resolver(
 
     else:
         return aiohttp.AsyncResolver
+
+
+def _check_etag(headers: Mapping[str, str]) -> None:
+    e_tag = headers.get("ETag", "").strip('"')
+    if message := _DOWNLOAD_ERROR_ETAGS.get(e_tag):
+        raise DownloadError(HTTPStatus.NOT_FOUND, message)

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -101,10 +101,14 @@ class ClientManager:
         self._cookies: aiohttp.CookieJar | None = None
         self.rate_limits: dict[str, AsyncLimiter] = {}
         self.download_slots: dict[str, int] = {}
-        self.global_rate_limiter = AsyncLimiter(self.rate_limiting_options.rate_limit, 1)
-        self.global_download_slots = asyncio.Semaphore(self.rate_limiting_options.max_simultaneous_downloads)
+        self.global_rate_limiter = AsyncLimiter(self.manager.config.global_settings.rate_limiting_options.rate_limit, 1)
+        self.global_download_slots = asyncio.Semaphore(
+            self.manager.config.global_settings.rate_limiting_options.max_simultaneous_downloads
+        )
         self.scraper_client = HTTPClient.from_client(self)
-        self.speed_limiter = DownloadSpeedLimiter(self.rate_limiting_options.download_speed_limit)
+        self.speed_limiter = DownloadSpeedLimiter(
+            self.manager.config.global_settings.rate_limiting_options.download_speed_limit
+        )
         self.download_client = DownloadClient(manager, self)
         self._flaresolverr: FlareSolverrClient | None = None
 
@@ -166,16 +170,16 @@ class ClientManager:
 
                 tg.create_task(close_curl())
 
-    @property
-    def rate_limiting_options(self):
-        return self.manager.config.global_settings.rate_limiting_options
-
     def get_download_slots(self, domain: str) -> int:
         """Returns the download limit for a domain."""
 
-        instances = self.download_slots.get(domain, self.rate_limiting_options.max_simultaneous_downloads_per_domain)
+        instances = self.download_slots.get(
+            domain, self.manager.config.global_settings.rate_limiting_options.max_simultaneous_downloads_per_domain
+        )
 
-        return min(instances, self.rate_limiting_options.max_simultaneous_downloads_per_domain)
+        return min(
+            instances, self.manager.config.global_settings.rate_limiting_options.max_simultaneous_downloads_per_domain
+        )
 
     def _create_curl_session(self) -> AsyncSession[CurlResponse]:
 
@@ -206,7 +210,7 @@ class ClientManager:
             impersonate="chrome",
             verify=bool(self.ssl_context),
             proxy=proxy_or_none,
-            timeout=self.rate_limiting_options._curl_timeout,
+            timeout=self.manager.config.global_settings.rate_limiting_options._curl_timeout,
             max_redirects=8,
             cookies={cookie.key: cookie.value for cookie in self.cookies},
         )
@@ -222,7 +226,7 @@ class ClientManager:
             },
             raise_for_status=False,
             cookie_jar=self.cookies,
-            timeout=self.rate_limiting_options._aiohttp_timeout,
+            timeout=self.manager.config.global_settings.rate_limiting_options._aiohttp_timeout,
             proxy=self.manager.config.global_settings.general.proxy,
             connector=tcp_conn,
             requote_redirect_url=False,
@@ -255,14 +259,9 @@ class ClientManager:
         response: ClientResponse | CurlResponse | AbstractResponse[Any],
         download: bool = False,
     ) -> None:
-        """Checks the HTTP status code and raises an exception if it's not acceptable.
-
-        If the response is successful and has valid html, returns soup
-        """
+        """Checks the HTTP status code and raises an exception if it's not acceptable."""
         if not isinstance(response, AbstractResponse):
             response = AbstractResponse.create(response)
-
-        message = None
 
         if download:
             _check_etag(response.headers)
@@ -275,7 +274,7 @@ class ClientManager:
         await self._check_json(response)
 
         await ddos_guard.check(response)
-        raise DownloadError(status=response.status, message=message)
+        raise DownloadError(status=response.status)
 
     async def _check_json(self, response: AbstractResponse[Any]) -> None:
         if "json" not in response.content_type:

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Generator
 from contextvars import ContextVar
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 import aiohttp
 import certifi
@@ -90,22 +90,26 @@ class DownloadSpeedLimiter(AsyncLimiter):
         return f"{self.__class__.__name__}(speed_limit={self.max_rate}, chunk_size={self.chunk_size})"
 
 
+def _make_ssl_context(ssl_context: str | None) -> ssl.SSLContext | Literal[False]:
+    if not ssl_context:
+        return False
+    if ssl_context == "certifi":
+        return ssl.create_default_context(cafile=certifi.where())
+    if ssl_context == "truststore":
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    if ssl_context == "truststore+certifi":
+        ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.load_verify_locations(cafile=certifi.where())
+        return ctx
+    raise ValueError(ssl_context)
+
+
 class ClientManager:
     """Creates a 'client' that can be referenced by scraping or download sessions."""
 
     def __init__(self, manager: Manager) -> None:
         self.manager = manager
-        ssl_context = self.manager.config.global_settings.general.ssl_context
-        if not ssl_context:
-            self.ssl_context = False
-        elif ssl_context == "certifi":
-            self.ssl_context = ssl.create_default_context(cafile=certifi.where())
-        elif ssl_context == "truststore":
-            self.ssl_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        elif ssl_context == "truststore+certifi":
-            self.ssl_context = ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            ctx.load_verify_locations(cafile=certifi.where())
-
+        self.ssl_context = _make_ssl_context(self.manager.config.global_settings.general.ssl_context)
         self._cookies: aiohttp.CookieJar | None = None
         self.rate_limits: dict[str, AsyncLimiter] = {}
         self.download_slots: dict[str, int] = {}

--- a/cyberdrop_dl/managers/client_manager.py
+++ b/cyberdrop_dl/managers/client_manager.py
@@ -5,8 +5,6 @@ import contextlib
 import logging
 import platform
 import ssl
-from collections import defaultdict
-from collections.abc import Generator
 from contextvars import ContextVar
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Literal, Self
@@ -17,14 +15,14 @@ import truststore
 from aiohttp import ClientResponse, ClientSession
 from aiolimiter import AsyncLimiter
 
-from cyberdrop_dl import ddos_guard, env
+from cyberdrop_dl import ddos_guard
 from cyberdrop_dl.clients import HTTPClient
 from cyberdrop_dl.clients.download_client import DownloadClient
 from cyberdrop_dl.clients.flaresolverr import FlareSolverrClient
 from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.constants import FileExt
 from cyberdrop_dl.cookies import export_cookies, extract_cookies, filter_cookies, read_netscape_files
-from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError, ScrapeError, TooManyCrawlerErrors
+from cyberdrop_dl.exceptions import DownloadError, ScrapeError
 from cyberdrop_dl.ffmpeg import probe
 from cyberdrop_dl.url_objects import AbsoluteHttpURL, MediaItem
 
@@ -37,11 +35,6 @@ if TYPE_CHECKING:
 
     from cyberdrop_dl.manager import Manager
 
-_curl_import_error = None
-try:
-    from curl_cffi.requests import AsyncSession  # noqa: TC002
-except ImportError as e:
-    _curl_import_error = e
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +49,6 @@ _DOWNLOAD_ERROR_ETAGS = {
     "19fdf2cd6-383c-5a4cd5b6710ed": "ImageVenue image not Found",
     "383c-5a4cd5b6710ed": "ImageVenue image not Found",
 }
-
-_crawler_errors: dict[str, int] = defaultdict(int)
 
 
 if TYPE_CHECKING:
@@ -229,12 +220,12 @@ class ClientManager:
             from curl_cffi.aio import AsyncCurl
             from curl_cffi.requests import AsyncSession
             from curl_cffi.utils import CurlCffiWarning
-        except ImportError:
+        except ImportError as e:
             msg = (
                 f"curl_cffi is required to scrape this URL but a dependency it's not available on {platform.system()}.\n"
-                f"See: https://github.com/lexiforest/curl_cffi/issues/74#issuecomment-1849365636\n{_curl_import_error!r}"
+                f"See: https://github.com/lexiforest/curl_cffi/issues/74#issuecomment-1849365636\n{e!r}"
             )
-            raise ScrapeError("Missing Dependency", msg) from None
+            raise ScrapeError("Missing Dependency", msg) from e
 
         import warnings
 
@@ -257,51 +248,22 @@ class ClientManager:
             cookies={cookie.key: cookie.value for cookie in self.cookies},
         )
 
-    def create_aiohttp_session(
-        self,
-    ) -> ClientSession:
+    def create_aiohttp_session(self) -> ClientSession:
+        assert DNS_RESOLVER is not None
+        tcp_conn = aiohttp.TCPConnector(ssl=self.ssl_context, resolver=DNS_RESOLVER())
+        tcp_conn._resolver_owner = True
+
         return ClientSession(
             headers={
-                "User-agent": self.manager.config.global_settings.general.user_agent,
+                "User-Agent": self.manager.config.global_settings.general.user_agent,
             },
             raise_for_status=False,
             cookie_jar=self.cookies,
             timeout=self.rate_limiting_options._aiohttp_timeout,
             proxy=self.manager.config.global_settings.general.proxy,
-            connector=self._new_tcp_connector(),
+            connector=tcp_conn,
             requote_redirect_url=False,
         )
-
-    def _new_tcp_connector(self) -> aiohttp.TCPConnector:
-        assert DNS_RESOLVER is not None
-        conn = aiohttp.TCPConnector(ssl=self.ssl_context, resolver=DNS_RESOLVER())
-        conn._resolver_owner = True
-        return conn
-
-    def check_domain_errors(self, domain: str) -> None:
-        if _crawler_errors[domain] >= env.MAX_CRAWLER_ERRORS:
-            if crawler := self.manager.scrape_mapper.disable_crawler(domain):
-                msg = (
-                    f"{crawler.__class__.__name__} has been disabled after too many errors. "
-                    f"URLs from the following domains will be ignored: {crawler.SCRAPE_MAPPER_KEYS}"
-                )
-                logger.error(msg)
-            raise TooManyCrawlerErrors
-
-    @contextlib.contextmanager
-    def request_context(self, domain: str) -> Generator[None]:
-        self.check_domain_errors(domain)
-        try:
-            yield
-        except DDOSGuardError:
-            _crawler_errors[domain] += 1
-            raise
-        else:
-            # we could potentially reset the counter here
-            # _crawler_errors[domain] = 0
-            pass
-        finally:
-            pass
 
     async def load_cookie_files(self) -> None:
         if self.manager.config.settings.browser_cookies.auto_import:

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -128,10 +128,10 @@ class ScrapeMapper:
     _done: asyncio.Event = dataclasses.field(init=False, default_factory=asyncio.Event)
 
     def _scrape_queue(self) -> int:
-        return sum(f.waiting_items for f in self._factory)
+        return sum(crawler.waiting_items for crawler in self._factory)
 
     def _download_queue(self):
-        total = sum(f.downloader.waiting_items for f in self._factory)
+        total = sum(crawler.downloader.waiting_items for crawler in self._factory)
         self.tui.files.stats.queued = total
         return total
 

--- a/cyberdrop_dl/utils/__init__.py
+++ b/cyberdrop_dl/utils/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import contextlib
 import dataclasses
 import functools
@@ -362,3 +363,8 @@ def truncated_preview(content: str, max_len: int = 100) -> str:
     if len(content) <= max_len:
         return content
     return f"{content[:max_len]} ... ({len(content) - max_len:,} chars omitted)"
+
+
+def basic_auth(username: str, password: str) -> str:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    return f"Basic {token}"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,6 @@
 import aiohttp
 import pytest
-
-try:
-    from curl_cffi.requests import AsyncSession
-except ImportError:
-    AsyncSession = None
+from curl_cffi.requests import AsyncSession
 
 from cyberdrop_dl.manager import Manager
 from cyberdrop_dl.managers.client_manager import ClientManager
@@ -22,11 +18,10 @@ async def test_context_manager(client: ClientManager) -> None:
     with pytest.raises(AttributeError):
         _ = client._download_session
 
-    with pytest.raises(AttributeError):
-        _ = client.curl_session
+    assert client._curl_session is None
 
     async with client:
         assert type(client._session) is aiohttp.ClientSession
         assert type(client._download_session) is aiohttp.ClientSession
-        if AsyncSession:
-            assert type(client.curl_session) is AsyncSession
+        assert client._curl_session is None
+        assert type(client.curl_session) is AsyncSession

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,10 +23,10 @@ async def test_context_manager(client: ClientManager) -> None:
         _ = client._download_session
 
     with pytest.raises(AttributeError):
-        _ = client._curl_session
+        _ = client.curl_session
 
     async with client:
         assert type(client._session) is aiohttp.ClientSession
         assert type(client._download_session) is aiohttp.ClientSession
         if AsyncSession:
-            assert type(client._curl_session) is AsyncSession
+            assert type(client.curl_session) is AsyncSession

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,9 @@
+import sys
+
 import aiohttp
 import pytest
-from curl_cffi.requests import AsyncSession
 
+from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.manager import Manager
 from cyberdrop_dl.managers.client_manager import ClientManager
 
@@ -24,4 +26,11 @@ async def test_context_manager(client: ClientManager) -> None:
         assert type(client._session) is aiohttp.ClientSession
         assert type(client._download_session) is aiohttp.ClientSession
         assert client._curl_session is None
-        assert type(client.curl_session) is AsyncSession
+
+        if sys.implementation.name == "cpython":
+            from curl_cffi.requests import AsyncSession
+
+            assert type(client.curl_session) is AsyncSession
+        else:
+            with pytest.raises(ScrapeError):
+                _ = client.curl_session

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,13 @@
+import ssl
 import sys
 
 import aiohttp
 import pytest
+import truststore
 
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.manager import Manager
-from cyberdrop_dl.managers.client_manager import ClientManager
+from cyberdrop_dl.managers.client_manager import ClientManager, _make_ssl_context
 
 
 @pytest.fixture
@@ -34,3 +36,28 @@ async def test_context_manager(client: ClientManager) -> None:
         else:
             with pytest.raises(ScrapeError):
                 _ = client.curl_session
+                # test_ssl_context.py
+
+
+class TestMakeSSLContext:
+    def test_none_or_empty_string_returns_false(self) -> None:
+        assert _make_ssl_context(None) is False
+        assert _make_ssl_context("") is False
+
+    def test_certifi_returns_default_context_with_certifi_bundle(self) -> None:
+        ctx = _make_ssl_context("certifi")
+        assert type(ctx) is ssl.SSLContext
+        assert ctx.check_hostname is True
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_truststore_returns_truststore_context(self) -> None:
+        ctx = _make_ssl_context("truststore")
+        assert isinstance(ctx, truststore.SSLContext)
+
+    def test_truststore_plus_certifi_returns_combined_context(self) -> None:
+        ctx = _make_ssl_context("truststore+certifi")
+        assert type(ctx) is truststore.SSLContext
+
+    def test_unknown_name_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="foobar"):
+            _make_ssl_context("foobar")


### PR DESCRIPTION
This is the last redundant manager

All HTTP logic should be inside the `HTTPClient` object