### PR TITLE
refactor: add custom HTTP context class

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -21,6 +21,6 @@ jobs:
 
       - uses: astral-sh/ruff-action@v4.0.0
         with:
-          version: "15.22"
+          version: ">=15.0<16.0"
       - run: ruff format --check --diff
         if: ${{ !cancelled() }}

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -20,5 +20,7 @@ jobs:
           persist-credentials: false
 
       - uses: astral-sh/ruff-action@v4.0.0
+        with:
+          version: "15.22"
       - run: ruff format --check --diff
         if: ${{ !cancelled() }}

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -21,6 +21,6 @@ jobs:
 
       - uses: astral-sh/ruff-action@v4.0.0
         with:
-          version: ">=0.15.0<0.16.0"
+          version: ">=0.15.0,<0.16.0"
       - run: ruff format --check --diff
         if: ${{ !cancelled() }}

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -21,6 +21,6 @@ jobs:
 
       - uses: astral-sh/ruff-action@v4.0.0
         with:
-          version: ">=15.0<16.0"
+          version: ">=0.15.0<0.16.0"
       - run: ruff format --check --diff
         if: ${{ !cancelled() }}

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -8,24 +8,26 @@ import time
 import warnings
 from contextvars import ContextVar
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Literal, Protocol, Self, cast, final
+from typing import TYPE_CHECKING, Any, Literal, Protocol, Self, Unpack, cast, final
 
 import aiohttp
+from aiohttp import hdrs
 from curl_cffi.aio import AsyncCurl
 from curl_cffi.requests import AsyncSession
 from curl_cffi.utils import CurlCffiWarning
 
-from cyberdrop_dl import aio, cookies, ddos_guard, signature
+from cyberdrop_dl import aio, cookies, ddos_guard
 from cyberdrop_dl.clients import flaresolverr, tcp
-from cyberdrop_dl.clients.request import Request, normalize_impersonation, prepare_headers
+from cyberdrop_dl.clients.request import Request, RequestParams
 from cyberdrop_dl.clients.response import AbstractResponse
 from cyberdrop_dl.cookies import make_simple_cookie
 from cyberdrop_dl.exceptions import DDOSGuardError, DownloadError
-from cyberdrop_dl.utils import truncated_preview
+from cyberdrop_dl.utils import enter_context, truncated_preview
+from cyberdrop_dl.utils.dataclass import DictDataclass
 
 if TYPE_CHECKING:
     import ssl
-    from collections.abc import AsyncGenerator, Callable, Mapping
+    from collections.abc import AsyncGenerator, Callable
     from pathlib import Path
 
     from bs4 import BeautifulSoup
@@ -35,7 +37,9 @@ if TYPE_CHECKING:
     from cyberdrop_dl.config import Config
     from cyberdrop_dl.url_objects import AbsoluteHttpURL
 
-JSON_CHECK: ContextVar[Callable[[Any, AbstractResponse[Any]], None] | None] = ContextVar("JSON_CHECK", default=None)
+type JSONCheck = Callable[[Any, AbstractResponse[Any]], None]
+
+JSON_CHECK: ContextVar[JSONCheck | None] = ContextVar("JSON_CHECK", default=None)
 RequestContext = contextlib._AsyncGeneratorContextManager[AbstractResponse[Any]]  # pyright: ignore[reportPrivateUsage]
 
 logger = logging.getLogger(__name__)
@@ -181,71 +185,43 @@ class HTTPClient:
             self.cookies.update_cookies(cookie)
 
     @contextlib.asynccontextmanager
-    async def request(  # noqa: PLR0913
+    async def request(
         self: object,
         url: AbsoluteHttpURL,
         /,
         method: HttpMethod = "GET",
-        headers: Mapping[str, str] | None = None,
-        *,
-        impersonate: str | bool | None = None,
-        data: Any = None,
-        json: Any = None,
-        default_ua: str | None = None,
-        **request_params: Any,
+        **kwargs: Unpack[RequestParams],
     ) -> AsyncGenerator[AbstractResponse[Any]]:
         """Make an HTTP request and retry w flaresolverr if required"""
         self = cast("HTTPClient", self)  # noqa: PLW0642
-        async with self.raw_request(
-            url,
-            method,
-            headers,
-            impersonate=impersonate,
-            data=data,
-            json=json,
-            default_ua=default_ua,
-            request_params=request_params,
-        ) as resp:
+        async with self.raw_request(url, method, **kwargs) as resp:
             try:
                 await check_http_status(resp)
             except DDOSGuardError:
                 await resp.aclose()
                 if not self.flaresolverr:
                     raise
-                yield await self._flaresolverr_request(url, data)
+                yield await self._flaresolverr_request(url, kwargs.get("data"))
             else:
                 yield resp
 
-    @contextlib.asynccontextmanager
-    async def raw_request(  # noqa: PLR0913
+    def raw_request(
         self,
         url: AbsoluteHttpURL,
         /,
         method: HttpMethod = "GET",
-        headers: Mapping[str, str] | None = None,
-        *,
-        impersonate: str | bool | None = None,
-        data: Any = None,
-        json: Any = None,
-        default_ua: str | None = None,
-        request_params: dict[str, Any] | None = None,
-    ) -> AsyncGenerator[AbstractResponse[Any]]:
+        **kwargs: Unpack[RequestParams],
+    ) -> RequestContext:
+        request = Request.from_params(url, method, kwargs)
+        if self.impersonate:
+            request.impersonate = self.impersonate
 
-        request = Request(
-            url=url,
-            method=method,
-            data=data,
-            json=json,
-            params=request_params or {},
-            headers=prepare_headers(headers),
-            impersonate=normalize_impersonation(self.impersonate or impersonate),
-        )
+        if request.impersonate:
+            request.headers.pop(hdrs.USER_AGENT, None)
+        else:
+            request.headers.setdefault(hdrs.USER_AGENT, self.config.network.user_agent)
 
-        if not request.impersonate:
-            _ = request.headers.setdefault("User-Agent", default_ua or self.config.network.user_agent)
-
-        async with self._request(request) as resp:
-            yield resp
+        return self._request(request)
 
     @contextlib.asynccontextmanager
     async def _request(self, request: Request) -> AsyncGenerator[AbstractResponse[Any]]:
@@ -317,6 +293,12 @@ class HTTPClient:
         flaresolverr.verify_solution(self.config.network.user_agent, solution)
         return AbstractResponse.create(solution)
 
+    @contextlib.asynccontextmanager
+    async def rate_limit_ctx(self, domain: str, json_check: JSONCheck | None = None) -> AsyncGenerator[None]:
+        with enter_context(JSON_CHECK, json_check):
+            async with self.rate_limits[domain], self.global_rate_limiter:
+                yield
+
 
 async def _check_json(response: AbstractResponse[Any]) -> None:
     if "json" not in response.content_type:
@@ -333,25 +315,70 @@ async def _check_json(response: AbstractResponse[Any]) -> None:
         return
 
 
-class HTTPMixin:
-    @signature.copy(HTTPClient.request)
-    def request(self, *args: Any, **kwargs: Any) -> RequestContext:
+class HTTPObject(Protocol):
+    __http_config__: HTTPConfig | None = None
+
+
+class HTTPMixin(HTTPObject):
+    def request(
+        self,
+        url: AbsoluteHttpURL,
+        /,
+        method: HttpMethod = "GET",
+        **kwargs: Unpack[RequestParams],
+    ) -> RequestContext:
         raise NotImplementedError
 
-    @signature.copy(request)
-    async def request_json(self, *args: Any, **kwargs: Any) -> Any:
-        async with self.request(*args, **kwargs) as resp:
+    async def request_json(
+        self,
+        url: AbsoluteHttpURL,
+        /,
+        method: HttpMethod = "GET",
+        **kwargs: Unpack[RequestParams],
+    ) -> Any:
+        async with self.request(url, method, **kwargs) as resp:
             return await resp.json()
 
-    @signature.copy(request)
-    async def request_soup(self, *args: Any, **kwargs: Any) -> BeautifulSoup:
-        async with self.request(*args, **kwargs) as resp:
+    async def request_soup(
+        self,
+        url: AbsoluteHttpURL,
+        /,
+        method: HttpMethod = "GET",
+        **kwargs: Unpack[RequestParams],
+    ) -> BeautifulSoup:
+        async with self.request(url, method, **kwargs) as resp:
             return await resp.soup()
 
-    @signature.copy(request)
-    async def request_text(self, *args: Any, **kwargs: Any) -> str:
-        async with self.request(*args, **kwargs) as resp:
+    async def request_text(
+        self,
+        url: AbsoluteHttpURL,
+        /,
+        method: HttpMethod = "GET",
+        **kwargs: Unpack[RequestParams],
+    ) -> str:
+        async with self.request(url, method, **kwargs) as resp:
             return await resp.text()
+
+    async def request_location(
+        self,
+        url: AbsoluteHttpURL,
+        /,
+        method: HttpMethod = "HEAD",
+        **kwargs: Unpack[RequestParams],
+    ) -> AbsoluteHttpURL | None:
+        async with self.request(url, method, **kwargs) as resp:
+            return resp.location
+
+    async def request_redirect(
+        self,
+        url: AbsoluteHttpURL,
+        /,
+        method: HttpMethod = "HEAD",
+        **kwargs: Unpack[RequestParams],
+    ) -> AbsoluteHttpURL:
+        "Like request_location, but it uses a GET request instead of HEAD to follow all redirects upto the final destination"
+        async with self.request(url, method, **kwargs) as resp:
+            return resp.url
 
 
 def _create_curl_session(config: Config) -> AsyncSession[CurlResponse]:
@@ -370,6 +397,50 @@ def _create_curl_session(config: Config) -> AsyncSession[CurlResponse]:
         timeout=config.network.curl_timeout,
         max_redirects=8,
     )
+
+
+type RateLimit = tuple[float, float]
+
+
+@final
+@dataclasses.dataclass(slots=True, frozen=True)
+class HTTPConfig:
+    headers: dict[str, str] | None = None
+    impersonate: str | bool | None = None
+    rate_limit: RateLimit | None = None
+    user_agent: str | None = None
+
+    __iter__ = DictDataclass.__iter__
+
+    def __post_init__(self) -> None:
+        if self.user_agent:
+            if not self.headers:
+                object.__setattr__(self, "headers", {})
+            assert self.headers is not None
+            self.headers[hdrs.USER_AGENT] = self.user_agent
+            object.__setattr__(self, "user_agent", None)
+
+    @classmethod
+    def _get(cls, obj: object) -> HTTPConfig | None:
+        return getattr(obj, "__http_config__", None)
+
+    def __or__(self, other: HTTPConfig) -> HTTPConfig:
+        changes = {k: v for k, v in other if v is not None}
+
+        if self.headers and other.headers:
+            changes["headers"] = self.headers | other.headers
+
+        elif (headers := (self.headers or other.headers)) is not None:
+            changes["headers"] = headers.copy()
+
+        return dataclasses.replace(self, **changes)
+
+    def __call__[T: HTTPObject](self, obj: type[T]) -> type[T]:
+        if config := self._get(obj):
+            obj.__http_config__ = config | self
+        else:
+            obj.__http_config__ = self
+        return obj
 
 
 async def check_http_status(response: AbstractResponse[Any]) -> None:

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -431,7 +431,7 @@ class HTTPConfig:
         return HTTPConfig(headers={k: v for k, v in headers.items() if v is not None})
 
     @classmethod
-    def _get(cls, obj: object) -> HTTPConfig | None:
+    def get(cls, obj: object) -> HTTPConfig | None:
         return getattr(obj, "__http_config__", None)
 
     def __or__(self, other: HTTPConfig) -> HTTPConfig:
