### PR TITLE
fix: honour the current TTL when reading a cached value

### DIFF
--- a/cyberdrop_dl/cache.py
+++ b/cyberdrop_dl/cache.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from pathlib import Path
     from types import CoroutineType
 
+    from typing_extensions import Sentinel
+
 logger = logging.getLogger(__name__)
 _IN_MEMORY_CACHE: dict[str, Any] = {}
 
@@ -102,25 +104,29 @@ class TTLCacheAdapter[T]:
             return self.__root
 
     def __getitem__(self, key: str, /) -> T:
-        cache_hit = self._get(key)
+        return self._get_value(key)
+
+    def _get_value(self, key: str, ttl: float | Sentinel | None = MISSING) -> T:
+        """Same as `self[key]`, but `ttl` (when given) overrides the one stored in the entry."""
+        cache_hit = self._get(key, ttl)
         if cache_hit is MISSING:
             raise KeyError(key)
         return cache_hit["value"]
 
-    def _has_expired(self, key: str, cache_hit: _CachedValue[T]) -> bool:
+    def _has_expired(self, key: str, cache_hit: _CachedValue[T], ttl: float | Sentinel | None = MISSING) -> bool:
         try:
-            return _has_expired(cache_hit)
+            return _has_expired(cache_hit, ttl)
         except (KeyError, TypeError, ValueError, AttributeError):
             logger.exception(f"Invalid cache entry {self._lookup_path(key)}, ignoring")
             return True
 
-    def _get(self, key: str) -> _CachedValue[T] | MISSING:  # pyright: ignore[reportInvalidTypeForm]
+    def _get(self, key: str, ttl: float | Sentinel | None = MISSING) -> _CachedValue[T] | MISSING:  # pyright: ignore[reportInvalidTypeForm]
         try:
             cache_hit = self._root[key]
         except KeyError:
             return MISSING
 
-        if self._has_expired(key, cache_hit):
+        if self._has_expired(key, cache_hit, ttl):
             del self[key]
             return MISSING
         return cache_hit
@@ -128,8 +134,8 @@ class TTLCacheAdapter[T]:
     def __delitem__(self, key: str) -> None:
         del self._root[key]
 
-    def get(self, key: str) -> T | None:
-        cache_hit = self._get(key)
+    def get(self, key: str, ttl: float | Sentinel | None = MISSING) -> T | None:
+        cache_hit = self._get(key, ttl)
         return None if cache_hit is MISSING else cache_hit["value"]
 
     def save(self, key: str, value: T, *, ttl: float | None = None) -> None:
@@ -151,10 +157,17 @@ class TTLCacheAdapter[T]:
             return
 
 
-def _has_expired(self: _CachedValue[Any]) -> bool:
-    if self["ttl"] is None:
+def _has_expired(self: _CachedValue[Any], ttl: float | Sentinel | None = MISSING) -> bool:
+    """Check expiry against `ttl`, falling back to the TTL stored in the entry.
+
+    Callers that know the current TTL should pass it. The stored value is only a snapshot of
+    what the TTL was when the entry was written, so trusting it means a shorter TTL never
+    applies to entries that already exist.
+    """
+    effective_ttl: float | None = self["ttl"] if ttl is MISSING else cast("float | None", ttl)
+    if effective_ttl is None:
         return False
-    return time.time() - self["created_at"] >= self["ttl"]
+    return time.time() - self["created_at"] >= effective_ttl
 
 
 def _ttl_from_callable[T](fn: Callable[..., Awaitable[T]]) -> TTLCacheAdapter[T]:
