### PR TITLE
refactor: use universal config locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `--cookies` option to read cookies from a file/folder
 - New `--hashes` option to control which hashes CDL computes for new downloads
+- New `--database-file` option
+- New `--cache-file` option
 
 ### Changed
 
@@ -158,6 +160,7 @@ The behavior of `--before` and `--after` has been reversed and the `--exclude` p
 
 Several config options have been removed:
 
+- `--appdata-folder`
 - `--add-md5-hash`
 - `--add-sha256-hash`
 - `--auto-import`

--- a/cyberdrop_dl/appdata.py
+++ b/cyberdrop_dl/appdata.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import final
 
 _WIN_APPDATA: Path | None = None
+_DEFAULT_APP_DIRS: AppDirs | None = None
 logger = logging.getLogger(__name__)
 _appname = "cyberdrop-dl"
 
@@ -42,7 +43,7 @@ def _expand(path: os.PathLike[str] | str) -> Path:
 
 
 def _resolve(path: os.PathLike[str] | str) -> Path:
-    return Path(path).resolve().absolute()
+    return Path(path).expanduser().resolve().absolute()
 
 
 class XDG:
@@ -68,21 +69,27 @@ class AppDirs:
 
     @staticmethod
     def default() -> AppDirs:
+        global _DEFAULT_APP_DIRS  # noqa: PLW0603
+        if _DEFAULT_APP_DIRS is not None:
+            return _DEFAULT_APP_DIRS
+
         if os.name == "nt":
             appdata = _windows_appdata()