@@ -445,11 +445,11 @@ class HTTPConfig:
 
         return dataclasses.replace(self, **changes)
 
-    def __call__[T: HTTPObject](self, obj: type[T]) -> type[T]:
-        if config := self._get(obj):
-            obj.__http_config__ = config | self
+    def __call__[T](self, obj: type[T]) -> type[T]:
+        if config := self.get(obj):
+            obj.__http_config__ = config | self  # pyright: ignore[reportAttributeAccessIssue]
         else:
-            obj.__http_config__ = self
+            obj.__http_config__ = self  # pyright: ignore[reportAttributeAccessIssue]
         return obj
 
 

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -27,7 +27,7 @@ from cyberdrop_dl.utils.dataclass import DictDataclass
 
 if TYPE_CHECKING:
     import ssl
-    from collections.abc import AsyncGenerator, Callable
+    from collections.abc import AsyncGenerator, Awaitable, Callable
     from pathlib import Path
 
     from bs4 import BeautifulSoup
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 type JSONCheck = Callable[[Any, AbstractResponse[Any]], None]
 
 JSON_CHECK: ContextVar[JSONCheck | None] = ContextVar("JSON_CHECK", default=None)
+
+
 RequestContext = contextlib._AsyncGeneratorContextManager[AbstractResponse[Any]]  # pyright: ignore[reportPrivateUsage]
 
 logger = logging.getLogger(__name__)
@@ -317,17 +319,33 @@ async def _check_json(response: AbstractResponse[Any]) -> None:
 
 class HTTPObject(Protocol):
     __http_config__: HTTPConfig
+    __http_ctx__: HTTPContext
 
 
-class HTTPMixin(HTTPObject):
-    def request(
+class HTTPMixin(HTTPObject, Protocol):
+    client: HTTPClient
+
+    @contextlib.asynccontextmanager
+    async def request(
         self,
         url: AbsoluteHttpURL,
         /,
         method: HttpMethod = "GET",
         **kwargs: Unpack[RequestParams],
-    ) -> RequestContext:
-        raise NotImplementedError
+    ) -> AsyncGenerator[AbstractResponse[Any]]:
+
+        ctx = self.__http_ctx__
+        if ctx.throttle is not None:
+            await ctx.throttle()
+
+        kwargs.setdefault("impersonate", ctx.impersonate)
+        kwargs["headers"] = ctx.headers | kwargs.setdefault("headers", {})
+
+        async with (
+            self.client.rate_limit_ctx(ctx.domain, ctx.json_check),
+            self.client.request(url, method, **kwargs) as resp,
+        ):
+            yield resp
 
     async def request_json(
         self,
@@ -408,6 +426,7 @@ class HTTPConfig:
     headers: dict[str, str] | None = None
     impersonate: str | bool | None = None
     rate_limit: RateLimit | None = None
+    json_check: JSONCheck | None = None
 
     __iter__ = DictDataclass.__iter__
 
@@ -460,7 +479,26 @@ class HTTPContext:
     rate_limit: RateLimit
     json_check: JSONCheck | None = None
     impersonate: str | bool | None = None
+    throttle: Callable[[], Awaitable[Any]] | None = None
     headers: dict[str, str] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def build(
+        cls,
+        domain: str,
+        config: HTTPConfig,
+        throttle: Callable[[], Awaitable[Any]] | None = None,
+    ) -> HTTPContext:
+        assert config.rate_limit is not None
+
+        return cls(
+            domain=domain,
+            rate_limit=config.rate_limit,
+            headers=config.headers or {},
+            impersonate=config.impersonate,
+            json_check=config.json_check,
+            throttle=throttle,
+        )
 
 
 async def check_http_status(response: AbstractResponse[Any]) -> None:

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -391,7 +391,7 @@ class HTTPMixin(HTTPObject, Protocol):
         self,
         url: AbsoluteHttpURL,
         /,
-        method: HttpMethod = "HEAD",
+        method: HttpMethod = "GET",
         **kwargs: Unpack[RequestParams],
     ) -> AbsoluteHttpURL:
         "Like request_location, but it uses a GET request instead of HEAD to follow all redirects upto the final destination"

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -316,7 +316,7 @@ async def _check_json(response: AbstractResponse[Any]) -> None:
 
 
 class HTTPObject(Protocol):
-    __http_config__: HTTPConfig | None = None
+    __http_config__: HTTPConfig
 
 
 class HTTPMixin(HTTPObject):
@@ -412,6 +412,25 @@ class HTTPConfig:
 
     __iter__ = DictDataclass.__iter__
 
+    @classmethod
+    def default_headers(
+        cls,
+        user_agent: str | None = None,
+        referer: str | None = None,
+        host: str | None = None,
+        content_type: str | None = None,
+        accept: str | None = None,
+        **kwargs: str,
+    ) -> HTTPConfig:
+        headers = {
+            hdrs.USER_AGENT: user_agent,
+            hdrs.REFERER: referer,
+            hdrs.HOST: host,
+            hdrs.CONTENT_TYPE: content_type,
+            hdrs.ACCEPT: accept,
+        } | kwargs
+        return HTTPConfig(headers={k: v for k, v in headers.items() if v is not None})
+
     def __post_init__(self) -> None:
         if self.user_agent:
             if not self.headers:
@@ -441,6 +460,14 @@ class HTTPConfig:
         else:
             obj.__http_config__ = self
         return obj
+
+
+@final
+@dataclasses.dataclass(slots=True, frozen=True)
+class HTTPContext:
+    rate_limit: RateLimit
+    impersonate: str | bool | None = None
+    headers: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
 async def check_http_status(response: AbstractResponse[Any]) -> None:

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -8,7 +8,7 @@ import time
 import warnings
 from contextvars import ContextVar
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Literal, Protocol, Self, Unpack, cast, final
+from typing import TYPE_CHECKING, Any, Literal, Protocol, Self, Unpack, final
 
 import aiohttp
 from aiohttp import hdrs
@@ -188,14 +188,13 @@ class HTTPClient:
 
     @contextlib.asynccontextmanager
     async def request(
-        self: object,
+        self,
         url: AbsoluteHttpURL,
         /,
         method: HttpMethod = "GET",
         **kwargs: Unpack[RequestParams],
     ) -> AsyncGenerator[AbstractResponse[Any]]:
         """Make an HTTP request and retry w flaresolverr if required"""
-        self = cast("HTTPClient", self)  # noqa: PLW0642
         async with self.raw_request(url, method, **kwargs) as resp:
             try:
                 await check_http_status(resp)
@@ -317,14 +316,13 @@ async def _check_json(response: AbstractResponse[Any]) -> None:
         return
 
 
-class HTTPObject(Protocol):
+class HTTPController(Protocol):
     __http_config__: HTTPConfig
     __http_ctx__: HTTPContext
-
-
-class HTTPMixin(HTTPObject, Protocol):
     client: HTTPClient
 
+
+class HTTPMixin(HTTPController, Protocol):
     @contextlib.asynccontextmanager
     async def request(
         self,

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -408,7 +408,6 @@ class HTTPConfig:
     headers: dict[str, str] | None = None
     impersonate: str | bool | None = None
     rate_limit: RateLimit | None = None
-    user_agent: str | None = None
 
     __iter__ = DictDataclass.__iter__
 
@@ -430,14 +429,6 @@ class HTTPConfig:
             hdrs.ACCEPT: accept,
         } | kwargs
         return HTTPConfig(headers={k: v for k, v in headers.items() if v is not None})
-
-    def __post_init__(self) -> None:
-        if self.user_agent:
-            if not self.headers:
-                object.__setattr__(self, "headers", {})
-            assert self.headers is not None
-            self.headers[hdrs.USER_AGENT] = self.user_agent
-            object.__setattr__(self, "user_agent", None)
 
     @classmethod
     def _get(cls, obj: object) -> HTTPConfig | None:

--- a/cyberdrop_dl/clients/http.py
+++ b/cyberdrop_dl/clients/http.py
@@ -456,7 +456,9 @@ class HTTPConfig:
 @final
 @dataclasses.dataclass(slots=True, frozen=True)
 class HTTPContext:
+    domain: str
     rate_limit: RateLimit
+    json_check: JSONCheck | None = None
     impersonate: str | bool | None = None
     headers: dict[str, str] = dataclasses.field(default_factory=dict)
 

--- a/cyberdrop_dl/clients/request.py
+++ b/cyberdrop_dl/clients/request.py
@@ -55,12 +55,10 @@ class Request:
     __iter__ = DictDataclass.__iter__
 
     def __json__(self) -> dict[str, Any]:
-        me = {k: v for k, v in self if v is not None}
+        me = {k: v for k, v in self if (v and k != "method") or (k in {"json", "data"} and v is not None)}
         me["url"] = str(self.url)
         if self.headers:
             me["headers"] = dict(self.headers)
-        else:
-            me.pop("headers", None)
         return me
 
     def __str__(self) -> str:

--- a/cyberdrop_dl/clients/request.py
+++ b/cyberdrop_dl/clients/request.py
@@ -2,17 +2,26 @@ from __future__ import annotations
 
 import dataclasses
 import uuid
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, Self, TypedDict, cast
 
 from multidict import CIMultiDict
 
+from cyberdrop_dl.utils.dataclass import DictDataclass, deserialize, fields_names
+
 if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping
+    from collections.abc import Mapping
 
     from curl_cffi.requests.impersonate import BrowserTypeLiteral
     from curl_cffi.requests.session import HttpMethod
 
     from cyberdrop_dl.url_objects import AbsoluteHttpURL
+
+
+class RequestParams(TypedDict, total=False):
+    headers: dict[str, str]
+    impersonate: str | bool | None
+    data: Any
+    json: Any
 
 
 @dataclasses.dataclass(slots=True, kw_only=True)
@@ -28,28 +37,40 @@ class Request:
     id: str = dataclasses.field(init=False, default_factory=lambda: str(uuid.uuid4()))
 
     def __post_init__(self) -> None:
+        self.headers = prepare_headers(self.headers)
+        self.impersonate = _normalize_impersonation(self.impersonate)
         if self.method == "GET" and (self.data or self.json):
             self.method = "POST"
 
-    def __json__(self) -> dict[str, Any]:
-        return dict(self._serialize())
+    @classmethod
+    def from_params(cls, url: AbsoluteHttpURL, method: HttpMethod, params: RequestParams) -> Self:
+        return deserialize(
+            cls,
+            params,
+            url=url,
+            method=method,
+            params={k: v for k, v in params.items() if k not in _REQUEST_FIELDS},
+        )
 
-    def _serialize(self) -> Generator[tuple[str, Any]]:
-        yield "url", str(self.url)
+    __iter__ = DictDataclass.__iter__
+
+    def __json__(self) -> dict[str, Any]:
+        me = {k: v for k, v in self if v is not None}
+        me["url"] = str(self.url)
         if self.headers:
-            yield "headers", dict(self.headers)
-        if self.impersonate is not None:
-            yield "impersonate", self.impersonate
-        if self.data is not None:
-            yield "data", self.data
-        if self.json is not None:
-            yield "json", self.json
+            me["headers"] = dict(self.headers)
+        else:
+            me.pop("headers", None)
+        return me
 
     def __str__(self) -> str:
         return str(self.__json__())
 
 
-def normalize_impersonation(value: str | bool | None, /) -> BrowserTypeLiteral | Literal[False] | None:  # noqa: FBT001
+_REQUEST_FIELDS = set(fields_names(Request))
+
+
+def _normalize_impersonation(value: str | bool | None, /) -> BrowserTypeLiteral | Literal[False] | None:  # noqa: FBT001
     if value is True:
         return "chrome"
     if value is None:

