### PR TITLE
feat: add --progress-events and --scrape-events JSONL feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ All notable changes to this project will be documented here. For more details, v
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Added
+
+- `--progress-events` flag emits per-file lifecycle events to `downloader.progress.jsonl`
+- `--scrape-events` flag emits scrape stats snapshots to `downloader.scrape.jsonl`
+
 ## [9.7.0] - 2026-05-07
 
 ### Added

--- a/cyberdrop_dl/clients/downloads.py
+++ b/cyberdrop_dl/clients/downloads.py
@@ -13,6 +13,7 @@ from cyberdrop_dl import aio, constants, ffmpeg, storage
 from cyberdrop_dl.clients import etag
 from cyberdrop_dl.constants import FileExt
 from cyberdrop_dl.exceptions import DownloadError, InvalidContentTypeError, SlowDownloadError
+from cyberdrop_dl.progress import chain_hooks
 from cyberdrop_dl.utils import dates
 
 if TYPE_CHECKING:
@@ -144,6 +145,16 @@ class DownloadClient:
                 media_item.domain,
                 size,
             )
+            files_settings = self.manager.config.settings.files
+            if files_settings.progress_events:
+                writer_hook = self.manager.logs.make_progress_writer(
+                    url=str(media_item.url),
+                    filename=media_item.filename,
+                    total=size,
+                    interval=files_settings.progress_event_interval,
+                    min_bytes=files_settings.progress_event_bytes,
+                )
+                hook = chain_hooks(hook, writer_hook)
 
         if resume_point:
             hook.advance(resume_point)

--- a/cyberdrop_dl/config/settings.py
+++ b/cyberdrop_dl/config/settings.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Annotated, Literal
 
 from cyclopts import Parameter
-from pydantic import BaseModel, ByteSize, Field, NonNegativeInt, PrivateAttr, field_validator
+from pydantic import BaseModel, ByteSize, Field, NonNegativeInt, PositiveFloat, PrivateAttr, field_validator
 
 from cyberdrop_dl.constants import (
     DEFAULT_APP_STORAGE,
@@ -75,7 +75,12 @@ class Files(SettingsGroup):
     )
     dump_json: Annotated[bool, Parameter(alias="-j")] = Field(default=False, validation_alias="j")
     input_file: Annotated[Path, Parameter(alias="-i")] = Field(default=Path("URLs.txt"), validation_alias="i")
+    progress_events: bool = False
+    progress_event_interval: PositiveFloat = 0.25
+    progress_event_bytes: NonNegativeInt = 262144
     save_pages_html: bool = False
+    scrape_events: bool = False
+    scrape_event_interval: PositiveFloat = 0.1
 
 
 class Logs(SettingsGroup):

--- a/cyberdrop_dl/csv_logs.py
+++ b/cyberdrop_dl/csv_logs.py
@@ -4,6 +4,7 @@ import asyncio
 import csv
 import dataclasses
 import logging
+import time
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
@@ -11,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Self
 from cyberdrop_dl import constants
 from cyberdrop_dl.exceptions import get_origin
 from cyberdrop_dl.logs import log_spacer
+from cyberdrop_dl.progress import ProgressHook
 from cyberdrop_dl.utils import json
 from cyberdrop_dl.utils.filepath import sanitize_filename
 
@@ -37,10 +39,14 @@ class CSVFiles:
     unsupported_urls_log: Path
     download_error_log: Path
     scrape_error_log: Path
+    progress_events_file: Path | None = None
+    scrape_events_file: Path | None = None
     jsonl_file: Path = dataclasses.field(init=False)
 
     def __iter__(self) -> Iterator[Path]:
-        return iter(dataclasses.astuple(self))
+        for value in dataclasses.astuple(self):
+            if isinstance(value, Path):
+                yield value
 
     def __post_init__(self) -> None:
         self.jsonl_file = self.main_log.with_suffix(".results.jsonl")
@@ -58,12 +64,16 @@ class CSVLogsManager:
 
     @classmethod
     def from_manager(cls, manager: Manager) -> Self:
