### PR TITLE
fix: concat MP4 fragments without ffmpeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use binary units instead of decimal units for file sizes
 - Increased database disk pre-allocation from 100 MiB to 250 MiB
 
+### Fixed
+
+- `FFmpeg Concat Error` on every stream (CloudflareStream)
+- M3U8 downloads of fragmented MP4s (HLS)
+
 ## [10.0.0] - 2026-06-28
 
 ⚠️**IMPORTANT**

--- a/cyberdrop_dl/downloader/hls.py
+++ b/cyberdrop_dl/downloader/hls.py
@@ -112,7 +112,7 @@ async def _download_m3u8(
 
     logger.debug(f"Starting HLS download ({m3u8.media_type}, {len(segments):,} segments) for {media_item.real_url}")
     results = await _download_segments(m_segments, m3u8.total_segments, download, sem)
-    await _merge_segments(tuple(result.item.path for result in results), output, m3u8.media_type)
+    await _merge_segments(tuple(result.item.path for result in results), output)
     return output
 
 
@@ -136,18 +136,12 @@ async def _download_segments(
     return results
 
 
-async def _merge_segments(seg_paths: Sequence[Path], output: Path, media_type: str) -> None:
+async def _merge_segments(seg_paths: Sequence[Path], output: Path) -> None:
     if len(seg_paths) == 1:
         _ = await aio.move(seg_paths[0], output)
         return
 
-    if media_type == "subtitle":
-        await ffmpeg.merge_subs(seg_paths, output)
-        return
-
-    ffmpeg_result = await ffmpeg.concat(seg_paths, output)
-    if not ffmpeg_result.success:
-        raise DownloadError("FFmpeg Concat Error", ffmpeg_result.stderr)
+    await ffmpeg.raw_concat(seg_paths, output)
 
 
 def _prepare_output_path(m3u8: M3U8, output: Path) -> Path:

--- a/cyberdrop_dl/downloader/http.py
+++ b/cyberdrop_dl/downloader/http.py
@@ -307,6 +307,10 @@ class Downloader:
             if not ffmpeg_result.success:
                 raise DownloadError("FFmpeg Concat Error", ffmpeg_result.stderr, media_item)
 
+        logger.debug(f"Running MP4 fixup ({media_item.real_url})")
+        ffmpeg_result = await ffmpeg.fixup_video(media_item.path)
+        if not ffmpeg_result.success:
+            raise DownloadError("FFmpeg Fixup Error", ffmpeg_result.stderr, media_item)
         await self.client.process_completed(media_item, media_item.domain)
         await self.client.handle_media_item_completion(media_item, downloaded=True)
         await self.__finalize_download(media_item)

--- a/cyberdrop_dl/ffmpeg.py
+++ b/cyberdrop_dl/ffmpeg.py
@@ -117,12 +117,14 @@ async def concat(input_files: Iterable[Path], output_file: Path) -> SubProcessRe
 
 
 async def _concat(input_file: Path, /, output: Path) -> SubProcessResult:
-    concatenated_file = output.with_suffix(".concat" + output.suffix)
-    command = *_FFMPEG_CALL_PREFIX, *Args.CONCAT, input_file, *Args.CODEC_COPY, concatenated_file
+    temp_file = output.with_suffix(".concat" + output.suffix)
+    command = *_FFMPEG_CALL_PREFIX, *Args.CONCAT, input_file, *Args.CODEC_COPY, temp_file
     result = await _run_command(command)
-    if not result.success:
-        return result
-    return await _fixup_concat_video(concatenated_file, output)
+    if result.success:
+        await aio.move(temp_file, output)
+    else:
+        await _try_delete(temp_file)
+    return result
 
 
 async def _create_concat_file(input_files: Iterable[Path], output_file: Path) -> None:
@@ -135,15 +137,20 @@ async def _create_concat_file(input_files: Iterable[Path], output_file: Path) ->
     return await asyncio.to_thread(write)
 
 
-async def _fixup_concat_video(input_file: Path, output_file: Path) -> SubProcessResult:
-    command = *_FFMPEG_CALL_PREFIX, "-i", input_file, *Args.FIXUP_MP4
-    probe_result = await probe(input_file)
+async def fixup_video(file: Path) -> SubProcessResult:
+    temp_file = file.with_suffix(".fixup" + file.suffix)
+    command = *_FFMPEG_CALL_PREFIX, "-i", file, *Args.FIXUP_MP4
+    probe_result = await probe(file)
     if probe_result and (audio := probe_result.audio) and audio.codec == "aac":
         command = *command, *Args.FIXUP_AUDIO_DTS_FILTER
-    command = *command, output_file
+    command = *command, temp_file
     result = await _run_command(command)
     if result.success:
-        await _try_delete(input_file)
+        await aio.unlink(file)
+        await aio.move(temp_file, file)
+    else:
+        await _try_delete(temp_file)
+
     return result
 
 
@@ -154,9 +161,10 @@ async def _try_delete(file: Path) -> None:
         logger.warning(f"Unable to delete '{file}' {e}")
 
 
-async def merge_subs(files: Iterable[Path], output: Path) -> None:
+async def raw_concat(files: Iterable[Path], output: Path) -> None:
     logger.debug("Merging subs to '%s'", output)
     await asyncio.to_thread(_raw_concat, files, output)
+    await aio.gather(*map(_try_delete, files))
 
 
 def _raw_concat(files: Iterable[Path], output: Path) -> None:
@@ -164,8 +172,6 @@ def _raw_concat(files: Iterable[Path], output: Path) -> None:
         for file in files:
             with file.open("rb") as fp_in:
                 out.write(fp_in.read())
-
-            file.unlink()
 
 
 async def probe(file: Path, /) -> FFprobeResult:

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -180,8 +180,6 @@ class TestMergeSubs:
         ffmpeg._raw_concat(srcs, out)
 
         assert out.read_bytes() == b"AAA\nBBB\nCCC\n"
-        for p in srcs:
-            assert not p.exists()
 
     def test_empty_input(self, tmp_path: Path) -> None:
         out = tmp_path / "empty.srt"
@@ -194,4 +192,3 @@ class TestMergeSubs:
         out = tmp_path / "out.srt"
         ffmpeg._raw_concat([src], out)
         assert out.read_bytes() == b" test \n"
-        assert not src.exists()


### PR DESCRIPTION
Concat them as raw bytes and then run MP4 fix-up on the final file

- Fixes #1968 