--- a/cyberdrop_dl/crawlers/__init__.py
+++ b/cyberdrop_dl/crawlers/__init__.py
@@ -85,12 +85,12 @@ class Registry:
         cls._loaded = True
 
     @classmethod
-    def _import_from(cls, module: ModuleType) -> Generator[ImportError]:
+    def _import_from(cls, module: ModuleType) -> Generator[Exception]:
         """Import every module (and sub-package) inside *pkg_name*."""
         for sub_module_info in pkgutil.iter_modules(module.__path__, module.__name__ + "."):
             try:
                 sub_module = cls._import_module(sub_module_info.name)
-            except ImportError as e:
+            except Exception as e:  # noqa: BLE001
                 yield e
             else:
                 if sub_module_info.ispkg:

--- a/cyberdrop_dl/crawlers/_fluid_player.py
+++ b/cyberdrop_dl/crawlers/_fluid_player.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar, NamedTuple
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.mediaprops import Resolution
 from cyberdrop_dl.utils import css, open_graph
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -28,9 +29,9 @@ class Format(NamedTuple):
     link_str: str
 
 
+@HTTPConfig(rate_limit=(3, 10))
 class FluidPlayerCrawler(Crawler, is_abc=True):
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 10
 
     @error_handling_wrapper
     async def video(self, scrape_item: ScrapeItem, video_id: str) -> None:

--- a/cyberdrop_dl/crawlers/_hls.py
+++ b/cyberdrop_dl/crawlers/_hls.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Literal, override
+from typing import TYPE_CHECKING, Literal, Unpack, override
 
 from cyberdrop_dl import aio, ffmpeg
 from cyberdrop_dl.exceptions import DownloadError
@@ -14,7 +14,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
     import aiohttp
+    from curl_cffi.requests.session import HttpMethod
 
+    from cyberdrop_dl.clients.request import RequestParams
     from cyberdrop_dl.url_objects import AbsoluteHttpURL
 
 logger = logging.getLogger(__name__)
@@ -36,7 +38,13 @@ class HLSMixin(ABC):
     For multi variant m3u8, the best resolution will be automatically selected"""
 
     @abstractmethod
-    async def request_text(self, url: AbsoluteHttpURL, /, *, headers: dict[str, str] | None = None) -> str: ...
+    async def request_text(
+        self,
+        url: AbsoluteHttpURL,
+        /,
+        method: HttpMethod = "GET",
+        **kwargs: Unpack[RequestParams],
+    ) -> str: ...
 
     async def request_m3u8(
         self,

--- a/cyberdrop_dl/crawlers/_hls.py
+++ b/cyberdrop_dl/crawlers/_hls.py
@@ -36,7 +36,7 @@ class HLSMixin(ABC):
     For multi variant m3u8, the best resolution will be automatically selected"""
 
     @abstractmethod
-    async def request_text(self, url: AbsoluteHttpURL, /, *, headers: Mapping[str, str] | None = None) -> str: ...
+    async def request_text(self, url: AbsoluteHttpURL, /, *, headers: dict[str, str] | None = None) -> str: ...
 
     async def request_m3u8(
         self,

--- a/cyberdrop_dl/crawlers/_kvs.py
+++ b/cyberdrop_dl/crawlers/_kvs.py
@@ -7,7 +7,8 @@ import itertools
 import re
 from typing import TYPE_CHECKING, Any, ClassVar, final
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import DownloadError, ScrapeError
 from cyberdrop_dl.mediaprops import Resolution
 from cyberdrop_dl.utils import css, extr_text, open_graph, parse_url
@@ -48,6 +49,7 @@ class Selector:
         TITLE = "div#list_videos_common_videos_list h1"
 
 
+@HTTPConfig(rate_limit=(6, 5))
 class KernelVideoSharingCrawler(Crawler, is_abc=True):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Albums": "/albums/<album_name>",
@@ -60,7 +62,6 @@ class KernelVideoSharingCrawler(Crawler, is_abc=True):
     }
     NEXT_PAGE_SELECTOR: ClassVar[str] = "li.pagination-next > a"
     THUMBNAIL_SELECTOR: ClassVar[str] = Selector.THUMBNAILS
-    _RATE_LIMIT: ClassVar[RateLimit] = 6, 5
 
     def __init_subclass__(cls, *, ensure_trailing_slash: bool = False, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/cyberdrop_dl/crawlers/_yetishare.py
+++ b/cyberdrop_dl/crawlers/_yetishare.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, final
 
 from bs4 import BeautifulSoup
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths, auto_task_id
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths, auto_task_id
 from cyberdrop_dl.exceptions import DDOSGuardError, PasswordProtectedError, ScrapeError
 from cyberdrop_dl.utils import css, extr_text
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@final
 class Selector:
     DOWNLOAD_BUTTON = ".btn-group.responsiveMobileMargin button:-soup-contains('Download')[onclick*='download_token']"
     DROPDOWN_MENU = ".dropdown-menu.dropdown-info a[onclick*='download_token']"
@@ -33,6 +35,7 @@ class Selector:
     RECAPTCHA = "form[method=POST] script[src*='/recaptcha/api.js']"
 
 
+@HTTPConfig(rate_limit=(5, 1))
 class YetiShareCrawler(Crawler, is_abc=True):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Files": (
@@ -45,7 +48,6 @@ class YetiShareCrawler(Crawler, is_abc=True):
         ),
         "Shared folders": "/shared/<share_key>",
     }
-    _RATE_LIMIT: ClassVar[RateLimit] = 5, 1
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/cyberdrop_dl/crawlers/apkmirror.py
+++ b/cyberdrop_dl/crawlers/apkmirror.py
@@ -4,7 +4,8 @@ import asyncio
 import random
 from typing import TYPE_CHECKING, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css
@@ -21,13 +22,13 @@ class Selector:
     dl_link: str = "a#download-link"
 
 
+@HTTPConfig(rate_limit=(4, 1))
 class APKMirrorCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {"APK": "/apk/<developer>/<application>/<release>/<variant>-download"}
     DOMAIN: ClassVar[str] = "apkmirror.com"
     FOLDER_DOMAIN: ClassVar[str] = "APK Mirror"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://www.apkmirror.com")
     DEFAULT_TRIM_URLS: ClassVar[bool] = False
-    _RATE_LIMIT: ClassVar[RateLimit] = 4, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/archive_org.py
+++ b/cyberdrop_dl/crawlers/archive_org.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
-@HTTPConfig(user_agent=CDL_USER_AGENT, rate_limit=(3, 1))
+@HTTPConfig(rate_limit=(3, 1))
+@HTTPConfig.default_headers(user_agent=CDL_USER_AGENT)
 class ArchiveOrgCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Item": (

--- a/cyberdrop_dl/crawlers/archive_org.py
+++ b/cyberdrop_dl/crawlers/archive_org.py
@@ -9,7 +9,9 @@ import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import API, Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.constants import CDL_USER_AGENT
+from cyberdrop_dl.crawlers.crawler import API, Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils.dataclass import DictDataclass
@@ -21,7 +23,8 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
-class ArchiveOrgCrawler(Crawler, cdl_user_agent=True):
+@HTTPConfig(user_agent=CDL_USER_AGENT, rate_limit=(3, 1))
+class ArchiveOrgCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Item": (
             "/details/<identifier>",
@@ -35,7 +38,6 @@ class ArchiveOrgCrawler(Crawler, cdl_user_agent=True):
 
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://archive.org")
     DOMAIN: ClassVar[str] = "archive.org"
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         if scrape_item.url.host == "web.archive.org":

--- a/cyberdrop_dl/crawlers/archivebate.py
+++ b/cyberdrop_dl/crawlers/archivebate.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, final
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, extr_text, open_graph
@@ -13,12 +14,14 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@final
 class Selector:
     VIDEO = "input[name=fid]"
     USER_NAME = "div.info a[href*='archivebate.store/profile/']"
     SITE_NAME = f"{USER_NAME} + p"
 
 
+@HTTPConfig(rate_limit=(4, 1))
 class ArchiveBateCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/watch/<video_id>",
@@ -26,7 +29,6 @@ class ArchiveBateCrawler(Crawler):
     DOMAIN: ClassVar[str] = "archivebate"
     FOLDER_DOMAIN: ClassVar[str] = "ArchiveBate"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://www.archivebate.store")
-    _RATE_LIMIT: ClassVar[RateLimit] = 4, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/ashemaletube.py
+++ b/cyberdrop_dl/crawlers/ashemaletube.py
@@ -4,7 +4,8 @@ import json
 from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, extr_text, m3u8
@@ -60,6 +61,7 @@ TITLE_TRASH = "Shemale Porn Videos - Trending"
 PRIMARY_URL = AbsoluteHttpURL("https://www.ashemaletube.com")
 
 
+@HTTPConfig(rate_limit=(3, 10))
 class AShemaleTubeCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Playlist": "/playlists/...",
@@ -71,7 +73,6 @@ class AShemaleTubeCrawler(Crawler):
     FOLDER_DOMAIN: ClassVar[str] = "aShemaleTube"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = PRIMARY_URL
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 10
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:  # noqa: PLR0911
         if any(p in scrape_item.url.parts for p in ("creators", "profiles", "pornstars", "model")):

--- a/cyberdrop_dl/crawlers/beeg.py
+++ b/cyberdrop_dl/crawlers/beeg.py
@@ -4,7 +4,8 @@ import dataclasses
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils.dataclass import DictDataclass
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -37,6 +38,7 @@ class Format(DictDataclass):
     url: AbsoluteHttpURL
 
 
+@HTTPConfig(rate_limit=(4, 1))
 class BeegComCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": (
@@ -46,7 +48,6 @@ class BeegComCrawler(Crawler):
     }
     DOMAIN: ClassVar[str] = "beeg.com"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://beeg.com/")
-    _RATE_LIMIT: ClassVar[RateLimit] = 4, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/bunkr.py
+++ b/cyberdrop_dl/crawlers/bunkr.py
@@ -4,12 +4,13 @@ import asyncio
 import dataclasses
 import json
 import re
-from typing import TYPE_CHECKING, Any, ClassVar, override
+from typing import TYPE_CHECKING, Any, ClassVar, final, override
 
 from aiohttp import ClientConnectorError
 
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.crawlers import Registry
-from cyberdrop_dl.crawlers.crawler import API, Crawler, RateLimit, SupportedDomains, SupportedPaths
+from cyberdrop_dl.crawlers.crawler import API, Crawler, SupportedDomains, SupportedPaths
 from cyberdrop_dl.exceptions import DDOSGuardError, ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, open_graph
@@ -28,6 +29,7 @@ _find_js_vars = re.compile(r'var\s+(\w+)\s*=\s*(".*?"|\'.*?\'|[^;]+);', re.DOTAL
 known_bad_hosts: set[str] = set()
 
 
+@final
 class Selector:
     ALBUM_FILES = "script:-soup-contains('window.albumFiles = ')"
     DOWNLOAD_BTN = "a.btn.ic-download-01"
@@ -35,6 +37,7 @@ class Selector:
     JS_VARS = "script:-soup-contains-own('var jsCDN')"
 
 
+@HTTPConfig(rate_limit=(5, 1))
 class BunkrCrawler(Crawler):
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = ("bunkr",)
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
@@ -58,7 +61,7 @@ class BunkrCrawler(Crawler):
         "bunkr.se",
         "bunkrr.su",
     )
-    _RATE_LIMIT: ClassVar[RateLimit] = 5, 1
+
     _known_good_host: ClassVar[str | None] = None
 
     @staticmethod

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -17,8 +17,7 @@ from aiohttp import hdrs
 
 from cyberdrop_dl import aio, env
 from cyberdrop_dl.cache import TTLCacheAdapter