-            return AppDirs(
+            _DEFAULT_APP_DIRS = AppDirs(  # pyright: ignore[reportConstantRedefinition]
                 cache=appdata,
                 config=appdata,
                 data=appdata,
                 logs=appdata / "Logs",
             )
 
-        return AppDirs(
-            cache=_resolve(XDG.CACHE_HOME) / _appname,
-            config=_resolve(XDG.CONFIG_HOME) / _appname,
-            data=_resolve(XDG.DATA_HOME) / _appname,
-            logs=_resolve(XDG.STATE_HOME) / _appname / "logs",
-        )
+        else:
+            _DEFAULT_APP_DIRS = AppDirs(  # pyright: ignore[reportConstantRedefinition]
+                cache=_resolve(XDG.CACHE_HOME) / _appname,
+                config=_resolve(XDG.CONFIG_HOME) / _appname,
+                data=_resolve(XDG.DATA_HOME) / _appname,
+                logs=_resolve(XDG.STATE_HOME) / _appname / "logs",
+            )
+        return _DEFAULT_APP_DIRS
 
     def __json__(self) -> dict[str, str]:
         return {k: str(v) for k, v in dataclasses.asdict(self).items()}
@@ -97,6 +104,25 @@ class AppData:
     logs_folder: Path
 
     __json__ = AppDirs.__json__
+
+    @staticmethod
+    def create(
+        *,
+        config_file: Path | None = None,
+        cache_file: Path | None = None,
+        db_file: Path | None = None,
+    ):
+        default = AppData.default()
+
+        def resolve(path: Path | None) -> Path | None:
+            return _resolve(path) if path else None
+
+        return AppData(
+            config_file=resolve(config_file) or default.config_file,
+            cache_file=resolve(cache_file) or default.cache_file,
+            db_file=resolve(db_file) or default.db_file,
+            logs_folder=default.logs_folder,
+        )
 
     @staticmethod
     def default() -> AppData:

--- a/cyberdrop_dl/appdata.py
+++ b/cyberdrop_dl/appdata.py
@@ -25,14 +25,14 @@ def _windows_appdata() -> Path:
     anchor = appdata / "cdl.anchor"
     anchor.touch()
     try:
-        real_appdata = _win_appdata = anchor.resolve().parent  # pyright: ignore[reportConstantRedefinition]
-        if appdata != real_appdata:
-            logger.warning("Windows virtualized path detected at '%s'. Real destination: '%s'", appdata, real_appdata)
+        _win_appdata = anchor.resolve().parent
+        if appdata != _win_appdata:
+            logger.warning("Windows virtualized path detected at '%s'. Real destination: '%s'", appdata, _win_appdata)
         try:
-            real_appdata.rmdir()
+            _win_appdata.rmdir()
         except OSError:
             pass
-        return real_appdata
+        return _win_appdata
     finally:
         anchor.unlink()
 

--- a/cyberdrop_dl/appdata.py
+++ b/cyberdrop_dl/appdata.py
@@ -7,9 +7,9 @@ from enum import StrEnum
 from pathlib import Path
 from typing import final
 
-_WIN_APPDATA: Path | None = None
-_DEFAULT_APP_DIRS: AppDirs | None = None
 logger = logging.getLogger(__name__)
+_win_appdata: Path | None = None
+_default_app_dirs: AppDirs | None = None
 _appname = "cyberdrop-dl"
 
 
@@ -18,15 +18,15 @@ def _windows_appdata() -> Path:
     # https://github.com/Cyberdrop-DL/cyberdrop-dl/issues/1700#issuecomment-4317561031
     # https://learn.microsoft.com/en-us/windows/msix/desktop/flexible-virtualization#default-msix-behavior
 
-    global _WIN_APPDATA  # noqa: PLW0603
-    if _WIN_APPDATA is not None:
-        return _WIN_APPDATA
+    global _win_appdata  # noqa: PLW0603
+    if _win_appdata is not None:
+        return _win_appdata
     appdata = _expand("%APPDATA%") / _appname
     appdata.mkdir(parents=True, exist_ok=True)
     anchor = appdata / "cdl.anchor"
     anchor.touch()
     try:
-        real_appdata = _WIN_APPDATA = anchor.resolve().parent  # pyright: ignore[reportConstantRedefinition]
+        real_appdata = _win_appdata = anchor.resolve().parent  # pyright: ignore[reportConstantRedefinition]
         if appdata != real_appdata:
             logger.warning("Windows virtualized path detected at '%s'. Real destination: '%s'", appdata, real_appdata)
         try:
@@ -39,7 +39,7 @@ def _windows_appdata() -> Path:
 
 
 def _expand(path: os.PathLike[str] | str) -> Path:
-    return Path(os.path.expandvars(os.path.expanduser(path)))  # noqa: PTH111
+    return Path(os.path.expandvars(path)).expanduser()
 
 
 def _resolve(path: os.PathLike[str] | str) -> Path:
@@ -69,13 +69,13 @@ class AppDirs:
 
     @staticmethod
     def default() -> AppDirs:
-        global _DEFAULT_APP_DIRS  # noqa: PLW0603
-        if _DEFAULT_APP_DIRS is not None:
-            return _DEFAULT_APP_DIRS
+        global _default_app_dirs  # noqa: PLW0603
+        if _default_app_dirs is not None:
+            return _default_app_dirs
 
         if os.name == "nt":
             appdata = _windows_appdata()
-            _DEFAULT_APP_DIRS = AppDirs(  # pyright: ignore[reportConstantRedefinition]
+            _default_app_dirs = AppDirs(
                 cache=appdata,
                 config=appdata,
                 data=appdata,
@@ -83,13 +83,13 @@ class AppDirs:
             )
 
         else:
-            _DEFAULT_APP_DIRS = AppDirs(  # pyright: ignore[reportConstantRedefinition]
+            _default_app_dirs = AppDirs(
                 cache=_resolve(XDG.CACHE_HOME) / _appname,
                 config=_resolve(XDG.CONFIG_HOME) / _appname,
                 data=_resolve(XDG.DATA_HOME) / _appname,
                 logs=_resolve(XDG.STATE_HOME) / _appname / "logs",
             )
-        return _DEFAULT_APP_DIRS
+        return _default_app_dirs
 
     def __json__(self) -> dict[str, str]:
         return {k: str(v) for k, v in dataclasses.asdict(self).items()}

--- a/cyberdrop_dl/appdata.py
+++ b/cyberdrop_dl/appdata.py
@@ -127,6 +127,15 @@ class AppData:
             logs_folder=app_dirs.logs,
         )
 
+    def mkdirs(self) -> None:
+        for folder in {
+            self.config_file.parent,
+            self.cache_file.parent,
+            self.db_file.parent,
+            self.logs_folder,
+        }:
+            folder.mkdir(parents=True, exist_ok=True)
+
 
 if __name__ == "__main__":
     print(AppDirs.default().__json__())  # noqa: T201

--- a/cyberdrop_dl/appdata.py
+++ b/cyberdrop_dl/appdata.py
@@ -4,7 +4,10 @@ import dataclasses
 import logging
 import os
 from pathlib import Path
-from typing import final
+from typing import TYPE_CHECKING, final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 logger = logging.getLogger(__name__)
 _win_appdata: Path | None = None
@@ -84,8 +87,11 @@ class AppDirs:
             )
         return _default_app_dirs
 
+    def __iter__(self) -> Iterator[tuple[str, Path]]:
+        return iter(dataclasses.asdict(self).items())
+
     def __json__(self) -> dict[str, str]:
-        return {k: str(v) for k, v in dataclasses.asdict(self).items()}
+        return {k: str(v) for k, v in self}
 
 
 @final
@@ -96,6 +102,7 @@ class AppData:
     db_file: Path
     logs_folder: Path
 
+    __iter__ = AppDirs.__iter__
     __json__ = AppDirs.__json__
 
     @staticmethod
@@ -138,4 +145,4 @@ class AppData:
 
 
 if __name__ == "__main__":
-    print(AppDirs.default().__json__())  # noqa: T201
+    print(dict(AppDirs.default()))  # noqa: T201

--- a/cyberdrop_dl/appdata.py
+++ b/cyberdrop_dl/appdata.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+from enum import StrEnum
+from pathlib import Path
+from typing import final
+
+_WIN_APPDATA: Path | None = None
+logger = logging.getLogger(__name__)
+_appname = "cyberdrop-dl"
+
+
+def _windows_appdata() -> Path:
+    # Detect the real path when running in sandboxed interpreter (ex: UWP Python)
+    # https://github.com/Cyberdrop-DL/cyberdrop-dl/issues/1700#issuecomment-4317561031
+    # https://learn.microsoft.com/en-us/windows/msix/desktop/flexible-virtualization#default-msix-behavior
+
+    global _WIN_APPDATA  # noqa: PLW0603
+    if _WIN_APPDATA is not None:
+        return _WIN_APPDATA
+    appdata = _expand("%APPDATA%") / _appname
+    appdata.mkdir(parents=True, exist_ok=True)
+    anchor = appdata / "cdl.anchor"
+    anchor.touch()
+    try:
+        real_appdata = _WIN_APPDATA = anchor.resolve().parent  # pyright: ignore[reportConstantRedefinition]
+        if appdata != real_appdata:
+            logger.warning("Windows virtualized path detected at '%s'. Real destination: '%s'", appdata, real_appdata)
+        try:
+            real_appdata.rmdir()
+        except OSError:
+            pass
+        return real_appdata
+    finally:
+        anchor.unlink()
+
+
+def _expand(path: os.PathLike[str] | str) -> Path:
+    return Path(os.path.expandvars(os.path.expanduser(path)))  # noqa: PTH111
+
+
+def _resolve(path: os.PathLike[str] | str) -> Path:
+    return Path(path).resolve().absolute()
+
+
+class XDG:
+    CACHE_HOME: Path = _expand(os.getenv("XDG_CACHE_HOME") or "~/.cache")
+    CONFIG_HOME: Path = _expand(os.getenv("XDG_CONFIG_HOME") or "~/.config")
+    DATA_HOME: Path = _expand(os.getenv("XDG_DATA_HOME") or "~/.local/share")
+    STATE_HOME: Path = _expand(os.getenv("XDG_STATE_HOME") or "~/.local/state")
+
+
+class AppFiles(StrEnum):
+    cache = "cache.json"
+    config = "config.yaml"
+    database = "cyberdrop.db"
+
+
+@final
+@dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
+class AppDirs:
+    cache: Path
+    config: Path
+    data: Path
+    logs: Path
+
+    @staticmethod
+    def default() -> AppDirs:
+        if os.name == "nt":
+            appdata = _windows_appdata()
+            return AppDirs(
+                cache=appdata,
+                config=appdata,
+                data=appdata,
+                logs=appdata / "Logs",
+            )
+
+        return AppDirs(
+            cache=_resolve(XDG.CACHE_HOME) / _appname,
+            config=_resolve(XDG.CONFIG_HOME) / _appname,
+            data=_resolve(XDG.DATA_HOME) / _appname,
+            logs=_resolve(XDG.STATE_HOME) / _appname / "logs",
+        )
+
+    def __json__(self) -> dict[str, str]:
+        return {k: str(v) for k, v in dataclasses.asdict(self).items()}
+
+
+@final
+@dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
+class AppData:
+    config_file: Path
+    cache_file: Path
+    db_file: Path
+    logs_folder: Path
+
+    __json__ = AppDirs.__json__
+
+    @staticmethod
+    def default() -> AppData:
+        app_dirs = AppDirs.default()
+        return AppData(
+            config_file=app_dirs.config / AppFiles.config,
+            cache_file=app_dirs.cache / AppFiles.cache,
+            db_file=app_dirs.data / AppFiles.database,
+            logs_folder=app_dirs.logs,
+        )
+
+
+if __name__ == "__main__":
+    print(AppDirs.default().__json__())  # noqa: T201

--- a/cyberdrop_dl/appdata.py
+++ b/cyberdrop_dl/appdata.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
-from enum import StrEnum
 from pathlib import Path
 from typing import final
 
@@ -51,12 +50,6 @@ class XDG:
     CONFIG_HOME: Path = _expand(os.getenv("XDG_CONFIG_HOME") or "~/.config")
     DATA_HOME: Path = _expand(os.getenv("XDG_DATA_HOME") or "~/.local/share")
     STATE_HOME: Path = _expand(os.getenv("XDG_STATE_HOME") or "~/.local/state")
-
-
-class AppFiles(StrEnum):
-    cache = "cache.json"
-    config = "config.yaml"
-    database = "cyberdrop.db"
 
 
 @final
@@ -128,9 +121,9 @@ class AppData:
     def default() -> AppData:
         app_dirs = AppDirs.default()
         return AppData(
-            config_file=app_dirs.config / AppFiles.config,
-            cache_file=app_dirs.cache / AppFiles.cache,
-            db_file=app_dirs.data / AppFiles.database,
+            config_file=app_dirs.config / "config.yaml",
+            cache_file=app_dirs.cache / "cache.json",
+            db_file=app_dirs.data / "cyberdrop.db",
             logs_folder=app_dirs.logs,
         )
 

--- a/cyberdrop_dl/cli/__init__.py
+++ b/cyberdrop_dl/cli/__init__.py
@@ -15,10 +15,6 @@ class CLIargs(BaseModel):
         default=(),
         description="link(s) to content to download (passing multiple links is supported)",
     )
