### PR TITLE
fix: convert float timestamps when building separate post titles

### DIFF
--- a/cyberdrop_dl/crawlers/crawler.py
+++ b/cyberdrop_dl/crawlers/crawler.py
@@ -676,7 +676,7 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         self,
         title: str | None = None,
         id: str | None = None,  # noqa: A002
-        date: datetime.datetime | datetime.date | int | None = None,
+        date: datetime.datetime | datetime.date | float | None = None,
         /,
     ) -> str:
         if not self.separate_posts:
@@ -684,7 +684,7 @@ class Crawler(HTTPMixin, HLSMixin, ABC):
         title_format = self.config.subfolders.separate_posts.format
         if title_format.strip().casefold() == "{default}":
             title_format = self.DEFAULT_POST_TITLE_FORMAT
-        if isinstance(date, int):
+        if isinstance(date, (int, float)):
             date = dates.from_timestamp(date)
 
         post_title, _ = strings.safe_format(title_format, id=id, number=id, date=date, title=title)

--- a/tests/test_separate_post_title.py
+++ b/tests/test_separate_post_title.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cyberdrop_dl.crawlers.crawler import Crawler
+from cyberdrop_dl.crawlers.fsiblog import FSIBlogCrawler
+from cyberdrop_dl.crawlers.nsfw_xxx import NsfwXXXCrawler
+from cyberdrop_dl.crawlers.patreon import PatreonCrawler
+
+if TYPE_CHECKING:
+    from cyberdrop_dl.manager import Manager
+
+ISO_DATE = "2024-01-15T10:30:00+00:00"
+
+# Crawlers that pass a `parse_date` / `parse_iso_date` result to `create_separate_post_title`
+# and whose default post title format has a strftime spec for it
+CRAWLERS_WITH_DATE_IN_POST_TITLE = [PatreonCrawler, FSIBlogCrawler, NsfwXXXCrawler]
+
+
+def test_parse_date_returns_a_float() -> None:
+    assert isinstance(Crawler.parse_iso_date(ISO_DATE), float)
+    assert isinstance(Crawler.parse_date("January 2024", "%B %Y"), float)
+
+
+@pytest.mark.parametrize("crawler_type", CRAWLERS_WITH_DATE_IN_POST_TITLE)
+def test_post_title_accepts_the_timestamps_parse_date_returns(manager: Manager, crawler_type: type[Crawler]) -> None:
+    crawler = object.__new__(crawler_type)
+    crawler.config = manager.config
+    assert "2024-01" in crawler.create_separate_post_title("a_title", "1", Crawler.parse_iso_date(ISO_DATE))


### PR DESCRIPTION
### What's wrong

When a crawler wants to put each post in its own subfolder, it calls `Crawler.create_separate_post_title(title, id, date)`, which renders the crawler's post title format. As an example, for patreon that's `{date:%Y-%m-%d} - {title}`. The `date` it gets handed comes from `Crawler.parse_date` or `Crawler.parse_iso_date`, helpers on the same base class.

Those two helpers return a **float**, because they end in `.timestamp()`. But `create_separate_post_title` converts a timestamp into a real datetime only when it looks like an integer:

```python
if isinstance(date, int):
    date = dates.from_timestamp(date)
```

A float ends up at `str.format`, which is then asked to apply a strftime spec to a plain number. Python refuses:

```
ValueError: Invalid format specifier '%Y-%m-%d' for object of type 'float'
```

### Why it's the guard that's wrong, and not the callers

This used to work. Until June, `parse_date` returned a `TimeStamp` — a `NewType` wrapper that was an actual `int` at runtime — so the `isinstance` check caught it. Commit `107d870f` ("refactor: simplify dates API", 2026-06-21) deliberately dropped those wrapper types in favor of plain floats and datetimes, and this one consumer was never updated to match.

`int` timestamps still flow into this same parameter from crawlers that never touch `parse_date` (tiktok, twitter, girlsreleased, kemono), which is why it has to accept both types rather than simply swapping `int` for `float`.

### What it affects

Three crawlers feed a `parse_date`/`parse_iso_date` result into a post title format containing a strftime spec: **patreon, fsiblog, and nsfw.xxx**.