-from cyberdrop_dl.clients.http import HTTPClient, HTTPMixin, RequestContext
-from cyberdrop_dl.constants import CDL_USER_AGENT
+from cyberdrop_dl.clients.http import HTTPClient, HTTPContext, HTTPMixin, RequestContext
 from cyberdrop_dl.crawlers import ALLOW_NO_EXT, SKIP_DOWNLOAD, Registry
 from cyberdrop_dl.crawlers._hls import HLSMixin
 from cyberdrop_dl.downloader.http import Downloader
@@ -137,7 +136,6 @@ class _CrawlerLogger(logging.LoggerAdapter[logging.Logger]):
 
 class Crawler(HTTPMixin, HLSMixin, ABC):
     DOMAIN: ClassVar[str]
-    _IMPERSONATE: ClassVar[str | bool | None] = None
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = ()
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = ()
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {}
@@ -152,11 +150,9 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL]
     _FORUM: ClassVar[bool] = False
 
-    _RATE_LIMIT: ClassVar[RateLimit] = 25, 1
     _DOWNLOAD_SLOTS: ClassVar[int | None] = None
     _SCRAPE_SLOTS: ClassVar[int] = 20
     _USE_DOWNLOAD_SERVERS_LOCKS: ClassVar[bool] = False
-    _DEFAULT_UA: ClassVar[str | None] = None
 
     disabled: bool = False
 
@@ -185,6 +181,11 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         self._semaphore: asyncio.Semaphore = asyncio.Semaphore(self._SCRAPE_SLOTS)
         self.config: Config = manager.config
         self.client: HTTPClient = manager.http_client
+        self.__http_ctx__: HTTPContext = HTTPContext(
+            rate_limit=self.__http_config__.rate_limit or (25, 1),
+            headers=self.__http_config__.headers or {},
+            impersonate=self.__http_ctx__.impersonate,
+        )
         self._task_mngr: Final = task_mng
         self.tui: Final = tui
         self.downloader: Downloader = Downloader(
@@ -208,7 +209,7 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
             if self._ready:
                 return
 
-            self.client.rate_limits[self.DOMAIN] = aio.RateLimiter.w_no_burst(*self._RATE_LIMIT)
+            self.client.rate_limits[self.DOMAIN] = aio.RateLimiter.w_no_burst(*self.__http_ctx__.rate_limit)
             try:
                 await self.__async_post_init__()
             except Exception:
@@ -232,7 +233,6 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         is_generic: bool = False,
         is_debug: bool = False,
         db_path: Literal["url", "name", "path", "path_qs", "path_qs_frag", "path_frag"] | None = None,
-        cdl_user_agent: bool = False,
         **kwargs: Any,
     ) -> None:
         assert cls.__name__.endswith("Crawler"), f"{cls.__name__} does not end with 'Crawler'"
@@ -253,8 +253,6 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
 
         if db_path:
             cls.__db_path__ = staticmethod(_DB_PATH_BUILDERS[db_path])
-        if cdl_user_agent:
-            cls._DEFAULT_UA = CDL_USER_AGENT  # pyright: ignore[reportConstantRedefinition]
 
         if cls.IS_GENERIC:
             cls.SCRAPE_MAPPER_KEYS = ()
@@ -293,12 +291,12 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         method: HttpMethod = "GET",
         **kwargs: Unpack[RequestParams],
     ) -> AsyncGenerator[AbstractResponse[Any]]:
-        kwargs.setdefault("impersonate", self._IMPERSONATE)
-        if self._DEFAULT_UA:
-            kwargs.setdefault("headers", {}).setdefault(hdrs.USER_AGENT, self._DEFAULT_UA)
 
         if _CHECK_DL_CAPACITY.get():
             await self.downloader.capacity.wait(self.FOLDER_DOMAIN)
+
+        kwargs.setdefault("impersonate", self.__http_ctx__.impersonate)
+        kwargs["headers"] = self.__http_ctx__.headers | kwargs.setdefault("headers", {})
 
         async with (
             self.client.rate_limit_ctx(self.DOMAIN, self.__json_resp_check__),
@@ -532,7 +530,7 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
 
     def _prepare_headers(self, scrape_item: ScrapeItem) -> dict[str, str]:
         return {
-            "User-Agent": self._DEFAULT_UA or self.config.network.user_agent,
+            "User-Agent": self.__http_ctx__.headers.get(hdrs.USER_AGENT) or self.config.network.user_agent,
             "Referer": str(scrape_item.url),
         }
 

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -182,19 +182,23 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         self._semaphore: asyncio.Semaphore = asyncio.Semaphore(self._SCRAPE_SLOTS)
         self.config: Config = manager.config
         self.client: HTTPClient = manager.http_client
-        assert self.__http_config__.rate_limit is not None
-        self.__http_ctx__: HTTPContext = HTTPContext(
-            rate_limit=self.__http_config__.rate_limit,
-            headers=self.__http_config__.headers or {},
-            impersonate=self.__http_config__.impersonate,
-        )
-        self._task_mngr: Final = task_mng
-        self.tui: Final = tui
         self.downloader: Downloader = Downloader(
             manager,
             use_server_lock=self._USE_DOWNLOAD_SERVERS_LOCKS,
             _slots=self._DOWNLOAD_SLOTS,
         )
+
+        assert self.__http_config__.rate_limit is not None
+        self.__http_ctx__: HTTPContext = HTTPContext(
+            domain=self.DOMAIN,
+            rate_limit=self.__http_config__.rate_limit,
+            headers=self.__http_config__.headers or {},
+            impersonate=self.__http_config__.impersonate,
+            json_check=self.__json_resp_check__,
+        )
+
+        self._task_mngr: Final = task_mng
+        self.tui: Final = tui
 
         self.__post_init__()
 
@@ -297,11 +301,12 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         if _CHECK_DL_CAPACITY.get():
             await self.downloader.capacity.wait(self.FOLDER_DOMAIN)
 
-        kwargs.setdefault("impersonate", self.__http_ctx__.impersonate)
-        kwargs["headers"] = self.__http_ctx__.headers | kwargs.setdefault("headers", {})
+        ctx = self.__http_ctx__
+        kwargs.setdefault("impersonate", ctx.impersonate)
+        kwargs["headers"] = ctx.headers | kwargs.setdefault("headers", {})
 
         async with (
-            self.client.rate_limit_ctx(self.DOMAIN, self.__json_resp_check__),
+            self.client.rate_limit_ctx(ctx.domain, ctx.json_check),
             self.client.request(url, method, **kwargs) as resp,
         ):
             yield resp

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -17,7 +17,7 @@ from aiohttp import hdrs
 
 from cyberdrop_dl import aio, env
 from cyberdrop_dl.cache import TTLCacheAdapter
-from cyberdrop_dl.clients.http import HTTPClient, HTTPContext, HTTPMixin, RequestContext
+from cyberdrop_dl.clients.http import HTTPClient, HTTPConfig, HTTPContext, HTTPMixin, RequestContext
 from cyberdrop_dl.crawlers import ALLOW_NO_EXT, SKIP_DOWNLOAD, Registry
 from cyberdrop_dl.crawlers._hls import HLSMixin
 from cyberdrop_dl.downloader.http import Downloader
@@ -134,6 +134,7 @@ class _CrawlerLogger(logging.LoggerAdapter[logging.Logger]):
         return f"[{self._crawler_name}] {msg}", kwargs
 
 
+@HTTPConfig(rate_limit=(25, 1))
 class Crawler(HTTPMixin, HLSMixin, ABC):
     DOMAIN: ClassVar[str]
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = ()
@@ -181,10 +182,11 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         self._semaphore: asyncio.Semaphore = asyncio.Semaphore(self._SCRAPE_SLOTS)
         self.config: Config = manager.config
         self.client: HTTPClient = manager.http_client
+        assert self.__http_config__.rate_limit is not None
         self.__http_ctx__: HTTPContext = HTTPContext(
-            rate_limit=self.__http_config__.rate_limit or (25, 1),
+            rate_limit=self.__http_config__.rate_limit,
             headers=self.__http_config__.headers or {},
-            impersonate=self.__http_ctx__.impersonate,
+            impersonate=self.__http_config__.impersonate,
         )
         self._task_mngr: Final = task_mng
         self.tui: Final = tui

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -17,7 +17,7 @@ from aiohttp import hdrs
 
 from cyberdrop_dl import aio, env
 from cyberdrop_dl.cache import TTLCacheAdapter
-from cyberdrop_dl.clients.http import HTTPClient, HTTPConfig, HTTPContext, HTTPMixin, RequestContext
+from cyberdrop_dl.clients.http import HTTPClient, HTTPConfig, HTTPContext, HTTPMixin
 from cyberdrop_dl.crawlers import ALLOW_NO_EXT, SKIP_DOWNLOAD, Registry
 from cyberdrop_dl.crawlers._hls import HLSMixin
 from cyberdrop_dl.downloader.http import Downloader
@@ -188,15 +188,7 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
             _slots=self._DOWNLOAD_SLOTS,
         )
 
-        assert self.__http_config__.rate_limit is not None
-        self.__http_ctx__: HTTPContext = HTTPContext(
-            domain=self.DOMAIN,
-            rate_limit=self.__http_config__.rate_limit,
-            headers=self.__http_config__.headers or {},
-            impersonate=self.__http_config__.impersonate,
-            json_check=self.__json_resp_check__,
-        )
-
+        self.__http_ctx__: HTTPContext = HTTPContext.build(self.DOMAIN, self.__http_config__, self.__throttle)
         self._task_mngr: Final = task_mng
         self.tui: Final = tui
 
@@ -288,6 +280,10 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         )
         if add_to_registry:
             Registry.concrete.add(cls)