-    appdata_folder: Path | None = Field(
-        default=None,
-        description="AppData folder path",
-    )
 
     config_file: Path | None = Field(
         default=None,

--- a/cyberdrop_dl/cli/__init__.py
+++ b/cyberdrop_dl/cli/__init__.py
@@ -15,11 +15,10 @@ class CLIargs(BaseModel):
         default=(),
         description="link(s) to content to download (passing multiple links is supported)",
     )
-
-    config_file: Path | None = Field(
-        default=None,
-        description="path to the CDL settings.yaml file to load",
-    )
+    config_file: Path | None = None
+    "path to the config.yaml file to load"
+    cache_file: Path | None = None
+    database_file: Path | None = None
 
     download: bool = Field(
         default=False,

--- a/cyberdrop_dl/cli/download.py
+++ b/cyberdrop_dl/cli/download.py
@@ -133,8 +133,8 @@ def download(
         db_file=cli.database_file,
     )
 
-    system_config = Config.from_file(cli.config_file or appdata.config_file)
-    config = merge_models(system_config, config_overrides) if config_overrides else system_config
+    default_config = Config.from_file(cli.config_file or appdata.config_file)
+    config = merge_models(default_config, config_overrides) if config_overrides else default_config
 
     if not config.ui.mode.is_fullscreen or cli.config_file or config.sort.enabled:
         cli.download = True

--- a/cyberdrop_dl/cli/download.py
+++ b/cyberdrop_dl/cli/download.py
@@ -122,7 +122,7 @@ def download(
     if input_file:
         input_file = input_file.resolve().absolute()
 
-    from cyberdrop_dl.appdata import AppData
+    from cyberdrop_dl.config.appdata import AppData
     from cyberdrop_dl.manager import Manager
 
     cli = cli or CLIargs()

--- a/cyberdrop_dl/cli/download.py
+++ b/cyberdrop_dl/cli/download.py
@@ -124,13 +124,23 @@ def download(
         ),
     ] = None,
     cli: CLIargs | None = None,
-    config_overrides: Config | None = None,
+    cli_overrides: Config | None = None,
 ) -> None:
     if input_file:
         input_file = input_file.resolve().absolute()
 
-    from cyberdrop_dl.config.appdata import AppData
     from cyberdrop_dl.manager import Manager
+
+    appdata, config = _prepare_appdata_and_config(urls, cli, cli_overrides)
+    _main(Manager(cli, appdata, config, input_file))
+
+
+def _prepare_appdata_and_config(
+    urls: tuple[HttpURL, ...] = (),
+    cli: CLIargs | None = None,
+    cli_overrides: Config | None = None,
+):
+    from cyberdrop_dl.config.appdata import AppData
 
     cli = cli or CLIargs()
     cli.links = urls
@@ -141,8 +151,8 @@ def download(
     )
 
     default_config = Config.from_file(cli.config_file or appdata.config_file)
-    config = merge_models(default_config, config_overrides) if config_overrides else default_config
-    _main(Manager(cli, appdata, config, input_file))
+    config = merge_models(default_config, cli_overrides) if cli_overrides else default_config
+    return appdata, config
 
 
 def _check_ffmpeg(config: Config) -> None:

--- a/cyberdrop_dl/cli/download.py
+++ b/cyberdrop_dl/cli/download.py
@@ -28,38 +28,34 @@ async def _scrape(manager: Manager) -> None:
     from cyberdrop_dl.updates import check_latest_pypi
     from cyberdrop_dl.utils import apprise
 
-    with setup_file_logging(
-        manager.config.logs.files.main,
-        level=manager.config.logs.effective_level,
-    ):
-        manager.log_config_settings()
-        if not ffmpeg.is_installed():
-            _check_ffmpeg(manager.config)
+    manager.log_config_settings()
+    if not ffmpeg.is_installed():
+        _check_ffmpeg(manager.config)
+
+    log_spacer()
+    async with manager.database:
+        log_spacer()
+        logger.info("Starting CDL...")
+        async with ScrapeMapper(manager)() as scrape_mapper:
+            stats = await scrape_mapper.run()
 
         log_spacer()