+        main_log = manager.config.settings.logs.main_log
+        files_settings = manager.config.settings.files
         files = CSVFiles(
-            main_log=manager.config.settings.logs.main_log,
+            main_log=main_log,
             last_post_log=manager.config.settings.logs.last_forum_post,
             unsupported_urls_log=manager.config.settings.logs.unsupported_urls,
             download_error_log=manager.config.settings.logs.download_error_urls,
             scrape_error_log=manager.config.settings.logs.scrape_error_urls,
+            progress_events_file=main_log.with_suffix(".progress.jsonl") if files_settings.progress_events else None,
+            scrape_events_file=main_log.with_suffix(".scrape.jsonl") if files_settings.scrape_events else None,
         )
         return cls(files)
 
@@ -83,6 +93,64 @@ class CSVLogsManager:
     async def write_jsonl(self, data: Iterable[dict[str, Any]]) -> None:
         async with self._file_locks[self.files.jsonl_file]:
             await asyncio.to_thread(json.dump_jsonl, data, self.files.jsonl_file)
+
+    def write_progress_event(self, event: dict[str, Any]) -> None:
+        if (path := self.files.progress_events_file) is None:
+            return
+        _ = self.task_group.create_task(self._append_jsonl(path, event))
+
+    def write_scrape_event(self, event: dict[str, Any]) -> None:
+        if (path := self.files.scrape_events_file) is None:
+            return
+        _ = self.task_group.create_task(self._append_jsonl(path, event))
+
+    async def _append_jsonl(self, path: Path, event: dict[str, Any]) -> None:
+        async with self._file_locks[path]:
+            await asyncio.to_thread(_ensure_parent, path)
+            await asyncio.to_thread(json.dump_jsonl, (event,), path)
+
+    def make_progress_writer(
+        self,
+        *,
+        url: str,
+        filename: str,
+        total: int | None,
+        interval: float,
+        min_bytes: int,
+    ) -> ProgressHook:
+        cumulative = 0
+        started = False
+        last_emit_ts = time.monotonic()
+        last_emit_bytes = 0
+
+        def emit_start() -> None:
+            nonlocal started
+            self.write_progress_event(
+                {"event": "start", "ts": time.time(), "url": url, "filename": filename, "total": total},
+            )
+            started = True
+
+        def advance(amount: int = 1) -> None:
+            nonlocal cumulative, last_emit_ts, last_emit_bytes
+            if not started:
+                emit_start()
+            cumulative += amount
+            now = time.monotonic()
+            if (now - last_emit_ts) >= interval and (cumulative - last_emit_bytes) >= min_bytes:
+                self.write_progress_event(
+                    {"event": "chunk", "ts": time.time(), "url": url, "bytes": cumulative},
+                )
+                last_emit_ts = now
+                last_emit_bytes = cumulative
+
+        def done() -> None:
+            if not started:
+                emit_start()
+            self.write_progress_event(
+                {"event": "finish", "ts": time.time(), "url": url, "bytes": cumulative, "ok": True},
+            )
+
+        return ProgressHook(advance, _zero_speed, done)
 
     async def _write_to_csv(self, file: Path, **row: object) -> None:
         async with self._file_locks[file]:
@@ -224,6 +292,14 @@ def _write_resp_to_disk(
         _ = file.write_text(response.create_report(exc), "utf8")
     except OSError:
         pass
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _zero_speed() -> float:
+    return 0.0
 
 
 def _prepare_resp_file(folder: Path, url: AbsoluteHttpURL, created_at: datetime.datetime) -> Path:

--- a/cyberdrop_dl/progress/__init__.py
+++ b/cyberdrop_dl/progress/__init__.py
@@ -80,6 +80,23 @@ class ProgressHook:
         self._done = True
 
 
+def chain_hooks(*hooks: ProgressHook) -> ProgressHook:
+    """Fan `advance`/`done`; delegate `get_speed` to the first. Inner hooks must not be reused after chaining."""
+    if not hooks:
+        raise ValueError("chain_hooks requires at least one hook")
+    head = hooks[0]
+
+    def advance(amount: int = 1) -> None:
+        for h in hooks:
+            h.advance(amount)
+
+    def done() -> None:
+        for h in hooks:
+            h.done()
+
+    return ProgressHook(advance, head.get_speed, done)
+
+
 class LiveUI(ABC):
     @property
     def disabled(self) -> bool:

--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -43,6 +43,10 @@ logger = logging.getLogger(__name__)
 REGEX_LINKS = re.compile(r"(?:http.*?)(?=($|\n|\r\n|\r|\s|\"|\[/URL]|']\[|]\[|\[/img]))")
 
 
+def _scrape_event(event: str, stats: dict[str, int]) -> dict[str, Any]:
+    return {"event": event, "ts": time.time(), **stats}
+
+
 def _filter_by_date(scrape_item: ScrapeItem, before: datetime.date | None, after: datetime.date | None) -> bool:
     skip = False
     item_date = scrape_item.completed_at or scrape_item.created_at
@@ -180,6 +184,11 @@ class ScrapeMapper:
                 self.manager.logs.task_group,
                 self._task_groups.downloads,
             ):