+
+    async def __throttle(self) -> None:
+        if _CHECK_DL_CAPACITY.get():
+            await self.downloader.capacity.wait(self.FOLDER_DOMAIN)
 
     @contextlib.asynccontextmanager
     async def request(
@@ -922,31 +918,35 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
 
 class API(HTTPMixin, ABC):
     # We inherit from ABC to force type checkers to recognize attributes defined in __post_init__ as if they were defined in __init__
+
     @final
     def __init__(
         self,
+        domain: str,
         PRIMARY_URL: AbsoluteHttpURL,  # noqa: N803
         config: Config,
-        request: Callable[..., RequestContext],
         cache: TTLCacheAdapter[Any],
         parse_url: Callable[[str | yarl.URL], AbsoluteHttpURL] = parse_url,
     ) -> None:
         self.PRIMARY_URL: Final = PRIMARY_URL
         self.parse_url: Final = parse_url
-        self.request: Final = request
         self.config: Final = config
         self.cache: Final = cache
+        self.__http_ctx__: HTTPContext = HTTPContext.build(domain, self.__http_config__)
         self.__post_init__()
 
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
-        return cls(
+        self = cls(
+            domain=crawler.DOMAIN,
             PRIMARY_URL=crawler.PRIMARY_URL,
             parse_url=crawler.parse_url,
-            request=crawler.request,
             cache=crawler.cache,
             config=crawler.manager.config,
         )
+        self.__http_config__ = crawler.__http_config__ | self.__http_config__
+        self.__http_ctx__ = HTTPContext.build(crawler.DOMAIN, self.__http_config__, crawler.__http_ctx__.throttle)
+        return self
 
     def __post_init__(self) -> None: ...
 

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -61,7 +61,6 @@ logger = logging.getLogger(__name__)
 type OneOrTuple[T] = T | tuple[T, ...]
 type SupportedPaths = dict[str, OneOrTuple[str]]
 type SupportedDomains = OneOrTuple[str]
-type RateLimit = tuple[float, float]
 type DebridURL = Callable[[], Awaitable[AbsoluteHttpURL]] | AbsoluteHttpURL | None
 
 _ORIGIN: ContextVar[AbsoluteHttpURL] = ContextVar("ORIGIN")

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -11,7 +11,7 @@ from collections import Counter
 from contextvars import ContextVar
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, ClassVar, Concatenate, Final, Literal, Self, Unpack, final
+from typing import TYPE_CHECKING, Any, ClassVar, Concatenate, Final, Literal, Self, final
 
 from aiohttp import hdrs
 
@@ -46,9 +46,7 @@ if TYPE_CHECKING:
     import yarl
     from bs4 import BeautifulSoup, Tag
     from curl_cffi.requests.impersonate import BrowserTypeLiteral
-    from curl_cffi.requests.session import HttpMethod
 
-    from cyberdrop_dl.clients.request import RequestParams
     from cyberdrop_dl.clients.response import AbstractResponse
     from cyberdrop_dl.config import Config
     from cyberdrop_dl.database import Database
@@ -283,28 +281,6 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
     async def __throttle(self) -> None:
         if _CHECK_DL_CAPACITY.get():
             await self.downloader.capacity.wait(self.FOLDER_DOMAIN)
-
-    @contextlib.asynccontextmanager
-    async def request(
-        self,
-        url: AbsoluteHttpURL,
-        /,
-        method: HttpMethod = "GET",
-        **kwargs: Unpack[RequestParams],
-    ) -> AsyncGenerator[AbstractResponse[Any]]:
-
-        if _CHECK_DL_CAPACITY.get():
-            await self.downloader.capacity.wait(self.FOLDER_DOMAIN)
-
-        ctx = self.__http_ctx__
-        kwargs.setdefault("impersonate", ctx.impersonate)
-        kwargs["headers"] = ctx.headers | kwargs.setdefault("headers", {})
-
-        async with (
-            self.client.rate_limit_ctx(ctx.domain, ctx.json_check),
-            self.client.request(url, method, **kwargs) as resp,
-        ):
-            yield resp
 
     def __json_resp_check__(self, json_resp: Any, resp: AbstractResponse[Any], /) -> None:
         """Custom check for JSON responses.
@@ -915,8 +891,16 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
             )
 
 
+@HTTPConfig(rate_limit=(25, 1))
 class API(HTTPMixin, ABC):
     # We inherit from ABC to force type checkers to recognize attributes defined in __post_init__ as if they were defined in __init__
+
+    class EntryPoint[T: API]:
+        def __init__(self, api: T) -> None:
+            self.api: T = api
+
+        def __repr__(self) -> str:
+            return f"<{type(self).__name__}>"
 
     @final
     def __init__(

--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -11,11 +11,13 @@ from collections import Counter
 from contextvars import ContextVar
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, ClassVar, Concatenate, Final, Literal, Self, final
+from typing import TYPE_CHECKING, Any, ClassVar, Concatenate, Final, Literal, Self, Unpack, final
 
-from cyberdrop_dl import aio, env, signature
+from aiohttp import hdrs
+
+from cyberdrop_dl import aio, env
 from cyberdrop_dl.cache import TTLCacheAdapter
-from cyberdrop_dl.clients.http import JSON_CHECK, HTTPClient, HTTPMixin, RequestContext
+from cyberdrop_dl.clients.http import HTTPClient, HTTPMixin, RequestContext
 from cyberdrop_dl.constants import CDL_USER_AGENT
 from cyberdrop_dl.crawlers import ALLOW_NO_EXT, SKIP_DOWNLOAD, Registry
 from cyberdrop_dl.crawlers._hls import HLSMixin
@@ -45,7 +47,9 @@ if TYPE_CHECKING:
     import yarl
     from bs4 import BeautifulSoup, Tag
     from curl_cffi.requests.impersonate import BrowserTypeLiteral
+    from curl_cffi.requests.session import HttpMethod
 
+    from cyberdrop_dl.clients.request import RequestParams
     from cyberdrop_dl.clients.response import AbstractResponse
     from cyberdrop_dl.config import Config
     from cyberdrop_dl.database import Database
@@ -281,33 +285,26 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         if add_to_registry:
             Registry.concrete.add(cls)
 
-    @signature.copy(HTTPClient.request)
     @contextlib.asynccontextmanager
     async def request(
         self,
-        *args: Any,
-        impersonate: str | bool | None = None,
-        default_ua: str | None = None,
-        **kwargs: Any,
+        url: AbsoluteHttpURL,
+        /,
+        method: HttpMethod = "GET",
+        **kwargs: Unpack[RequestParams],
     ) -> AsyncGenerator[AbstractResponse[Any]]:
-        if impersonate is None:
-            impersonate = self._IMPERSONATE
+        kwargs.setdefault("impersonate", self._IMPERSONATE)
+        if self._DEFAULT_UA:
+            kwargs.setdefault("headers", {}).setdefault(hdrs.USER_AGENT, self._DEFAULT_UA)
 
         if _CHECK_DL_CAPACITY.get():
             await self.downloader.capacity.wait(self.FOLDER_DOMAIN)
 
-        with enter_context(JSON_CHECK, self.__json_resp_check__):
-            async with (
-                self.client.rate_limits[self.DOMAIN],
-                self.client.global_rate_limiter,
-                self.client.request(
-                    *args,
-                    impersonate=impersonate,
-                    default_ua=default_ua or self._DEFAULT_UA,
-                    **kwargs,
-                ) as resp,
-            ):
-                yield resp
+        async with (
+            self.client.rate_limit_ctx(self.DOMAIN, self.__json_resp_check__),
+            self.client.request(url, method, **kwargs) as resp,
+        ):
+            yield resp
 
     def __json_resp_check__(self, json_resp: Any, resp: AbstractResponse[Any], /) -> None:
         """Custom check for JSON responses.

--- a/cyberdrop_dl/crawlers/cyberdrop.py
+++ b/cyberdrop_dl/crawlers/cyberdrop.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 from cyberdrop_dl import aio
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.crawlers import Registry
-from cyberdrop_dl.crawlers.crawler import API, Crawler, RateLimit, SupportedDomains, SupportedPaths
+from cyberdrop_dl.crawlers.crawler import API, Crawler, SupportedDomains, SupportedPaths
 from cyberdrop_dl.filepath import remove_file_id
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css
@@ -21,6 +22,7 @@ class Selector:
 
 
 @Registry.database.fix_referer
+@HTTPConfig(rate_limit=(5, 1))
 class CyberdropCrawler(Crawler):
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = "k1-cd.cdn.gigachad-cdn.ru", "cyberdrop"
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
@@ -34,7 +36,6 @@ class CyberdropCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://cyberdrop.cr/")
     DOMAIN: ClassVar[str] = "cyberdrop"
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = ("cyberdrop.me", "cyberdrop.to")
-    _RATE_LIMIT: ClassVar[RateLimit] = 5, 1
 
     def __post_init__(self) -> None:
         self.api: CyberdropAPI = CyberdropAPI.from_crawler(self)

--- a/cyberdrop_dl/crawlers/e621.py
+++ b/cyberdrop_dl/crawlers/e621.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
-@HTTPConfig(user_agent=f"{CDL_USER_AGENT} (by B05FDD249DF29ED3)", rate_limit=(2, 1))
+@HTTPConfig(rate_limit=(2, 1))
+@HTTPConfig.default_headers(user_agent=f"{CDL_USER_AGENT} (by B05FDD249DF29ED3)")
 class E621Crawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Post": "/posts/<post_id>",

--- a/cyberdrop_dl/crawlers/e621.py
+++ b/cyberdrop_dl/crawlers/e621.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.constants import CDL_USER_AGENT
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils.errors import error_handling_wrapper
 
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@HTTPConfig(user_agent=f"{CDL_USER_AGENT} (by B05FDD249DF29ED3)", rate_limit=(2, 1))
 class E621Crawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Post": "/posts/<post_id>",
@@ -23,8 +25,6 @@ class E621Crawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://e621.net")
     DOMAIN: ClassVar[str] = "e621.net"
     FOLDER_DOMAIN: ClassVar[str] = "E621"
-    _RATE_LIMIT: ClassVar[RateLimit] = 2, 1
-    _DEFAULT_UA: ClassVar[str | None] = f"{CDL_USER_AGENT} (by B05FDD249DF29ED3)"
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
 

--- a/cyberdrop_dl/crawlers/eporner.py
+++ b/cyberdrop_dl/crawlers/eporner.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from bs4 import BeautifulSoup
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.mediaprops import Resolution
 from cyberdrop_dl.url_objects import AbsoluteHttpURL, ScrapeItem
@@ -54,6 +55,7 @@ class VideoSource:
     format: str
 
 
+@HTTPConfig(rate_limit=(2, 1))
 class EpornerCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Categories": "/cat/...",
@@ -74,7 +76,6 @@ class EpornerCrawler(Crawler):
     DOMAIN: ClassVar[str] = "eporner"
     FOLDER_DOMAIN: ClassVar[str] = "ePorner"
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
-    _RATE_LIMIT: ClassVar[RateLimit] = 2, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:  # noqa: PLR0911
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/fapello.py
+++ b/cyberdrop_dl/crawlers/fapello.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, final
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -12,12 +13,14 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@final
 class Selector:
     POSTS = "a[href]:has(img)"
     IMAGE_OR_VIDEO = ".main_content .uk-align-center [src]"
     NEXT_PAGE = 'div[id="next_page"] a'
 
 
+@HTTPConfig(rate_limit=(5, 1))
 class FapelloComCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Individual Post": "/<model_nam>/<post_id>",
@@ -26,7 +29,6 @@ class FapelloComCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://fapello.com")
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
     DOMAIN: ClassVar[str] = "fapello.com"
-    _RATE_LIMIT: ClassVar[RateLimit] = 5, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/fileditch.py
+++ b/cyberdrop_dl/crawlers/fileditch.py
@@ -7,8 +7,9 @@ import json
 from typing import TYPE_CHECKING, ClassVar, Self, override
 
 from cyberdrop_dl import multi_process
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.crawlers import Registry
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, extr_text, parse_url
@@ -25,6 +26,7 @@ _HOMEPAGE_CATCH_ALL = "/s21/FHVZKQyAZlIsrneDAsp.jpeg"
 
 
 @Registry.database.fix_referer
+@HTTPConfig(rate_limit=(3, 1))
 class FileditchCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "File": (
@@ -36,7 +38,6 @@ class FileditchCrawler(Crawler):
     }
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://fileditchfiles.me/")
     DOMAIN: ClassVar[str] = "fileditch"
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/filester.py
+++ b/cyberdrop_dl/crawlers/filester.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import base64
 import dataclasses
 import time
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, final
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import API, Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import API, Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import PasswordProtectedError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, extr_text, open_graph
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@final
 class Selector:
     FILES = ".file-item[onclick]"
     SUBFOLDER = ".subfolder-item[href]"
@@ -27,6 +29,7 @@ class Selector:
     FILE_DETAILS = "#detailsContent"
 
 
+@HTTPConfig(rate_limit=(4, 1))
 class FilesterCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "File": "/d/<slug>",
@@ -34,7 +37,6 @@ class FilesterCrawler(Crawler):
     }
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://filester.me")
     DOMAIN: ClassVar[str] = "filester"
-    _RATE_LIMIT: ClassVar[RateLimit] = 4, 1
     _DOWNLOAD_SLOTS: ClassVar[int | None] = 4
 
     def __post_init__(self) -> None:

--- a/cyberdrop_dl/crawlers/fourchan.py
+++ b/cyberdrop_dl/crawlers/fourchan.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, NotRequired, TypedDict
 
 from bs4 import BeautifulSoup
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -25,6 +26,7 @@ class ImagePost(TypedDict):
     time: int  # Unix timestamp
 
 
+@HTTPConfig(rate_limit=(3, 10))
 class FourChanCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Board": "/<board>",
@@ -33,7 +35,6 @@ class FourChanCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://boards.4chan.org")
     DOMAIN: ClassVar[str] = "4chan"
     _DOWNLOAD_SLOTS: ClassVar[int | None] = 1
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 10
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/gofile.py
+++ b/cyberdrop_dl/crawlers/gofile.py
@@ -9,7 +9,8 @@ from typing_extensions import ReadOnly
 
 from cyberdrop_dl import env
 from cyberdrop_dl.cache import disk_cached_method
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import PasswordProtectedError, ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL, ScrapeItem, ScrapeItemType
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -56,6 +57,7 @@ class Folder(UnlockedNode):
     passwordStatus: NotRequired[str]
 
 
+@HTTPConfig(rate_limit=(4, 10))
 class GoFileCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Folder / File": "/d/<content_id>",
@@ -71,7 +73,6 @@ class GoFileCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = _PRIMARY_URL
     DOMAIN: ClassVar[str] = "gofile"
     FOLDER_DOMAIN: ClassVar[str] = "GoFile"
-    _RATE_LIMIT: ClassVar[RateLimit] = 4, 10
 
     _SALT: ClassVar[str] = env.GOFILE_SALT or "9844d94d963d30"
     _BROWSER_LANG: ClassVar[str] = "en-US"

--- a/cyberdrop_dl/crawlers/hitomi_la.py
+++ b/cyberdrop_dl/crawlers/hitomi_la.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from cyberdrop_dl import aio
 from cyberdrop_dl.cache import cached_fn
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.crawlers.crawler import API, Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.filepath import get_filename_and_ext
@@ -31,6 +32,7 @@ _LTN_SERVER = AbsoluteHttpURL(f"https://ltn.{_CONTENT_HOST}/")
 _VIDEOS_SERVER = AbsoluteHttpURL(f"https://streaming.{_CONTENT_HOST}/")
 
 
+@HTTPConfig(rate_limit=(3, 1))
 class HitomiLaCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Gallery": tuple(
@@ -62,7 +64,6 @@ class HitomiLaCrawler(Crawler):
     }
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://hitomi.la")
     DOMAIN: ClassVar[str] = "hitomi.la"