-        async with manager.database:
-            log_spacer()
-            logger.info("Starting CDL...")
-            async with ScrapeMapper(manager)() as scrape_mapper:
-                stats = await scrape_mapper.run()
+        await _post_runtime(manager)
 
-            log_spacer()
-            await _post_runtime(manager)
+        stats_summary = manager.print_stats(stats)
 
-            stats_summary = manager.print_stats(stats)
+        log_spacer()
+        async with manager.http_client.create_aiohttp_session() as session:
+            await check_latest_pypi(session)
+        log_spacer()
+        logger.info("Closing program...")
+        logger.info("Finished downloading. Enjoy :)", extra={"color": "green"})
 
-            log_spacer()
-            async with manager.http_client.create_aiohttp_session() as session:
-                await check_latest_pypi(session)
-            log_spacer()
-            logger.info("Closing program...")
-            logger.info("Finished downloading. Enjoy :)", extra={"color": "green"})
+        if webhook_url := manager.config.notifications.webhook:
+            await webhook.send_notification(webhook_url, stats_summary)
 
-            if webhook_url := manager.config.notifications.webhook:
-                await webhook.send_notification(webhook_url, stats_summary)
-
-            if urls := manager.config.notifications.apprise:
-                await apprise.send_notifications(urls, stats_summary)
+        if urls := manager.config.notifications.apprise:
+            await apprise.send_notifications(urls, stats_summary)
 
 
 async def _post_runtime(manager: Manager) -> None:
@@ -84,6 +80,7 @@ def _main(manager: Manager) -> None:
     from cyberdrop_dl import aio, program_ui
 
     set_console_level(manager.config.logs.effective_console_level)
+    manager.appdata.mkdirs()
     try:
         with manager():
             if (
@@ -93,7 +90,12 @@ def _main(manager: Manager) -> None:
                 or manager.config.sort.enabled
             ):
                 program_ui.run(manager)
-            aio.run(_scrape(manager))
+
+            with setup_file_logging(
+                manager.config.logs.files.main,
+                level=manager.config.logs.effective_level,
+            ):
+                aio.run(_scrape(manager))
 
     except KeyboardInterrupt:
         logger.info("Exiting (Ctrl + C) ...")

--- a/cyberdrop_dl/cli/download.py
+++ b/cyberdrop_dl/cli/download.py
@@ -86,7 +86,12 @@ def _main(manager: Manager) -> None:
     set_console_level(manager.config.logs.effective_console_level)
     try:
         with manager():
-            if not manager.cli_args.download:
+            if (
+                not manager.cli_args.download
+                or not manager.config.ui.mode.is_fullscreen
+                or manager.cli_args.config_file
+                or manager.config.sort.enabled
+            ):
                 program_ui.run(manager)
             aio.run(_scrape(manager))
 
@@ -135,12 +140,7 @@ def download(
 
     default_config = Config.from_file(cli.config_file or appdata.config_file)
     config = merge_models(default_config, config_overrides) if config_overrides else default_config
-
-    if not config.ui.mode.is_fullscreen or cli.config_file or config.sort.enabled:
-        cli.download = True
-
-    manager = Manager(cli, appdata, config, input_file)
-    _main(manager)
+    _main(Manager(cli, appdata, config, input_file))
 
 
 def _check_ffmpeg(config: Config) -> None:

--- a/cyberdrop_dl/cli/download.py
+++ b/cyberdrop_dl/cli/download.py
@@ -117,19 +117,24 @@ def download(
         ),
     ] = None,
     cli: CLIargs | None = None,
-    config: Config | None = None,
+    config_overrides: Config | None = None,
 ) -> None:
     if input_file:
         input_file = input_file.resolve().absolute()
-    from cyberdrop_dl.manager import AppData, Manager
+
+    from cyberdrop_dl.appdata import AppData
+    from cyberdrop_dl.manager import Manager
 
     cli = cli or CLIargs()
     cli.links = urls
-    config = config or Config()
-    appdata = AppData.default()
+    appdata = AppData.create(
+        config_file=cli.config_file,
+        cache_file=cli.cache_file,
+        db_file=cli.database_file,
+    )
 
-    config_file = cli.config_file or appdata.config_file
-    config = merge_models(Config.from_file(config_file), config)
+    system_config = Config.from_file(cli.config_file or appdata.config_file)
+    config = merge_models(system_config, config_overrides) if config_overrides else system_config
 
     if not config.ui.mode.is_fullscreen or cli.config_file or config.sort.enabled:
         cli.download = True

