### PR TITLE
fix(downloader): retry mega downloads on transient network errors

### DIFF
--- a/cyberdrop_dl/downloader/mega_nz.py
+++ b/cyberdrop_dl/downloader/mega_nz.py
@@ -60,7 +60,7 @@ class MegaDownloadClient(DownloadClient):  # pyright: ignore[reportGeneralTypeIs
 @dataclasses.dataclass(slots=True)
 class MegaDownloader(Downloader):
     _client: MegaDownloadClient = dataclasses.field(init=False)
-    SUPPORTS_RETRIES: ClassVar[bool] = False
+    SUPPORTS_RETRIES: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
         super(MegaDownloader, self).__post_init__()


### PR DESCRIPTION
## Summary

Enables automatic retries for mega.nz / transfer.it downloads when a transient
network error (connection reset, timeout) interrupts the stream mid-download.

Previously `MegaDownloader` set `SUPPORTS_RETRIES = False`, so even though the
shared retry loop in `Downloader.__download_w_retries` raised a retryable
`DownloadError` on transient errors, the loop bailed out immediately and the download failed for good.

This flips the flag to `True`. It is safe because:

- Mega downloads never resume (`_supports_ranges = False`, no `Range` header), and `_pre_download_check` already `unlink`s the partial file at the start of every attempt, so each retry re-streams from byte 0 with a fresh CTR counter and re-runs `check_integrity()`.
- Max attempts remain capped by the existing `downloads.attempts` config (default `2`). No new config or behavior is introduced.

## Type of change

- [x] Bug fix (non-breaking change)

## Checklist

- [x] Branched off `main`
- [x] Matches existing code style (single existing `ClassVar[bool]` field)
- [x] Ran `uv run ruff check --fix && uv run ruff format`
- [x] Ran `uv run pytest