-    _RATE_LIMIT: ClassVar[tuple[float, float]] = 3, 1
     _SCRAPE_SLOTS: ClassVar[int] = 3
 
     def __post_init__(self) -> None:

--- a/cyberdrop_dl/crawlers/leakedzone.py
+++ b/cyberdrop_dl/crawlers/leakedzone.py
@@ -6,7 +6,8 @@ import itertools
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, extr_text
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -50,6 +51,7 @@ class Post:
         )
 
 
+@HTTPConfig(rate_limit=(3, 10))
 class LeakedZoneCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/<model_id>/video/<video_id>",
@@ -59,7 +61,6 @@ class LeakedZoneCrawler(Crawler):
     FOLDER_DOMAIN: ClassVar[str] = "LeakedZone"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://leakedzone.com")
     IMAGES_CDN: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://image-cdn.leakedzone.com/storage/")
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 10
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/livestreamfails.py
+++ b/cyberdrop_dl/crawlers/livestreamfails.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import API, Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import API, Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils.dataclass import deserialize
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -19,6 +20,7 @@ class _CDN:
     VIDEO = AbsoluteHttpURL("https://livestreamfails-video-prod.b-cdn.net/video")
 
 
+@HTTPConfig(rate_limit=(8, 1))
 class LivestreamFailsCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Clip": "/clip/<video_id>",
@@ -26,7 +28,6 @@ class LivestreamFailsCrawler(Crawler):
     }
     DOMAIN: ClassVar[str] = "livestreamfails.com"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://livestreamfails.com")
-    _RATE_LIMIT: ClassVar[RateLimit] = 8, 1
 
     def __post_init__(self) -> None:
         self.api: LivestreamFailsAPI = LivestreamFailsAPI.from_crawler(self)

--- a/cyberdrop_dl/crawlers/luxuretv.py
+++ b/cyberdrop_dl/crawlers/luxuretv.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, final
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -11,6 +12,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@final
 class Selector:
     VIDEO_PLAYER = "video.video-js > source"
     TITLE = "h1.title-right"
@@ -18,6 +20,7 @@ class Selector:
     VIDEOS_THUMBS = "div.contents div.content a"
 
 
+@HTTPConfig(rate_limit=(3, 10))
 class LuxureTVCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/videos/<name>-<id>.html",
@@ -28,7 +31,6 @@ class LuxureTVCrawler(Crawler):
     DEFAULT_TRIM_URLS: ClassVar[bool] = False
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://luxuretv.com")
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 10
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/mega_nz.py
+++ b/cyberdrop_dl/crawlers/mega_nz.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.utils import m3u8
 
 
-@HTTPConfig(user_agent=CDL_USER_AGENT)
+@HTTPConfig.default_headers(user_agent=CDL_USER_AGENT)
 class MegaNzCrawler(Crawler, db_path="path_qs_frag"):
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = "mega.io", "mega.nz"
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {

--- a/cyberdrop_dl/crawlers/mega_nz.py
+++ b/cyberdrop_dl/crawlers/mega_nz.py
@@ -12,6 +12,7 @@ from mega.core import MegaCore
 from mega.crypto import b64_to_a32
 from mega.data_structures import Crypto
 
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.constants import CDL_USER_AGENT
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedDomains, SupportedPaths, auto_task_id
 from cyberdrop_dl.downloader.mega_nz import MegaDownloader
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.utils import m3u8
 
 
+@HTTPConfig(user_agent=CDL_USER_AGENT)
 class MegaNzCrawler(Crawler, db_path="path_qs_frag"):
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = "mega.io", "mega.nz"
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
@@ -47,7 +49,6 @@ class MegaNzCrawler(Crawler, db_path="path_qs_frag"):
     DOMAIN: ClassVar[str] = "mega.nz"
     FOLDER_DOMAIN: ClassVar[str] = "MegaNz"
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = ("mega.co.nz",)
-    _DEFAULT_UA: ClassVar[str | None] = CDL_USER_AGENT
 
     core: MegaCore
     downloader: MegaDownloader

--- a/cyberdrop_dl/crawlers/missav.py
+++ b/cyberdrop_dl/crawlers/missav.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedDomains, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, open_graph
@@ -25,6 +26,7 @@ class Selector:
     ITEM = ".grid .thumbnail.group a"
 
 
+@HTTPConfig(impersonate=True)
 class MissAVCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/...",
@@ -35,7 +37,6 @@ class MissAVCrawler(Crawler):
     DOMAIN: ClassVar[str] = "missav"
     FOLDER_DOMAIN: ClassVar[str] = "MissAV"
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
-    _IMPERSONATE: ClassVar[str | bool | None] = True
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/motherless.py
+++ b/cyberdrop_dl/crawlers/motherless.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, final, override
 
 from cyberdrop_dl import aio
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.crawlers import Registry
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import TextExtractor, css, dates, parse_url
@@ -30,6 +31,7 @@ class Selector:
 
 
 @Registry.database.fix_referer
+@HTTPConfig(rate_limit=(2, 1))
 class MotherlessCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Group": (
@@ -60,8 +62,6 @@ class MotherlessCrawler(Crawler):
     NEXT_PAGE_SELECTOR: ClassVar[str] = ".pagination_link > a[rel=next]"
     DOMAIN: ClassVar[str] = "motherless"
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = ("motherless.com",)
-    _RATE_LIMIT: ClassVar[RateLimit] = 2, 1
-    _IMPERSONATE = True
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/nhentai.py
+++ b/cyberdrop_dl/crawlers/nhentai.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, final
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import LoginError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@final
 class Selector:
     ITEM = "div.gallery > a"
     COLLECTION_TITLE = "span.name"
@@ -25,6 +27,7 @@ class Selector:
     LOGIN_PAGE = "input.id_username_or_email"
 
 
+@HTTPConfig(rate_limit=(4, 1))
 class NHentaiCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Collections": (
@@ -42,7 +45,6 @@ class NHentaiCrawler(Crawler):
     NEXT_PAGE_SELECTOR: ClassVar[str] = "a.next"
     DOMAIN: ClassVar[str] = "nhentai.net"
     FOLDER_DOMAIN: ClassVar[str] = "nHentai"
-    _RATE_LIMIT: ClassVar[RateLimit] = 4, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/noodle_magazine.py
+++ b/cyberdrop_dl/crawlers/noodle_magazine.py
@@ -5,7 +5,8 @@ import itertools
 import json
 from typing import TYPE_CHECKING, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.mediaprops import Resolution
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
@@ -39,6 +40,7 @@ class Video:
 _VIDEO_PER_PAGE = 24
 
 
+@HTTPConfig(impersonate=True, rate_limit=(1, 3))
 class NoodleMagazineCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Search": "/video/<search_query>",
@@ -47,10 +49,7 @@ class NoodleMagazineCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://noodlemagazine.com")
     DOMAIN: ClassVar[str] = "noodlemagazine"
     FOLDER_DOMAIN: ClassVar[str] = "NoodleMagazine"
-
     _DOWNLOAD_SLOTS: ClassVar[int | None] = 2
-    _RATE_LIMIT: ClassVar[RateLimit] = 1, 3
-    _IMPERSONATE: ClassVar[str | bool | None] = True
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/onefichier.py
+++ b/cyberdrop_dl/crawlers/onefichier.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, override
+from typing import TYPE_CHECKING, ClassVar, final, override
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedDomains, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedDomains, SupportedPaths
 from cyberdrop_dl.exceptions import PasswordProtectedError, ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@final
 class Selector:
     NO_FREE_DOWNLOAD = ".ct_warn:-soup-contains('Free download is temporarily limited due to high demand')"
     RATE_LIMITED = ".ct_warn:-soup-contains('You must wait')"
@@ -24,6 +26,7 @@ class Selector:
     )
 
 
+@HTTPConfig(rate_limit=(1, 2))
 class OneFichierCrawler(Crawler):
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = (
         "1fichier.com",
@@ -38,7 +41,6 @@ class OneFichierCrawler(Crawler):
         "tenvoi.com",
         "dl4free.com",
     )  # https://1fichier.com/api.html
-    RATE_LIMIT: ClassVar[RateLimit] = 1, 2
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "File": "?<file_id>",
     }

--- a/cyberdrop_dl/crawlers/pixeldrain.py
+++ b/cyberdrop_dl/crawlers/pixeldrain.py
@@ -6,7 +6,8 @@ import asyncio
 import dataclasses
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, final, override
 
-from cyberdrop_dl.crawlers.crawler import API, Crawler, RateLimit, SupportedDomains, SupportedPaths, auto_task_id
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import API, Crawler, SupportedDomains, SupportedPaths, auto_task_id
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.models import type_adapter
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
@@ -95,6 +96,7 @@ class PixelDrainProxyCrawler(Crawler):
                 return url
 
 