--- a/cyberdrop_dl/cli/download.py
+++ b/cyberdrop_dl/cli/download.py
@@ -126,7 +126,7 @@ def download(
     cli = cli or CLIargs()
     cli.links = urls
     config = config or Config()
-    appdata = AppData.from_path(cli.appdata_folder) if cli.appdata_folder else AppData.default()
+    appdata = AppData.default()
 
     config_file = cli.config_file or appdata.config_file
     config = merge_models(Config.from_file(config_file), config)

--- a/cyberdrop_dl/config/__init__.py
+++ b/cyberdrop_dl/config/__init__.py
@@ -9,6 +9,7 @@ from cyclopts.bind import normalize_tokens
 from pydantic import AfterValidator, BaseModel, Field, NonNegativeInt, PositiveInt
 
 from cyberdrop_dl import yaml
+from cyberdrop_dl.config.appdata import AppData
 from cyberdrop_dl.constants import DEFAULT_DOWNLOAD_STORAGE
 from cyberdrop_dl.exceptions import CDLConfigRuntimeErrorsGroup
 from cyberdrop_dl.models import DeferedModel
@@ -120,11 +121,12 @@ class Config(DeferedModel, title="cyberdrop-dl config"):
         if self._resolved:
             return
 
-        self.logs.resolve_filenames()
+        default_log_folder = AppData.default().logs_folder
+        self.logs.resolve_filenames(default_log_folder)
         _resolve_paths(self)
         if self.logs.expire_after:
             self.logs.delete_old_logs_and_folders()
-            cleanup.rm_empty_dirs(self.logs.folder)
+            cleanup.rm_empty_dirs(self.logs.effective_log_folder)
         self._resolved = True
 
 

--- a/cyberdrop_dl/config/__init__.py
+++ b/cyberdrop_dl/config/__init__.py
@@ -10,7 +10,7 @@ from pydantic import AfterValidator, BaseModel, Field, NonNegativeInt, PositiveI
 
 from cyberdrop_dl import yaml
 from cyberdrop_dl.config.appdata import AppData
-from cyberdrop_dl.constants import DEFAULT_DOWNLOAD_STORAGE
+from cyberdrop_dl.constants import DEFAULT_DOWNLOAD_PATH
 from cyberdrop_dl.exceptions import CDLConfigRuntimeErrorsGroup
 from cyberdrop_dl.models import DeferedModel
 from cyberdrop_dl.models.types import ByteSizeSerilized, FalsyAsTuple  # noqa: TC001
@@ -57,7 +57,7 @@ class Config(DeferedModel, title="cyberdrop-dl config"):
     deep_scrape: bool = False
     delete_empty_folders: bool = True
     delete_partial_files: bool = False
-    download_folder: Annotated[Path, Parameter(alias=("--output", "-o", "-d"))] = DEFAULT_DOWNLOAD_STORAGE
+    download_folder: Annotated[Path, Parameter(alias=("--output", "-o", "-d"))] = DEFAULT_DOWNLOAD_PATH
     downloads: Downloads = Field(default_factory=Downloads)
     dump_json: Annotated[bool, Parameter(alias="-j")] = False
     filters: Filters = Field(default_factory=Filters)

--- a/cyberdrop_dl/config/appdata.py
+++ b/cyberdrop_dl/config/appdata.py
@@ -23,7 +23,8 @@ def _windows_appdata() -> Path:
     global _win_appdata  # noqa: PLW0603
     if _win_appdata is not None:
         return _win_appdata
-    appdata = _expand("%APPDATA%") / _appname
+
+    appdata = Path(os.environ["APPDATA"]) / _appname
     appdata.mkdir(parents=True, exist_ok=True)
     anchor = appdata / "cdl.anchor"
     anchor.touch()
@@ -40,19 +41,19 @@ def _windows_appdata() -> Path:
         anchor.unlink()
 
 
-def _expand(path: os.PathLike[str] | str) -> Path:
-    return Path(os.path.expandvars(path)).expanduser()
+def _resolve(path: Path) -> Path:
+    return path.expanduser().resolve().absolute()
 
 
-def _resolve(path: os.PathLike[str] | str) -> Path:
-    return Path(path).expanduser().resolve().absolute()
+def _xdg_expand(name: str, default: str) -> Path:
+    return Path(os.environ.get(name, default)).expanduser()
 
 
 class XDG:
-    CACHE_HOME: Path = _expand(os.getenv("XDG_CACHE_HOME") or "~/.cache")
-    CONFIG_HOME: Path = _expand(os.getenv("XDG_CONFIG_HOME") or "~/.config")
-    DATA_HOME: Path = _expand(os.getenv("XDG_DATA_HOME") or "~/.local/share")
-    STATE_HOME: Path = _expand(os.getenv("XDG_STATE_HOME") or "~/.local/state")
+    CACHE_HOME: Path = _xdg_expand("XDG_CACHE_HOME", "~/.cache")
+    CONFIG_HOME: Path = _xdg_expand("XDG_CONFIG_HOME", "~/.config")
+    DATA_HOME: Path = _xdg_expand("XDG_DATA_HOME", "~/.local/share")
+    STATE_HOME: Path = _xdg_expand("XDG_STATE_HOME", "~/.local/state")
 
 
 @final
@@ -136,10 +137,6 @@ class AppData:
     @staticmethod
     def default() -> AppData:
         return AppData.from_dirs(AppDirs.default())
-
-    @staticmethod
-    def from_path(path: Path) -> AppData:
-        return AppData.from_dirs(AppDirs.from_path(path))
 
     @staticmethod
     def from_dirs(app_dirs: AppDirs) -> AppData:

--- a/cyberdrop_dl/config/appdata.py
+++ b/cyberdrop_dl/config/appdata.py
@@ -145,4 +145,4 @@ class AppData:
 
 
 if __name__ == "__main__":
-    print(dict(AppDirs.default()))  # noqa: T201
+    print(AppDirs.default().__json__())  # noqa: T201

--- a/cyberdrop_dl/config/appdata.py
+++ b/cyberdrop_dl/config/appdata.py
@@ -29,16 +29,17 @@ def _windows_appdata() -> Path:
     anchor = appdata / "cdl.anchor"
     anchor.touch()
     try:
-        _win_appdata = anchor.resolve().parent
-        if appdata != _win_appdata:
-            logger.warning("Windows virtualized path detected at '%s'. Real destination: '%s'", appdata, _win_appdata)
-        try:
-            _win_appdata.rmdir()
-        except OSError:
-            pass
-        return _win_appdata
+        _win_appdata = anchor.resolve(strict=True).parent
     finally:
-        anchor.unlink()
+        anchor.unlink(missing_ok=True)
+
+    if appdata != _win_appdata:
+        logger.warning("Windows virtualized path detected at '%s'. Real destination: '%s'", appdata, _win_appdata)
+    try:
+        _win_appdata.rmdir()
+    except OSError:
+        pass
+    return _win_appdata
 
 
 def _resolve(path: Path) -> Path:

--- a/cyberdrop_dl/config/appdata.py
+++ b/cyberdrop_dl/config/appdata.py
@@ -64,6 +64,15 @@ class AppDirs:
     logs: Path
 
     @staticmethod
+    def from_path(path: Path) -> AppDirs:
+        return AppDirs(
+            cache=path,
+            config=path,
+            data=path,
+            logs=path,
+        )
+
+    @staticmethod
     def default() -> AppDirs:
         global _default_app_dirs  # noqa: PLW0603
         if _default_app_dirs is not None:
@@ -126,7 +135,14 @@ class AppData:
 
     @staticmethod
     def default() -> AppData:
-        app_dirs = AppDirs.default()
+        return AppData.from_dirs(AppDirs.default())
+
+    @staticmethod
+    def from_path(path: Path):
+        return AppData.from_dirs(AppDirs.from_path(path))
+
+    @staticmethod
+    def from_dirs(app_dirs: AppDirs) -> AppData:
         return AppData(
             config_file=app_dirs.config / "config.yaml",
             cache_file=app_dirs.cache / "cache.json",

--- a/cyberdrop_dl/config/appdata.py
+++ b/cyberdrop_dl/config/appdata.py
@@ -138,7 +138,7 @@ class AppData:
         return AppData.from_dirs(AppDirs.default())
 
     @staticmethod
-    def from_path(path: Path):
+    def from_path(path: Path) -> AppData:
         return AppData.from_dirs(AppDirs.from_path(path))
 
     @staticmethod

--- a/cyberdrop_dl/config/default.json
+++ b/cyberdrop_dl/config/default.json
@@ -130,7 +130,7 @@
       "scrape_errors": "Scrape_Error_URLs.csv",
       "unsupported": "Unsupported_URLs.csv"
     },
-    "folder": "AppData/Logs",
+    "folder": null,
     "expire_after": null,
     "rotate": false
   },