@@ -238,18 +251,18 @@ def cached_fn[T](
     @functools.wraps(fn)
     async def wrapper() -> T:
         with contextlib.suppress(KeyError):
-            return cache[key]
+            return cache._get_value(key, ttl)
 
         async with lock:
             with contextlib.suppress(KeyError):
-                return cache[key]
+                return cache._get_value(key, ttl)
 
             value = await fn()
             cache.save(key, value, ttl=ttl)
             return value
 
     wrapper.clear = lambda: cache.discard(key)  # pyright: ignore[reportAttributeAccessIssue]
-    wrapper.get = lambda: cache.get(key)  # pyright: ignore[reportAttributeAccessIssue]
+    wrapper.get = lambda: cache.get(key, ttl)  # pyright: ignore[reportAttributeAccessIssue]
     return cast("CachedAsyncFunc[T]", cast("object", wrapper))
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -221,6 +221,52 @@ async def test_ttl_cache_method() -> None:
     assert await inst.compute() == 3
 
 
+def test_stored_ttl_is_used_when_caller_does_not_pass_one() -> None:
+    cache = {}
+    ttl_cache = TTLCacheAdapter(cache, ("a", "b"))
+    ttl_cache.save("account", 123, ttl=60)
+
+    # No TTL passed -> the entry's own TTL applies, so this is still valid.
+    assert ttl_cache["account"] == 123
+    assert ttl_cache.get("account") == 123
+
+
+def test_shorter_ttl_expires_an_entry_saved_with_a_longer_one() -> None:
+    cache = {}
+    ttl_cache = TTLCacheAdapter(cache, ("a", "b"))
+    # Written 10s ago under a 60s TTL, i.e. still valid by its own TTL.
+    ttl_cache.save("account", 123, ttl=60)
+    cache["a"]["b"]["account"]["created_at"] = time.time() - 10
+
+    assert ttl_cache.get("account", 5) is None
+    assert cache == {"a": {"b": {}}}
+
+
+def test_longer_ttl_keeps_an_entry_saved_with_a_shorter_one() -> None:
+    cache = {}
+    ttl_cache = TTLCacheAdapter(cache, ("a", "b"))
+    ttl_cache.save("account", 123, ttl=5)
+    cache["a"]["b"]["account"]["created_at"] = time.time() - 10
+
+    assert ttl_cache.get("account", 60) == 123
+    assert ttl_cache.get("account") is None
+
+
+async def test_cached_fn_uses_its_own_ttl_over_the_stored_one() -> None:
+    cache: dict[str, Any] = {}
+    adapter: TTLCacheAdapter[Any] = TTLCacheAdapter(cache)
+    spy = Spy("new")
+
+    # Simulates an entry written by an older version that used a much longer TTL.
+    adapter.save("token", "stale", ttl=3600)
+    cache["token"]["created_at"] = time.time() - 600
+
+    fn = cached_fn(spy, adapter, key="token", ttl=60)
+    assert await fn() == "new"
+    assert spy.calls == 1
+    assert cache["token"]["ttl"] == 60
+
+
 @pytest.mark.parametrize(
     ("key", "expected_parent_keys", "expected_key"),
     [


### PR DESCRIPTION
## Problem

`TTLCacheAdapter` checks expiry against the `ttl` stored inside the cache entry. That
stored value is just a snapshot of what the TTL was when the entry was written.

So if a TTL is later lowered in code, entries that already exist ignore the new value.
They keep being served until the old, longer TTL runs out.

Every `@disk_cached_method` value is a credential, so in practice this means a dead
token can be served for a long time and never re-minted.

## Real-world case

The gofile `account_token`. An older release cached it with a 60 day TTL; current code
asks for 1 day. A token written 30 days earlier was still being served as valid.

Result: every API call returned `error-wrongToken`, `Creating temp account` never ran,
and 505 gofile scrapes produced zero successes. Clearing `cache.json` by hand fixes one
entry once, but the next TTL change hits the same wall.

## Change

`cached_fn` now passes its own TTL down to the read path. `_has_expired` uses that TTL
when it's given and falls back to the stored one when it isn't.

Reads that don't pass a TTL (`cache[key]`, `cache.get(key)`) behave exactly as before.

## Tests

Four new tests in `tests/test_cache.py`.