+@HTTPConfig(rate_limit=(10, 1))
 class PixelDrainCrawler(Crawler):
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = (
         "pixeldrain.com",
@@ -124,7 +126,6 @@ class PixelDrainCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = _PRIMARY_URL
     DOMAIN: ClassVar[str] = "pixeldrain"
     FOLDER_DOMAIN: ClassVar[str] = "PixelDrain"
-    _RATE_LIMIT: ClassVar[RateLimit] = 10, 1
     _DOWNLOAD_SLOTS: ClassVar[int | None] = 2
 
     def __post_init__(self) -> None:

--- a/cyberdrop_dl/crawlers/ranoz.py
+++ b/cyberdrop_dl/crawlers/ranoz.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils.errors import error_handling_wrapper
 
@@ -16,6 +17,7 @@ class File(NamedTuple):
     size: int
 
 
+@HTTPConfig(rate_limit=(100, 60))
 class RootzCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "File": (
@@ -25,7 +27,6 @@ class RootzCrawler(Crawler):
     }
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://www.rootz.so")
     DOMAIN: ClassVar[str] = "rootz.so"
-    _RATE_LIMIT: ClassVar[RateLimit] = 100, 60
     _API_ENTRYPOINT: ClassVar[AbsoluteHttpURL] = PRIMARY_URL / "api/files"
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:

--- a/cyberdrop_dl/crawlers/realdebrid.py
+++ b/cyberdrop_dl/crawlers/realdebrid.py
@@ -6,7 +6,9 @@ import re
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import API, Crawler, RateLimit
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.constants import CDL_USER_AGENT
+from cyberdrop_dl.crawlers.crawler import API, Crawler
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -56,11 +58,11 @@ _ERROR_CODES = {
 }
 
 
-class RealDebridCrawler(Crawler, cdl_user_agent=True):
+@HTTPConfig(user_agent=CDL_USER_AGENT, rate_limit=(250, 60))
+class RealDebridCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = _PRIMARY_URL
     DOMAIN: ClassVar[str] = "real-debrid"
     FOLDER_DOMAIN: ClassVar[str] = "RealDebrid"
-    _RATE_LIMIT: ClassVar[RateLimit] = 250, 60
 
     @classmethod
     def __json_resp_check__(cls, json_resp: dict[str, Any], _) -> None:

--- a/cyberdrop_dl/crawlers/realdebrid.py
+++ b/cyberdrop_dl/crawlers/realdebrid.py
@@ -58,7 +58,8 @@ _ERROR_CODES = {
 }
 
 
-@HTTPConfig(user_agent=CDL_USER_AGENT, rate_limit=(250, 60))
+@HTTPConfig(rate_limit=(250, 60))
+@HTTPConfig.default_headers(user_agent=CDL_USER_AGENT)
 class RealDebridCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = _PRIMARY_URL
     DOMAIN: ClassVar[str] = "real-debrid"

--- a/cyberdrop_dl/crawlers/redgifs.py
+++ b/cyberdrop_dl/crawlers/redgifs.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, ClassVar, Final
 
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.crawlers import Registry
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -40,6 +41,7 @@ class Gif:
         )
 
 
+@HTTPConfig(rate_limit=(2, 3))
 class RedGifsCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "User": "/users/<user>",
@@ -50,7 +52,6 @@ class RedGifsCrawler(Crawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://www.redgifs.com/")
     DOMAIN: ClassVar[str] = "redgifs"
     FOLDER_DOMAIN: ClassVar[str] = "RedGifs"
-    _RATE_LIMIT: ClassVar[RateLimit] = 2, 3
 
     @classmethod
     def __json_resp_check__(cls, json_resp: dict[str, Any], resp: AbstractResponse[Any]) -> None:

--- a/cyberdrop_dl/crawlers/soundgasm.py
+++ b/cyberdrop_dl/crawlers/soundgasm.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, extr_text
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
 _CDN = AbsoluteHttpURL("https://media.soundgasm.net")
 
 
+@HTTPConfig(rate_limit=(5, 1))
 class SoundGasmCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Audio": "/u/<user>/<slug>",
@@ -20,7 +22,6 @@ class SoundGasmCrawler(Crawler):
     }
     DOMAIN: ClassVar[str] = "soundgasm"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://soundgasm.net")
-    _RATE_LIMIT: ClassVar[RateLimit] = 5, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/spankbang.py
+++ b/cyberdrop_dl/crawlers/spankbang.py
@@ -4,7 +4,8 @@ import dataclasses
 from typing import TYPE_CHECKING, ClassVar, final
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.mediaprops import Resolution
 from cyberdrop_dl.url_objects import AbsoluteHttpURL, ScrapeItem
@@ -47,6 +48,7 @@ class Video:
     url: str
 
 
+@HTTPConfig(impersonate=True, rate_limit=(2, 5))
 class SpankBangCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Playlist": "/<playlist_id>/playlist/...",
@@ -65,8 +67,6 @@ class SpankBangCrawler(Crawler):
     DOMAIN: ClassVar[str] = "spankbang"
     FOLDER_DOMAIN: ClassVar[str] = "SpankBang"
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
-    _IMPERSONATE: ClassVar[str | bool | None] = True
-    _RATE_LIMIT: ClassVar[RateLimit] = 2, 5
 
     async def __async_post_init__(self) -> None:
         self.update_cookies({"country": "US", "age_pass": 1})

--- a/cyberdrop_dl/crawlers/tiktok.py
+++ b/cyberdrop_dl/crawlers/tiktok.py
@@ -4,7 +4,8 @@ import asyncio
 import dataclasses
 from typing import TYPE_CHECKING, Any, ClassVar, Self
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths, auto_task_id
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths, auto_task_id
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL, MediaItem
 from cyberdrop_dl.utils.dataclass import DictDataclass
@@ -78,6 +79,7 @@ class MusicInfo(DictDataclass):
         return _PRIMARY_URL / "music" / f"{safe_title}-{self.id}"
 
 
+@HTTPConfig(rate_limit=(1, 2))
 class TikTokCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "User": "/@<user>",
@@ -88,7 +90,6 @@ class TikTokCrawler(Crawler):
     DOMAIN: ClassVar[str] = "tiktok"
     FOLDER_DOMAIN: ClassVar[str] = "TikTok"
     DEFAULT_POST_TITLE_FORMAT: ClassVar[str] = "{date:%Y-%m-%d} - {id}"
-    _RATE_LIMIT: ClassVar[RateLimit] = 1, 2
 
     @property
     def download_src_quality_videos(self) -> bool:

--- a/cyberdrop_dl/crawlers/tnaflix.py
+++ b/cyberdrop_dl/crawlers/tnaflix.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar, NamedTuple
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.mediaprops import Resolution
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, open_graph
@@ -29,6 +30,7 @@ class Format(NamedTuple):
     link_str: str
 
 
+@HTTPConfig(rate_limit=(3, 10))
 class TNAFlixCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/<category>/<title>/video<video_id>",
@@ -40,7 +42,6 @@ class TNAFlixCrawler(Crawler):
     FOLDER_DOMAIN: ClassVar[str] = "TNAFlix"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://www.tnaflix.com")
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 10
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/tranny_one.py
+++ b/cyberdrop_dl/crawlers/tranny_one.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -25,6 +26,7 @@ class Selector:
 MAX_VIDEO_COUNT_PER_PAGE = 52
 
 
+@HTTPConfig(rate_limit=(3, 10))
 class TrannyOneCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/view/<video_id>",
@@ -35,7 +37,6 @@ class TrannyOneCrawler(Crawler):
     DOMAIN: ClassVar[str] = "tranny.one"
     FOLDER_DOMAIN: ClassVar[str] = "Tranny.One"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://www.tranny.one")
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 10
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/transfer_it.py
+++ b/cyberdrop_dl/crawlers/transfer_it.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
-@HTTPConfig(user_agent=CDL_USER_AGENT)
+@HTTPConfig.default_headers(user_agent=CDL_USER_AGENT)
 class TransferItCrawler(Crawler, db_path="path_qs_frag"):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {"Transfer": "/t/<transfer_id>"}
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://transfer.it")

--- a/cyberdrop_dl/crawlers/transfer_it.py
+++ b/cyberdrop_dl/crawlers/transfer_it.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar
 from mega.transfer_it import TransferItClient
 
 from cyberdrop_dl import aio
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.constants import CDL_USER_AGENT
 from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
@@ -17,7 +18,8 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
-class TransferItCrawler(Crawler, db_path="path_qs_frag", cdl_user_agent=True):
+@HTTPConfig(user_agent=CDL_USER_AGENT)
+class TransferItCrawler(Crawler, db_path="path_qs_frag"):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {"Transfer": "/t/<transfer_id>"}
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://transfer.it")
     DOMAIN: ClassVar[str] = "transfer.it"

--- a/cyberdrop_dl/crawlers/transflix.py
+++ b/cyberdrop_dl/crawlers/transflix.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, final
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, open_graph
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -14,12 +15,14 @@ if TYPE_CHECKING:
 _UNIX_TIMESTAMP_LENGTH: int = 10
 
 
+@final
 class Selector:
     VIDEO = "video#player > source"
     SEARCH_RESULTS = "div.list-videos div.item > a"
     NEXT_PAGE = "li.next > a"
 
 
+@HTTPConfig(rate_limit=(3, 2))
 class TransflixCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/video/<name>-<video_id>",
@@ -29,7 +32,6 @@ class TransflixCrawler(Crawler):
     FOLDER_DOMAIN: ClassVar[str] = "TransFlix"
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://transflix.net")
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 2
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/vbulletin/vipergirls.py
+++ b/cyberdrop_dl/crawlers/vbulletin/vipergirls.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.crawlers.vbulletin import vBulletinCrawler
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 
 if TYPE_CHECKING:
-    from cyberdrop_dl.crawlers.crawler import RateLimit, SupportedDomains
+    from cyberdrop_dl.crawlers.crawler import SupportedDomains
 
 
+@HTTPConfig(rate_limit=(4, 1))
 class ViperGirlsCrawler(vBulletinCrawler):
     login_required: ClassVar[bool] = False
     VBULLETIN_LOGIN_COOKIE_NAME: ClassVar[str] = "vg_password"
@@ -17,4 +19,3 @@ class ViperGirlsCrawler(vBulletinCrawler):
     FOLDER_DOMAIN: ClassVar[str] = "ViperGirls"
     SUPPORTED_DOMAINS: ClassVar[SupportedDomains] = "viper.click", "vipergirls.to"
     VBULLETIN_API_ENDPOINT: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://viper.click/vr.php")
-    _RATE_LIMIT: ClassVar[RateLimit] = 4, 1

--- a/cyberdrop_dl/crawlers/whyp_it.py
+++ b/cyberdrop_dl/crawlers/whyp_it.py
@@ -4,7 +4,8 @@ import dataclasses
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import API, Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import API, Crawler, SupportedPaths
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import parse_url
 from cyberdrop_dl.utils.dataclass import deserialize
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@HTTPConfig(rate_limit=(5, 1))
 class WhypItCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Audio": "/tracks/<id>/...",
@@ -25,7 +27,6 @@ class WhypItCrawler(Crawler):
 
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://whyp.it")
     DOMAIN: ClassVar[str] = PRIMARY_URL.host
-    _RATE_LIMIT: ClassVar[RateLimit] = 5, 1
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         match scrape_item.url.parts[1:]:

--- a/cyberdrop_dl/crawlers/wordpress/__init__.py
+++ b/cyberdrop_dl/crawlers/wordpress/__init__.py
@@ -13,7 +13,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, final
 
 from bs4 import BeautifulSoup
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.utils import css, open_graph
 from cyberdrop_dl.utils.errors import error_handling_wrapper
@@ -51,6 +52,7 @@ class Selector:
 _POST_ID_REGEX = re.compile(r"(?:postid-|post-)(\d+)")
 
 
+@HTTPConfig(rate_limit=(3, 1))
 class WordPressBaseCrawler(Crawler, is_abc=True):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Category": "/category/<category_slug>",