--- a/cyberdrop_dl/config/schema.json
+++ b/cyberdrop_dl/config/schema.json
@@ -589,10 +589,8 @@
           "$ref": "#/$defs/LogFiles"
         },
         "folder": {
-          "default": "AppData/Logs",
-          "format": "path",
-          "title": "Folder",
-          "type": "string"
+          "$ref": "#/$defs/FalsyAsNone_Path_",
+          "default": null
         },
         "expire_after": {
           "$ref": "#/$defs/FalsyAsNone_Timedelta_",

--- a/cyberdrop_dl/config/settings.py
+++ b/cyberdrop_dl/config/settings.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, PrivateAttr
 from pydantic.types import ByteSize, NonNegativeFloat, PositiveFloat, PositiveInt
 
 from cyberdrop_dl.constants import (
-    DEFAULT_DOWNLOAD_STORAGE,
+    DEFAULT_DOWNLOAD_PATH,
     LOGS_DATE_FORMAT,
     LOGS_DATETIME_FORMAT,
     CIStrEnum,
@@ -187,7 +187,7 @@ class SortFormats(DeferedModel):
 class Sort(ConfigGroup, name=None):
     enabled: Annotated[bool, Parameter(name="--sort")] = False
     input_folder: FalsyAsNone[Path] = None
-    output_folder: Path = DEFAULT_DOWNLOAD_STORAGE / "Cyberdrop-DL Sorted Downloads"
+    output_folder: Path = DEFAULT_DOWNLOAD_PATH / "Cyberdrop-DL Sorted Downloads"
     formats: SortFormats = Field(default_factory=SortFormats)
 
     @property

--- a/cyberdrop_dl/config/settings.py
+++ b/cyberdrop_dl/config/settings.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel, Field, PrivateAttr
 from pydantic.types import ByteSize, NonNegativeFloat, PositiveFloat, PositiveInt
 
 from cyberdrop_dl.constants import (
-    DEFAULT_APP_STORAGE,
     DEFAULT_DOWNLOAD_STORAGE,
     LOGS_DATE_FORMAT,
     LOGS_DATETIME_FORMAT,
@@ -67,7 +66,7 @@ class Logs(ConfigGroup, name=None):  # noqa: PLW1641
     "Only log messages of this level or higher to the console. An empty or `None` value will use the same level as `log_level`"
 
     files: LogFiles = Field(default_factory=LogFiles)
-    folder: Path = DEFAULT_APP_STORAGE / "Logs"
+    folder: FalsyAsNone[Path] = None
     expire_after: FalsyAsNone[Timedelta] = None
     rotate: bool = False
     _created_at: datetime.datetime = PrivateAttr(default_factory=datetime.datetime.now)
@@ -83,13 +82,13 @@ class Logs(ConfigGroup, name=None):  # noqa: PLW1641
 
         return logging.getLevelNamesMapping()[self.console_level]
 
-    def resolve_filenames(self) -> None:
-        self.folder = self.folder.expanduser().resolve().absolute()
+    def resolve_filenames(self, appdata_folder: Path) -> None:
+        self.folder = folder = self.folder.expanduser().resolve().absolute() if self.folder else appdata_folder
         now_file_iso: str = self._created_at.strftime(LOGS_DATETIME_FORMAT)
         now_folder_iso: str = self._created_at.strftime(LOGS_DATE_FORMAT)
 
         def resolve(path: Path) -> Path:
-            log_file = self.folder / path
+            log_file = folder / path
             if self.rotate:
                 file_name = f"{log_file.stem}_{now_file_iso}{log_file.suffix}"
                 log_file = log_file.parent / now_folder_iso / file_name
@@ -99,11 +98,16 @@ class Logs(ConfigGroup, name=None):  # noqa: PLW1641
             None, **{name: resolve(value) for name, value in self.files.model_dump().items()}
         )
 
+    @property
+    def effective_log_folder(self) -> Path:
+        assert self.folder
+        return self.folder
+
     def delete_old_logs_and_folders(self) -> None:
         if not self.expire_after:
             return
 
-        for file in self.folder.rglob("*"):
+        for file in (self.effective_log_folder).rglob("*"):
             if file.suffix.lower() not in {".log", ".csv"}:
                 continue
 

--- a/cyberdrop_dl/constants.py
+++ b/cyberdrop_dl/constants.py
@@ -59,8 +59,7 @@ class BlockedDomains:
         exact_match = *exact_match, "x.com"
 
 
-DEFAULT_APP_STORAGE = Path("./AppData")
-DEFAULT_DOWNLOAD_STORAGE = Path("./Downloads")
+DEFAULT_DOWNLOAD_PATH = Path("./Downloads")
 
 
 class HashType(StrEnum):

--- a/cyberdrop_dl/manager.py
+++ b/cyberdrop_dl/manager.py
@@ -27,7 +27,6 @@ from cyberdrop_dl.utils import enter_context, get_system_information
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from types import NotImplementedType
 
     from cyberdrop_dl.cli import CLIargs
     from cyberdrop_dl.scrape_mapper import ScrapeMapper, ScrapeStats
@@ -78,7 +77,6 @@ class Manager:
         return self._config
 
     def __resolve_paths(self) -> None:
-        self.appdata.mkdirs()
         self.config.resolve_paths()
         self.logs = CSVLogsManager.from_config(self.config)
         self.logs.delete_old_logs()
@@ -194,18 +192,23 @@ def _cache_context(cache_file: Path, cache: dict[str, Any]) -> Generator[None]:
 
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
 class AppData:
-    path: Path
     cache_file: Path
     config_file: Path
     db_file: Path
 
-    cache: Path
-    cookies: Path
-    configs: Path
-
     @classmethod
     def default(cls) -> Self:
-        return cls.from_path(Path.cwd())
+        path = Path.cwd().expanduser().resolve().absolute() / "AppData"
+        if os.name == "nt":
+            path = cls._resolve_win_path(path)
+
+        cache = path / "Cache"
+        configs = path / "Configs"
+        return cls(
+            config_file=configs / "Default" / "settings.yaml",
+            cache_file=cache / "cache.yaml",
+            db_file=cache / "cyberdrop.db",
+        )
 
     @staticmethod
     def _resolve_win_path(path: Path) -> Path:
@@ -224,40 +227,6 @@ class AppData:
         except OSError:
             pass
         return real_path
-
-    @classmethod
-    def from_path(cls, path: Path) -> Self:
-        path = path.expanduser().resolve().absolute() / "AppData"
-        if os.name == "nt":
-            path = cls._resolve_win_path(path)
-
-        cache = path / "Cache"
-        configs = path / "Configs"
-        return cls(
-            path=path,
-            cache=cache,
-            configs=configs,
-            cookies=path / "Cookies",
-            config_file=configs / "Default" / "settings.yaml",
-            cache_file=cache / "cache.yaml",
-            db_file=cache / "cyberdrop.db",
-        )
-
-    def __truediv__(self, other: os.PathLike[str]) -> Path | NotImplementedType:
-        try:
-            return self.path / other
-        except TypeError:
-            return NotImplemented
-
-    def __fspath__(self) -> str:
-        return str(self)
-
-    def __str__(self) -> str:
-        return str(self.path)
-
-    def mkdirs(self) -> None:
-        for folder in (self.cache, self.configs, self.cookies):
-            folder.mkdir(parents=True, exist_ok=True)
 
 
 def _log_dependencies() -> None:

--- a/cyberdrop_dl/manager.py
+++ b/cyberdrop_dl/manager.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING, Any, Self, final
 from pydantic.types import ByteSize
 
 from cyberdrop_dl import ALL_DEPENDENCIES, __version__, aio, env, ffmpeg, stats, yaml
-from cyberdrop_dl.appdata import AppData
 from cyberdrop_dl.clients.downloads import DownloadClient
 from cyberdrop_dl.clients.http import HTTPClient
 from cyberdrop_dl.config import Config
+from cyberdrop_dl.config.appdata import AppData
 from cyberdrop_dl.csv_logs import CSVLogsManager
 from cyberdrop_dl.database import Database
 from cyberdrop_dl.dedupe import Czkawka

--- a/cyberdrop_dl/manager.py
+++ b/cyberdrop_dl/manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import dataclasses
 import datetime
 import logging
 import os
@@ -13,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Self, final
 from pydantic.types import ByteSize
 
 from cyberdrop_dl import ALL_DEPENDENCIES, __version__, aio, env, ffmpeg, stats, yaml
+from cyberdrop_dl.appdata import AppData
 from cyberdrop_dl.clients.downloads import DownloadClient
 from cyberdrop_dl.clients.http import HTTPClient
 from cyberdrop_dl.config import Config
@@ -73,7 +73,7 @@ class Manager:
     @property
     def config(self) -> Config:
         if self._config is None:
-            self._config = Config.from_file(self.cli_args.config_file or self.appdata.config_file)
+            self._config = Config.from_file(self.appdata.config_file)
         return self._config
 
     def __resolve_paths(self) -> None:
@@ -188,45 +188,6 @@ def _cache_context(cache_file: Path, cache: dict[str, Any]) -> Generator[None]:
     finally:
         cache["version"] = __version__
         yaml.save(cache_file, cache)
-
-
-@dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
-class AppData:
-    cache_file: Path
-    config_file: Path
-    db_file: Path
-
-    @classmethod
-    def default(cls) -> Self:
-        path = Path.cwd().expanduser().resolve().absolute() / "AppData"
-        if os.name == "nt":
-            path = cls._resolve_win_path(path)
-
-        cache = path / "Cache"
-        configs = path / "Configs"
-        return cls(
-            config_file=configs / "Default" / "settings.yaml",
-            cache_file=cache / "cache.yaml",
-            db_file=cache / "cyberdrop.db",
-        )
-
-    @staticmethod
-    def _resolve_win_path(path: Path) -> Path:
-        # Detect the real path when running in sandboxed interpreter (ex: UWP Python)
-        # https://github.com/Cyberdrop-DL/cyberdrop-dl/issues/1700#issuecomment-4317561031
-        # https://learn.microsoft.com/en-us/windows/msix/desktop/flexible-virtualization#default-msix-behavior
-        anchor = path / "cyberdrop_dl.anchor"
-        path.mkdir(parents=True, exist_ok=True)
-        anchor.touch()
-        real_path = anchor.resolve().parent
-        if path != real_path:
-            logger.warning("Windows virtualized path detected at '%s'. Real destination: '%s'", path, real_path)
-        anchor.unlink()
-        try:
-            real_path.rmdir()
-        except OSError:
-            pass
-        return real_path
 
 
 def _log_dependencies() -> None:

--- a/cyberdrop_dl/manager.py
+++ b/cyberdrop_dl/manager.py
@@ -77,6 +77,7 @@ class Manager:
         return self._config
 
     def __resolve_paths(self) -> None:
+        self.appdata.mkdirs()
         self.config.resolve_paths()
         self.logs = CSVLogsManager.from_config(self.config)
         self.logs.delete_old_logs()

--- a/cyberdrop_dl/manager.py
+++ b/cyberdrop_dl/manager.py
@@ -51,7 +51,7 @@ class Manager:
         self._appdata: AppData | None = appdata
         self.cli_args: CLIargs = cli_args or CLIargs()
         self._config: Config | None = config
-        self.input_file: Path = input_file or Path("URLs.txt")
+        self._input_file: Path | None = input_file
 
         self._completed_downloads: list[MediaItem] = []
         self.hasher: Hasher = Hasher(self)
@@ -63,6 +63,12 @@ class Manager:
         self.database: Database
         self.deduper: Czkawka
         self.sorter: Sorter
+
+    @property
+    def input_file(self) -> Path:
+        if self._input_file is None:
+            self._input_file = Path("URLs.txt").absolute()
+        return self._input_file
 
     @property
     def appdata(self) -> AppData:

--- a/cyberdrop_dl/manager.py
+++ b/cyberdrop_dl/manager.py
@@ -144,7 +144,7 @@ class Manager:
         logger.info(f"  URLs source: {scrape_stats.source}")
         logger.info(f"  URLs: {scrape_stats.count:,}")
         logger.info(f"  URL groups: {len(scrape_stats.unique_groups):,}")
-        logger.info(f"  Logs folder: {self.config.logs.folder}")
+        logger.info(f"  Logs folder: {self.config.logs.effective_log_folder}")
         logger.info(f"  Total runtime: {elapsed}")
         logger.info(f"  Total downloaded data: {total_data_written}")
 

--- a/cyberdrop_dl/program_ui.py
+++ b/cyberdrop_dl/program_ui.py
@@ -114,12 +114,18 @@ def _app_header(manager: Manager) -> None:
     _clear_term()
     _CONSOLE.print(f"[bold]cyberdrop-dl ([blue]v{__version__!s}[/blue])[/bold]")
     _CONSOLE.rule(style="blue")
-    _CONSOLE.print("Config file  :", hyperlink(manager.config.source) if manager.config.source else None)
-    _CONSOLE.print("Database file:", hyperlink(manager.appdata.db_file))
-    _CONSOLE.print("URLs file    :", hyperlink(manager.input_file))
-    _CONSOLE.print("Cache file   :", hyperlink(manager.appdata.cache_file))
-    _CONSOLE.print("Logs         :", hyperlink(manager.config.logs.folder))
-    _CONSOLE.print("Main log file:", hyperlink(manager.config.logs.files.main))
+    paths = {
+        "Config file": manager.config.source,
+        "Database file": manager.appdata.db_file,
+        "URLs file": manager.input_file,
+        "Cache file": manager.appdata.cache_file,
+        "Logs": manager.config.logs.effective_log_folder,
+        "Main log file": manager.config.logs.files.main,
+    }
+    padding = max(map(len, paths))
+    for name, file in paths.items():
+        _CONSOLE.print(f"{name:<{padding}} :", hyperlink(file) if file else None)
+
     _CONSOLE.line()
 
 

--- a/cyberdrop_dl/program_ui.py
+++ b/cyberdrop_dl/program_ui.py
@@ -114,9 +114,12 @@ def _app_header(manager: Manager) -> None:
     _clear_term()
     _CONSOLE.print(f"[bold]cyberdrop-dl ([blue]v{__version__!s}[/blue])[/bold]")
     _CONSOLE.rule(style="blue")
-    _CONSOLE.print("Config file:  ", hyperlink(manager.config.source) if manager.config.source else None)
+    _CONSOLE.print("Config file  :", hyperlink(manager.config.source) if manager.config.source else None)
     _CONSOLE.print("Database file:", hyperlink(manager.appdata.db_file))
-    _CONSOLE.print("URLs file:    ", hyperlink(manager.input_file))
+    _CONSOLE.print("URLs file    :", hyperlink(manager.input_file))
+    _CONSOLE.print("Cache file   :", hyperlink(manager.appdata.cache_file))
+    _CONSOLE.print("Logs         :", hyperlink(manager.config.logs.folder))
+    _CONSOLE.print("Main log file:", hyperlink(manager.config.logs.files.main))
     _CONSOLE.line()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ async def logs(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
 def manager(tmp_cwd: Path) -> Generator[Manager]:
     with Manager(
         appdata=AppData.from_dirs(
-            AppDirs.from_path(tmp_cwd / "AppData"),
+            AppDirs.from_path(tmp_cwd / "pytest_appdata"),
         )
     )() as manager:
         yield manager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from cyberdrop_dl.config.appdata import AppData, AppDirs
 from cyberdrop_dl.manager import Manager
 
 if TYPE_CHECKING:
@@ -61,8 +62,12 @@ async def logs(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
 
 
 @pytest.fixture
-def manager() -> Generator[Manager]:
-    with Manager()() as manager:
+def manager(tmp_cwd: Path) -> Generator[Manager]:
+    with Manager(
+        appdata=AppData.from_dirs(
+            AppDirs.from_path(tmp_cwd / "AppData"),
+        )
+    )() as manager:
         yield manager
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 import cyberdrop_dl.cli.download
 from cyberdrop_dl.config import Config, Files, _resolve_paths, merge_additive_args, settings
+from cyberdrop_dl.config.appdata import AppData
 from cyberdrop_dl.config.auth import Authentication, Notifications
 from cyberdrop_dl.exceptions import CDLConfigRuntimeErrorsGroup
 from cyberdrop_dl.models import AppriseURL, merge_dicts
@@ -313,3 +314,26 @@ class TestCensoredConfig:
         noti = Notifications(apprise=(url,))
         assert "example.com" not in repr(noti)
         assert "example.com" not in str(noti)
+
+
+class TestAppData:
+    def test_default_names(self) -> None:
+        appdata = AppData.default()
+        assert appdata.cache_file.name == "cache.json"
+        assert appdata.db_file.name == "cyberdrop.db"
+        assert appdata.config_file.name == "config.yaml"
+
+    def test_default_log_folder_name(self) -> None:
+        appdata = AppData.default()
+        assert appdata.logs_folder.name == "Logs" if os.name == "nt" else "logs"
+
+    def test_create_w_no_args_is_default(self) -> None:
+        assert AppData.create() == AppData.default()
+
+
+def test_log_folder_after_resolution(tmp_cwd: Path) -> None:
+    logs = settings.Logs()
+    assert logs.folder is None
+    tmp_log_folder = tmp_cwd / "logs"
+    logs.resolve_filenames(tmp_log_folder)
+    assert logs.folder == tmp_log_folder


### PR DESCRIPTION
- Add XDG spec support for app files on unix
- Use `%AppData%` for app files on Windows
- Remove `--appdata-folder` option
- Supersedes #1840
- Closes #1221