### PR TITLE
refactor: prevent requests from bursting over the rate limit 

### DIFF
--- a/cyberdrop_dl/aio.py
+++ b/cyberdrop_dl/aio.py
@@ -50,7 +50,7 @@ class RateLimiter(AsyncLimiter):
     __slots__ = ()
 
     async def acquire(self, amount: float = 1) -> None:
-        if self.max_rate <= 0:
+        if self.max_rate == 0:
             return
         await super().acquire(amount)
 
@@ -61,7 +61,13 @@ class RateLimiter(AsyncLimiter):
         Instead of allowing up to <max_rate> acquisitions over a period of <time_period>,
         spread them evenly across the <time_period> to maintain a steady rate of <max_rate>.
         """
+        if max_rate == 0:
+            return cls.no_op()
         return cls(max_rate=1, time_period=time_period / max_rate)
+
+    @classmethod
+    def no_op(cls) -> Self:
+        return cls(max_rate=0, time_period=1)
 
 
 @dataclasses.dataclass(slots=True, eq=False)

--- a/cyberdrop_dl/aio.py
+++ b/cyberdrop_dl/aio.py
@@ -13,6 +13,7 @@ from stat import S_ISREG
 from typing import IO, TYPE_CHECKING, Any, AnyStr, Generic, ParamSpec, Self, TypeVar, TypeVarTuple, cast, overload
 from weakref import WeakValueDictionary
 
+from aiolimiter.leakybucket import AsyncLimiter
 from typing_extensions import Sentinel
 
 if TYPE_CHECKING:
@@ -43,6 +44,24 @@ class WeakAsyncLocks(Generic[_T]):
         if lock is None:
             self._locks[key] = lock = asyncio.Lock()
         return lock
+
+
+class RateLimiter(AsyncLimiter):
+    __slots__ = ()
+
+    async def acquire(self, amount: float = 1) -> None:
+        if self.max_rate <= 0:
+            return
+        await super().acquire(amount)
+
+    @classmethod
+    def w_no_burst(cls, max_rate: float, time_period: float = 1) -> Self:
+        """Create a new instance that prevents acquisitions from bursting through the limit.
+
+        Instead of allowing up to <max_rate> acquisitions over a period of <time_period>,
+        spread them evenly across the <time_period> to maintain a steady rate of <max_rate>.
+        """
+        return cls(max_rate=1, time_period=time_period / max_rate)
 
 
 @dataclasses.dataclass(slots=True, eq=False)

--- a/cyberdrop_dl/clients/downloads.py
+++ b/cyberdrop_dl/clients/downloads.py
@@ -7,8 +7,6 @@ import time
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, final
 
-from aiolimiter import AsyncLimiter
-
 from cyberdrop_dl import aio, constants, ffmpeg, storage
 from cyberdrop_dl.clients import etag
 from cyberdrop_dl.constants import FileExt
@@ -37,15 +35,6 @@ _FREE_SPACE_CHECK_PERIOD: int = 5  # Check every 5 chunks
 _USE_IMPERSONATION: set[str] = {"vsco", "celebforum"}
 
 
-class DownloadSpeedLimiter(AsyncLimiter):
-    __slots__ = ()
-
-    async def acquire(self, amount: float = 1) -> None:
-        if self.max_rate <= 0:
-            return
-        await super().acquire(amount)
-
-
 @final
 class DownloadClient:
     """Low level class that performs the actual HTTP download operations"""
@@ -55,7 +44,7 @@ class DownloadClient:
         self.download_speed_threshold = self.manager.config.settings.runtime_options.slow_download_speed
         self._supports_ranges: bool = True
         speed_limit = self.manager.config.global_settings.rate_limiting_options.download_speed_limit
-        self.speed_limiter = DownloadSpeedLimiter(speed_limit, time_period=1)
+        self.speed_limiter = aio.RateLimiter.w_no_burst(speed_limit)
         self.chunk_size: int = 1024 * 1024 * 10  # 10MB
         if speed_limit:
             self.chunk_size = min(self.chunk_size, speed_limit)

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -273,6 +273,8 @@ class HTTPClient:
             logger.debug("Finished %s request [id=%s]\n%s", method, request_id, _LazyResponseLog(resp))
             try:
                 yield resp
+            except Exception as e:
+                exc = e
             finally:
                 if self._responses_folder:
                     self.manager.logs.write_response(self._responses_folder, url, resp, exc)

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -11,10 +11,9 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, Self, cast, final
 
 import aiohttp
-from aiolimiter import AsyncLimiter
 from multidict import CIMultiDict
 
-from cyberdrop_dl import cookies, ddos_guard, signature
+from cyberdrop_dl import aio, cookies, ddos_guard, signature
 from cyberdrop_dl.clients import flaresolverr, tcp
 from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.cookies import make_simple_cookie
@@ -73,9 +72,9 @@ class HTTPClient:
     def __init__(self, manager: Manager) -> None:
         self.manager = manager
         self.ssl_context = tcp.create_ssl_context(self.manager.config.global_settings.general.ssl_context)
-        self.rate_limits: dict[str, AsyncLimiter] = {}
-        self.global_rate_limiter = AsyncLimiter(
-            self.manager.config.global_settings.rate_limiting_options.rate_limit, time_period=1
+        self.rate_limits: dict[str, aio.RateLimiter] = {}
+        self.global_rate_limiter = aio.RateLimiter.w_no_burst(
+            self.manager.config.global_settings.rate_limiting_options.rate_limit
         )
         self.global_download_limiter = asyncio.Semaphore(
             self.manager.config.global_settings.rate_limiting_options.max_simultaneous_downloads

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -17,10 +17,9 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar, Concatenate, Final, Literal, ParamSpec, Self, TypeVar, final
 
-from aiolimiter import AsyncLimiter
 from typing_extensions import deprecated
 
-from cyberdrop_dl import env
+from cyberdrop_dl import aio, env
 from cyberdrop_dl.clients.http import HTTPClient, HTTPClientProxy
 from cyberdrop_dl.crawlers._hls import HLSParser
 from cyberdrop_dl.downloader.http import Downloader
@@ -205,7 +204,7 @@ class Crawler(HTTPClientProxy, HLSParser, ABC):
         async with self._startup_lock:
             if self._ready:
                 return
-            self.manager.http_client.rate_limits[self.DOMAIN] = AsyncLimiter(*self._RATE_LIMIT)
+            self.manager.http_client.rate_limits[self.DOMAIN] = aio.RateLimiter.w_no_burst(*self._RATE_LIMIT)
 
             await self.__async_post_init__()
             self._ready = True

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,61 @@
+import asyncio
+import time
+
+import pytest
+
+from cyberdrop_dl.aio import RateLimiter
+
+
+async def consume(limiter: RateLimiter, iterations: int) -> list[float]:
+    times: list[float] = []
+    for _ in range(iterations):
+        await limiter.acquire()
+        times.append(time.perf_counter())
+    return times
+
+
+async def test_no_op_never_throttles() -> None:
+    limiter = RateLimiter.no_op()
+    assert limiter.max_rate == 0
+    start = time.perf_counter()
+    # calls should pretty much return instantly
+    await asyncio.gather(*(limiter.acquire() for _ in range(1_000)))
+    delta = time.perf_counter() - start
+    assert delta < 0.05
+
+
+async def test_w_no_burst_zero_rate() -> None:
+    limiter = RateLimiter.w_no_burst(0)
+    assert limiter.max_rate == 0
+    assert limiter.time_period == 1
+
+
+async def test_w_no_burst_spreads_evenly() -> None:
+    """10 req/s should yield about 0.1s spacing inbetween calls."""
+    limiter = RateLimiter.w_no_burst(max_rate=10, time_period=1)
+    n_calls = 10
+    times = await consume(limiter, n_calls)
+    deltas = [times[i + 1] - times[i] for i in range(n_calls - 1)]
+    for delta in deltas:
+        assert delta == pytest.approx(0.1, rel=0.05)
+
+
+async def test_default_contructor_allows_burst() -> None:
+    max_rate = 20
+    limiter = RateLimiter(max_rate, time_period=1)
+    start = time.perf_counter()
+    await asyncio.gather(*(limiter.acquire() for _ in range(max_rate)))
+    delta = time.perf_counter() - start
+    assert delta < 0.001
+
+
+async def test_acquire_when_bucket_is_full() -> None:
+    max_rate = 2
+    expected_delta = 1 / max_rate
+    limiter = RateLimiter(max_rate, time_period=1)
+    start = time.perf_counter()
+    await limiter.acquire(max_rate)
+    assert time.perf_counter() - start < 0.001
+    await limiter.acquire(1)
+    delta = time.perf_counter() - start
+    assert delta == pytest.approx(expected_delta, rel=0.05)

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -46,7 +46,7 @@ async def test_default_contructor_allows_burst() -> None:
     start = time.perf_counter()
     await asyncio.gather(*(limiter.acquire() for _ in range(max_rate)))
     delta = time.perf_counter() - start
-    assert delta < 0.001
+    assert delta < 0.002
 
 
 async def test_acquire_when_bucket_is_full() -> None:

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -37,7 +37,7 @@ async def test_w_no_burst_spreads_evenly() -> None:
     times = await consume(limiter, n_calls)
     deltas = [times[i + 1] - times[i] for i in range(n_calls - 1)]
     for delta in deltas:
-        assert delta == pytest.approx(0.1, rel=0.05)
+        assert delta == pytest.approx(0.1, rel=0.15)
 
 
 async def test_default_contructor_allows_burst() -> None:
@@ -58,4 +58,4 @@ async def test_acquire_when_bucket_is_full() -> None:
     assert time.perf_counter() - start < 0.001
     await limiter.acquire(1)
     delta = time.perf_counter() - start
-    assert delta == pytest.approx(expected_delta, rel=0.05)
+    assert delta == pytest.approx(expected_delta, rel=0.15)

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -37,7 +37,7 @@ async def test_w_no_burst_spreads_evenly() -> None:
     times = await consume(limiter, n_calls)
     deltas = [times[i + 1] - times[i] for i in range(n_calls - 1)]
     for delta in deltas:
-        assert delta == pytest.approx(0.1, rel=0.15)
+        assert delta == pytest.approx(0.1, rel=0.3)
 
 
 async def test_default_contructor_allows_burst() -> None:
@@ -58,4 +58,4 @@ async def test_acquire_when_bucket_is_full() -> None:
     assert time.perf_counter() - start < 0.001
     await limiter.acquire(1)
     delta = time.perf_counter() - start
-    assert delta == pytest.approx(expected_delta, rel=0.15)
+    assert delta == pytest.approx(expected_delta, rel=0.3)


### PR DESCRIPTION
This changes the semantics of the rate limiter. 

The current default rate limit (`25 req/s`) allows the crawler to fire 25 requests at same time and only wait until at least 1 second has passed and one of them completes to fire the 26th request.

This bursting can cause immediate `429` on some sites.

Now, instead of allowing up to `max_rate` acquisitions over a period of `time_period`, spread them evenly across the `time_period` to maintain a steady rate of `max_rate`

This will (intentionally) slow down the initial speed of CDL, but it will prevent queuing a bunch of requests immediately and the overall performance over time should be better.

Reference: https://aiolimiter.readthedocs.io/en/stable/#bursting
- Related to #1702