@@ -73,7 +75,6 @@ class WordPressBaseCrawler(Crawler, is_abc=True):
     DEFAULT_POST_TITLE_FORMAT: ClassVar[str] = "{date} - {id} - {title}"
     WP_USE_REGEX: ClassVar[bool] = True
     SUPPORTS_THREAD_RECURSION: ClassVar[bool] = False
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 1
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/cyberdrop_dl/crawlers/xenforo/celebforum.py
+++ b/cyberdrop_dl/crawlers/xenforo/celebforum.py
@@ -1,23 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 
 from .xenforo import XenforoCrawler
 
-if TYPE_CHECKING:
-    from cyberdrop_dl.crawlers.crawler import RateLimit
 
-
+@HTTPConfig(impersonate=True, rate_limit=(3, 10))
 class CelebForumCrawler(XenforoCrawler):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://celebforum.cc")
     DOMAIN: ClassVar[str] = "celebforum"
     FOLDER_DOMAIN: ClassVar[str] = "CelebForum"
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = ("celebforum.to", "celeb.su")
     IGNORE_EMBEDED_IMAGES_SRC: ClassVar[bool] = True  # images src is always a thumbnail
-    _IMPERSONATE: ClassVar[str | bool | None] = True
-    _RATE_LIMIT: ClassVar[RateLimit] = 3, 10
 
     @classmethod
     def is_thumbnail(cls, link: AbsoluteHttpURL) -> bool:

--- a/cyberdrop_dl/crawlers/xenforo/simpcity.py
+++ b/cyberdrop_dl/crawlers/xenforo/simpcity.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
+from cyberdrop_dl.clients.http import HTTPConfig
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 
 from .xenforo import XenforoCrawler
 
-if TYPE_CHECKING:
-    from cyberdrop_dl.crawlers.crawler import RateLimit
 
-
+@HTTPConfig(rate_limit=(1, 20))
 class SimpCityCrawler(XenforoCrawler, is_debug=True):
     PRIMARY_URL: ClassVar[AbsoluteHttpURL] = AbsoluteHttpURL("https://simpcity.cr")
     DOMAIN: ClassVar[str] = "simpcity"
@@ -18,4 +17,3 @@ class SimpCityCrawler(XenforoCrawler, is_debug=True):
     login_required: bool = False
     IGNORE_EMBEDED_IMAGES_SRC: ClassVar[bool] = False
     OLD_DOMAINS: ClassVar[tuple[str, ...]] = ("simpcity.su",)
-    _RATE_LIMIT: ClassVar[RateLimit] = 1, 20

--- a/cyberdrop_dl/crawlers/xhamster.py
+++ b/cyberdrop_dl/crawlers/xhamster.py
@@ -8,7 +8,8 @@ import json
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.mediaprops import Resolution
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
@@ -59,6 +60,7 @@ def _parse_url(b64_url: str) -> AbsoluteHttpURL:
     return parse_url(url, relative_to=_PRIMARY_URL)
 
 
+@HTTPConfig(rate_limit=(4, 1))
 class XhamsterCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/videos/<title>",
@@ -77,7 +79,6 @@ class XhamsterCrawler(Crawler):
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
     DOMAIN: ClassVar[str] = "xhamster"
     FOLDER_DOMAIN: ClassVar[str] = "xHamster"
-    _RATE_LIMIT: ClassVar[RateLimit] = 4, 1
 
     def __post_init__(self) -> None:
         self._seen_hosts: set[str] = set()

--- a/cyberdrop_dl/crawlers/xxxbunker.py
+++ b/cyberdrop_dl/crawlers/xxxbunker.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, final
 
 from cyberdrop_dl import aio
-from cyberdrop_dl.crawlers.crawler import Crawler, RateLimit, SupportedPaths
+from cyberdrop_dl.clients.http import HTTPConfig
+from cyberdrop_dl.crawlers.crawler import Crawler, SupportedPaths
 from cyberdrop_dl.exceptions import ScrapeError
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
 from cyberdrop_dl.utils import css, open_graph
@@ -15,12 +16,14 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import ScrapeItem
 
 
+@final
 class Selector:
     VIDEOS = ".videolist a[data-anim]"
     VIDEO_IFRAME = "div.player-frame iframe"
     NEXT_PAGE = "div.page-list a:-soup-contains('Next')"
 
 
+@HTTPConfig(rate_limit=(1, 6))
 class XXXBunkerCrawler(Crawler):
     SUPPORTED_PATHS: ClassVar[SupportedPaths] = {
         "Video": "/<video_id>",
@@ -33,7 +36,6 @@ class XXXBunkerCrawler(Crawler):
     FOLDER_DOMAIN: ClassVar[str] = "XXXBunker"
     NEXT_PAGE_SELECTOR: ClassVar[str] = Selector.NEXT_PAGE
     _DOWNLOAD_SLOTS: ClassVar[int | None] = 2
-    _RATE_LIMIT: ClassVar[RateLimit] = 1, 6
 
     async def __async_post_init__(self) -> None:
         self.update_cookies({"ageconfirm": "True"})

--- a/cyberdrop_dl/utils/dataclass.py
+++ b/cyberdrop_dl/utils/dataclass.py
@@ -18,12 +18,12 @@ _FIELDS_CACHE: dict[type, tuple[str, ...]] = {}
 
 
 @fast_cache
-def _fields_names(cls: type[_DataClass]) -> tuple[str, ...]:
+def fields_names(cls: type[_DataClass]) -> tuple[str, ...]:
     return tuple(f.name for f in dataclasses.fields(cls) if f.init)
 
 
 def filter_data[DataClassT: _DataClass](cls: type[DataClassT], data: Mapping[str, Any], /) -> dict[str, Any]:
-    return {name: value for name in _fields_names(cls) if (value := data.get(name, MISSING)) is not MISSING}
+    return {name: value for name in fields_names(cls) if (value := data.get(name, MISSING)) is not MISSING}
 
 
 @dataclasses.dataclass(slots=True, frozen=True, eq=False)
@@ -67,7 +67,7 @@ deserialize = Deserializer()
 
 class DictDataclass(_DataClass, Protocol):
     def __iter__(self) -> Iterator[tuple[str, Any]]:
-        for field_name in _fields_names(type(self)):
+        for field_name in fields_names(type(self)):
             yield field_name, getattr(self, field_name)
 
     filter_dict = classmethod(filter_data)  # pyright: ignore[reportUnannotatedClassAttribute]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
     "pytest>=9.1.1",
-    "ruff>=0.15.18"
+    "ruff>=0.15.18,<16.0"
 ]
 
 [tool.basedpyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyberdrop-dl-patched"
-version = "10.2.1"
+version = "10.3.0.dev0"
 authors = [{name = "Jacob B", email = "admin@script-ware.net"}]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/scripts/tools/update_docs.py
+++ b/scripts/tools/update_docs.py
@@ -68,7 +68,13 @@ def _update_file(file: Path, new_content: str, *, marker: str) -> None:
 def _get_custom_ua_crawlers() -> list[str]:
     from cyberdrop_dl.crawlers import Registry
 
-    return sorted(c.FOLDER_DOMAIN for c in Registry.get_crawlers() if c._DEFAULT_UA and CDL_USER_AGENT in c._DEFAULT_UA)
+    return sorted(
+        c.FOLDER_DOMAIN
+        for c in Registry.get_crawlers()
+        if c.__http_config__
+        and c.__http_config__.headers
+        and CDL_USER_AGENT in c.__http_config__.headers.get("User-Agent", "")
+    )
 
 
 def update_supported_sites() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ import sys
 import aiohttp
 import pytest
 
-from cyberdrop_dl.clients.http import HTTPClient
+from cyberdrop_dl.clients.http import HTTPClient, HTTPConfig
 from cyberdrop_dl.config import Config
 from cyberdrop_dl.exceptions import ScrapeError
 
@@ -57,3 +57,53 @@ async def test_create_aiohttp_session(client: HTTPClient) -> None:
         assert session.cookie_jar is client.cookies
         assert session._raise_for_status is False
         assert session.requote_redirect_url is False
+
+
+def test_http_config_combine_returns_a_new_config() -> None:
+    config_1 = HTTPConfig(headers={"a": "b"}, rate_limit=(3, 1))
+    config_2 = HTTPConfig(headers={"c": "d"}, rate_limit=(3, 1))
+    config_3 = config_1 | config_2
+    assert config_3 is not config_1
+    assert config_3 is not config_2
+
+
+def test_http_config_combine_returns_a_new_headers_dict() -> None:
+    config_1 = HTTPConfig(rate_limit=(3, 1))
+    config_2 = HTTPConfig(headers={"c": "d"}, rate_limit=(2, 1))
+    config_3 = config_1 | config_2
+    assert config_3.headers == config_2.headers
+    assert config_3.headers is not config_2.headers
+
+
+def test_http_config_combine_is_not_permutable() -> None:
+    config_1 = HTTPConfig(headers={"a": "b"}, rate_limit=(3, 1))
+    config_2 = HTTPConfig(headers={"c": "d"}, rate_limit=(3, 1))
+    assert config_1 | config_2 == config_2 | config_1
+    config_3 = HTTPConfig(headers={"c": "d"}, rate_limit=(100, 1))
+    assert config_1 | config_3 != config_3 | config_1
+
+
+def test_http_config_combine_result() -> None:
+    config_1 = HTTPConfig(headers={"a": "b", "h": "l"}, rate_limit=(3, 1))
+    config_2 = HTTPConfig(headers={"a": "another", "c": "d"}, rate_limit=(100, 6))
+    config_3 = config_1 | config_2
+    assert config_3.headers == {"a": "another", "h": "l", "c": "d"}
+    assert config_3.rate_limit == (100, 6)
+    config_4 = config_2 | config_1
+    assert config_4.headers == {"a": "b", "h": "l", "c": "d"}
+    assert config_4.rate_limit == (3, 1)
+
+
+def test_http_config_as_decorator() -> None:
+    config_1 = HTTPConfig(headers={"a": "b", "h": "l"}, rate_limit=(3, 1))
+    config_2 = HTTPConfig(headers={"a": "another", "c": "d"}, rate_limit=(100, 6))
+
+    @config_1
+    class A:
+        pass
+
+    assert HTTPConfig.get(A) is config_1
+
+    B = config_2(A)
+
+    assert HTTPConfig.get(B) == config_1 | config_2

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -42,3 +42,12 @@ def test_json_method_returns_expected_dict() -> None:
         "json": {"foo": "bar"},
     }
     assert req.__json__() == expected
+    req_2 = Request(
+        url=AbsoluteHttpURL("https://example.com"),
+        method="GET",
+        headers=CIMultiDict({}),
+        data=None,
+        json=b"",
+        params={},
+    )
+    assert req_2.__json__() == {"url": "https://example.com", "json": b""}

--- a/uv.lock
+++ b/uv.lock
@@ -736,7 +736,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = ">=0.15.18" },
+    { name = "ruff", specifier = ">=0.15.18,<16.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -635,7 +635,7 @@ wheels = [
 
 [[package]]
 name = "cyberdrop-dl-patched"
-version = "10.2.1"
+version = "10.3.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns", marker = "sys_platform != 'android' and sys_platform != 'win32'" },


### PR DESCRIPTION
The `HTTPContext` is a concrete object that sets the rate limit, default headers, impersonation, JSON validation and backoff of the current request. 

The `HTTPConfig` is a generic object used to override the default values that the context will have when a crawler instance is created. This decouple most of the HTTP control logic from the crawler itself. 

Crawler subclasses can apply their own `HTTPConfig` to override the config of base classes. Only new values will be taken into account.

This will eventually allow us to temporarily set a new context for a single request since the values are no longer hardcoded to the crawler