+                files_settings = self.manager.config.settings.files
+                if files_settings.scrape_events:
+                    _ = self.manager.logs.task_group.create_task(
+                        self._poll_scrape_stats(files_settings.scrape_event_interval),
+                    )
                 try:
                     async with self._task_groups.scrape:
                         self.manager.scrape_mapper = self
@@ -189,6 +198,10 @@ class ScrapeMapper:
                 finally:
                     # The done event signals that all scraping is done, but there may still be downloads pending
                     self._done.set()
+                    if files_settings.scrape_events:
+                        self.manager.logs.write_scrape_event(
+                            _scrape_event("scrape_complete", dataclasses.asdict(self.tui.files.stats)),
+                        )
 
     async def run(self) -> ScrapeStats:
         self._init_crawlers()
@@ -314,6 +327,21 @@ class ScrapeMapper:
             return False
 
         return True
+
+    async def _poll_scrape_stats(self, interval: float) -> None:
+        last: dict[str, int] | None = None
+        while True:
+            try:
+                _ = await asyncio.wait_for(self._done.wait(), timeout=interval)
+            except TimeoutError:
+                pass
+            if self._done.is_set():
+                return
+            self._download_queue()  # refresh stats.queued (normally driven by Rich)
+            current = dataclasses.asdict(self.tui.files.stats)
+            if current != last:
+                self.manager.logs.write_scrape_event(_scrape_event("stats", current))
+                last = current
 
     def disable_crawler(self, domain: str) -> type[Crawler] | None:
         """Disables a crawler at runtime, after the scrape mapper is already running.

--- a/tests/test_progress_events.py
+++ b/tests/test_progress_events.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cyberdrop_dl import csv_logs
+from cyberdrop_dl.csv_logs import CSVFiles, CSVLogsManager
+from cyberdrop_dl.progress import ProgressHook, chain_hooks
+
+
+def _make_manager(tmp_path: Path, *, progress: bool = False, scrape: bool = False) -> CSVLogsManager:
+    main_log = tmp_path / "downloader.log"
+    files = CSVFiles(
+        main_log=main_log,
+        last_post_log=tmp_path / "last.csv",
+        unsupported_urls_log=tmp_path / "unsupported.csv",
+        download_error_log=tmp_path / "download_errors.csv",
+        scrape_error_log=tmp_path / "scrape_errors.csv",
+        progress_events_file=main_log.with_suffix(".progress.jsonl") if progress else None,
+        scrape_events_file=main_log.with_suffix(".scrape.jsonl") if scrape else None,
+    )
+    return CSVLogsManager(files)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf8").splitlines() if line]
+
+
+def test_csv_files_iter_skips_none(tmp_path: Path) -> None:
+    main = tmp_path / "downloader.log"
+    files = CSVFiles(
+        main_log=main,
+        last_post_log=tmp_path / "a.csv",
+        unsupported_urls_log=tmp_path / "b.csv",
+        download_error_log=tmp_path / "c.csv",
+        scrape_error_log=tmp_path / "d.csv",
+        progress_events_file=None,
+        scrape_events_file=None,
+    )
+    assert all(isinstance(p, Path) for p in files)
+    assert main.with_suffix(".results.jsonl") in list(files)
+
+
+def test_chain_hooks_fans_advance_and_done() -> None:
+    advances_a: list[int] = []
+    advances_b: list[int] = []
+    done_calls: list[str] = []
+
+    a = ProgressHook(advances_a.append, lambda: 12.5, lambda: done_calls.append("a"))
+    b = ProgressHook(advances_b.append, lambda: 99.0, lambda: done_calls.append("b"))
+
+    chained = chain_hooks(a, b)
+    chained.advance(7)
+    chained.advance(3)
+    assert advances_a == [7, 3]
+    assert advances_b == [7, 3]
+    assert chained.get_speed() == 12.5
+
+    with chained:
+        pass
+    assert done_calls == ["a", "b"]
+
+
+def test_chain_hooks_requires_at_least_one() -> None:
+    with pytest.raises(ValueError):
+        _ = chain_hooks()
+
+
+async def test_progress_event_noop_when_disabled(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, progress=False)
+    async with mgr.task_group:
+        mgr.write_progress_event({"event": "start", "url": "x"})
+    assert not (tmp_path / "downloader.progress.jsonl").exists()
+
+
+async def test_progress_event_writes_when_enabled(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, progress=True)
+    async with mgr.task_group:
+        mgr.write_progress_event({"event": "start", "url": "https://x/foo", "total": 10})
+        mgr.write_progress_event({"event": "finish", "url": "https://x/foo", "bytes": 10, "ok": True})
+
+    rows = _read_jsonl(tmp_path / "downloader.progress.jsonl")
+    assert [r["event"] for r in rows] == ["start", "finish"]
+    assert rows[0]["url"] == "https://x/foo"
+    assert rows[1]["bytes"] == 10
+
+
+async def test_scrape_event_noop_when_disabled(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, scrape=False)
+    async with mgr.task_group:
+        mgr.write_scrape_event({"event": "stats", "queued": 1})
+    assert not (tmp_path / "downloader.scrape.jsonl").exists()
+
+
+async def test_make_progress_writer_emits_start_and_finish(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, progress=True)
+    async with mgr.task_group:
+        hook = mgr.make_progress_writer(
+            url="https://x/foo.mp4",
+            filename="foo.mp4",
+            total=1000,
+            interval=0.0,
+            min_bytes=0,
+        )
+        with hook:
+            hook.advance(500)
+            hook.advance(500)
+
+    rows = _read_jsonl(tmp_path / "downloader.progress.jsonl")
+    events = [r["event"] for r in rows]
+    assert events[0] == "start"
+    assert events[-1] == "finish"
+    assert "chunk" in events
+    assert rows[0]["total"] == 1000
+    assert rows[0]["filename"] == "foo.mp4"
+    assert rows[-1]["bytes"] == 1000
+    assert rows[-1]["ok"] is True
+
+
+async def test_make_progress_writer_throttles_chunks(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, progress=True)
+    async with mgr.task_group:
+        hook = mgr.make_progress_writer(
+            url="https://x/foo.mp4",
+            filename="foo.mp4",
+            total=1_000_000,
+            interval=10.0,
+            min_bytes=10_000_000,
+        )
+        with hook:
+            for _ in range(50):
+                hook.advance(1000)
+
+    rows = _read_jsonl(tmp_path / "downloader.progress.jsonl")
+    chunks = [r for r in rows if r["event"] == "chunk"]
+    assert chunks == []
+    assert rows[0]["event"] == "start"
+    assert rows[-1]["event"] == "finish"
+    assert rows[-1]["bytes"] == 50_000
+
+
+async def test_progress_writer_chunk_bytes_are_cumulative(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, progress=True)
+    async with mgr.task_group:
+        hook = mgr.make_progress_writer(
+            url="https://x/foo.mp4",
+            filename="foo.mp4",
+            total=None,
+            interval=0.0,
+            min_bytes=0,
+        )
+        with hook:
+            hook.advance(100)
+            hook.advance(150)
+            hook.advance(50)
+
+    rows = _read_jsonl(tmp_path / "downloader.progress.jsonl")
+    chunks = [r["bytes"] for r in rows if r["event"] == "chunk"]
+    assert chunks == sorted(chunks)
+    assert chunks[-1] == 300
+
+
+async def test_progress_writer_emits_nothing_when_never_used(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, progress=True)
+    async with mgr.task_group:
+        _ = mgr.make_progress_writer(
+            url="https://x/foo.mp4",
+            filename="foo.mp4",
+            total=1000,
+            interval=0.0,
+            min_bytes=0,
+        )
+    assert not (tmp_path / "downloader.progress.jsonl").exists()
+
+
+async def test_progress_writer_done_without_advance_pairs_start_and_finish(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, progress=True)
+    async with mgr.task_group:
+        hook = mgr.make_progress_writer(
+            url="https://x/foo.mp4",
+            filename="foo.mp4",
+            total=1000,
+            interval=0.0,
+            min_bytes=0,
+        )
+        with hook:
+            pass
+
+    rows = _read_jsonl(tmp_path / "downloader.progress.jsonl")
+    assert [r["event"] for r in rows] == ["start", "finish"]
+    assert rows[-1]["bytes"] == 0
+
+
+def test_ensure_parent_creates_dirs(tmp_path: Path) -> None:
+    nested = tmp_path / "a" / "b" / "c.jsonl"
+    csv_logs._ensure_parent(nested)
+    assert nested.parent.is_dir()
+
+
+async def test_progress_event_creates_parent_dir(tmp_path: Path) -> None:
+    main = tmp_path / "nested" / "logs" / "downloader.log"
+    files = CSVFiles(
+        main_log=main,
+        last_post_log=tmp_path / "a.csv",
+        unsupported_urls_log=tmp_path / "b.csv",
+        download_error_log=tmp_path / "c.csv",
+        scrape_error_log=tmp_path / "d.csv",
+        progress_events_file=main.with_suffix(".progress.jsonl"),
+    )
+    mgr = CSVLogsManager(files)
+    async with mgr.task_group:
+        mgr.write_progress_event({"event": "start", "url": "x"})
+
+    expected = main.with_suffix(".progress.jsonl")
+    assert expected.exists()
+    assert _read_jsonl(expected)[0]["event"] == "start"


### PR DESCRIPTION
`cyberdrop-dl` running unattended — cron, container deployments, monitoring scripts, log aggregators, anything wrapping the binary as a subprocess — uses `--ui disabled`, which gives no in-flight machine-readable feed today. The text log is parse-fragile, `results.jsonl` only lands at end-of-run.

Two flag-gated JSONL sinks alongside `--dump-json`:

- `--progress-events` → `downloader.progress.jsonl` — per-file `start` / `chunk` / `finish`
- `--scrape-events` → `downloader.scrape.jsonl` — `FileStats` snapshots + final `scrape_complete`

Throttling: `--progress-event-interval` (0.25s), `--progress-event-bytes` (256 KiB), `--scrape-event-interval` (0.1s). Both default off; no file created, no task spawned when absent.

```jsonl
{"event":"start","ts":1736884403.149,"url":"https://…/foo.mp4","filename":"foo.mp4","total":22651490}
{"event":"chunk","ts":1736884403.402,"url":"https://…/foo.mp4","bytes":524288}
{"event":"finish","ts":1736884406.584,"url":"https://…/foo.mp4","bytes":22651490,"ok":true}
{"event":"stats","ts":1736884405.000,"queued":4118,"completed":0,"previously_completed":0,"skipped":0,"failed":0}
{"event":"scrape_complete","ts":1736884405.110,"queued":4118,"completed":0,"previously_completed":0,"skipped":0,"failed":0}
```

`url` joins against `results.jsonl`. `bytes` on `chunk` is cumulative (resync-safe). `chunk` emits only when both the time and byte thresholds clear since the previous emit. `total` is `null` if there's no `Content-Length`.

Tests in `tests/test_progress_events.py`. Smoke-validated against a real gofile download.

Limitations:

- HLS files emit no progress events — `download_hls_seg()` has no `media_item` to bind a `url` to. They still appear in `scrape.jsonl` and `results.jsonl`. Could be a follow-up.
- `ok` on `finish` is always `true`. Capturing real status would mean changing `ProgressHook.__exit__` to forward `exc_info` to `done` (breaking). Cross-reference `results.jsonl` for ground truth.
